### PR TITLE
feat(booking): Duplicate + ManualIntervention customer emails

### DIFF
--- a/App/Modules/Bookings/Data/BookingEmailNotifierAdapter.cs
+++ b/App/Modules/Bookings/Data/BookingEmailNotifierAdapter.cs
@@ -79,6 +79,33 @@ public class BookingEmailNotifierAdapter(
         bookingTime = request.Booking.Record.Time.ToString("HH:mm"),
         terminationDate = request.Booking.Status.CompletedAt?.ToString("ddd, MMM dd yyyy") ?? "Not Applicable",
       }),
+      BookingEmailNotificationType.Duplicate => emailRenderer.RenderEmail("booking-duplicate", new
+      {
+        baseUrl = o.BaseUrl,
+        whatsappUrl = o.WhatsAppUrl,
+        telegramUrl = o.TelegramUrl,
+        supportEmail = o.SupportEmail,
+        userName = request.User.Record.Username.CapitalizeUsername(),
+        userEmail = request.User.Record.Email,
+        bookingId = request.Booking.Id,
+        direction = request.Booking.Record.Direction == TrainDirection.JToW ? "Johor Bahru → Singapore" : "Singapore → Johor Bahru",
+        bookingDate = request.Booking.Record.Date.ToString("ddd, MMM dd yyyy"),
+        bookingTime = request.Booking.Record.Time.ToString("HH:mm"),
+        duplicateDate = request.Booking.Status.CompletedAt?.ToString("ddd, MMM dd yyyy") ?? "Not Applicable",
+      }),
+      BookingEmailNotificationType.RequireManualIntervention => emailRenderer.RenderEmail("booking-manual-intervention", new
+      {
+        baseUrl = o.BaseUrl,
+        whatsappUrl = o.WhatsAppUrl,
+        telegramUrl = o.TelegramUrl,
+        supportEmail = o.SupportEmail,
+        userName = request.User.Record.Username.CapitalizeUsername(),
+        userEmail = request.User.Record.Email,
+        bookingId = request.Booking.Id,
+        direction = request.Booking.Record.Direction == TrainDirection.JToW ? "Johor Bahru → Singapore" : "Singapore → Johor Bahru",
+        bookingDate = request.Booking.Record.Date.ToString("ddd, MMM dd yyyy"),
+        bookingTime = request.Booking.Record.Time.ToString("HH:mm"),
+      }),
       _ => throw new ArgumentOutOfRangeException(nameof(request.Type), request.Type, null)
     };
 
@@ -92,6 +119,8 @@ public class BookingEmailNotifierAdapter(
         BookingEmailNotificationType.Completed => "BunnyBooker - Confirmation",
         BookingEmailNotificationType.Refunded => "BunnyBooker - Refund",
         BookingEmailNotificationType.Terminated => "BunnyBooker - Terminated",
+        BookingEmailNotificationType.Duplicate => "BunnyBooker - Duplicate Booking Refunded",
+        BookingEmailNotificationType.RequireManualIntervention => "BunnyBooker - Booking Under Review",
         _ => throw new ArgumentOutOfRangeException(nameof(request.Type), request.Type, null)
       };
       return (subject, x);

--- a/App/Templates/Email/emails/booking-duplicate.tsx
+++ b/App/Templates/Email/emails/booking-duplicate.tsx
@@ -1,0 +1,137 @@
+import { Heading, Text } from '@react-email/components';
+import { EmailLayout } from './lib/layout';
+import { BookingDetails, RefundInfo } from './lib/booking-details';
+
+interface BookingDuplicateEmailProps {
+  baseUrl: string;
+  userName: string;
+  userEmail: string;
+  whatsappUrl: string;
+  telegramUrl: string;
+  supportEmail: string;
+  bookingId: string;
+  direction: string;
+  bookingDate: string;
+  bookingTime: string;
+  duplicateDate: string;
+}
+
+export const BookingDuplicateEmail = ({
+  baseUrl = '{{ baseUrl }}',
+  whatsappUrl = '{{ whatsappUrl }}',
+  telegramUrl = '{{ telegramUrl }}',
+  supportEmail = '{{ supportEmail }}',
+  userName = '{{ userName }}',
+  userEmail = '{{ userEmail }}',
+  bookingId = '{{ bookingId }}',
+  direction = '{{ direction }}',
+  bookingDate = '{{ bookingDate }}',
+  bookingTime = '{{ bookingTime }}',
+  duplicateDate = '{{ duplicateDate }}',
+}: BookingDuplicateEmailProps) => {
+  const subject = 'Duplicate Booking Refunded';
+  const previewText = `Hi ${userName}, we found a duplicate ticket for this trip and refunded this booking.`;
+
+  return (
+    <EmailLayout
+      baseUrl={baseUrl}
+      supportEmail={supportEmail}
+      whatsappUrl={whatsappUrl}
+      telegramUrl={telegramUrl}
+      subject={subject}
+      previewText={previewText}
+      userEmail={userEmail}
+    >
+      <Heading
+        as="h1"
+        style={{
+          fontSize: '28px',
+          fontWeight: 'bold',
+          color: '#111827',
+          margin: '0 0 24px 0',
+          lineHeight: '1.2',
+        }}
+      >
+        Duplicate Booking Refunded, {userName}
+      </Heading>
+
+      <Text
+        style={{
+          fontSize: '18px',
+          color: '#111827',
+          lineHeight: '1.75',
+          marginBottom: '32px',
+          margin: '0 0 32px 0',
+          fontWeight: '500',
+        }}
+      >
+        While processing this booking we found that you already have a ticket for the same trip — booked through another
+        channel or as a duplicate request. To avoid charging you twice, we've cancelled this booking and refunded it in
+        full to your wallet as BunnyBooker credits.
+      </Text>
+
+      <BookingDetails
+        bookingId={bookingId}
+        status="Duplicate"
+        direction={direction}
+        bookingDate={bookingDate}
+        bookingTime={bookingTime}
+        refundDate={duplicateDate}
+      />
+
+      <RefundInfo
+        refundType="Full Refund"
+        refundStatus="Instant"
+        refundMethod="BunnyBooker Credits"
+        withdrawalAvailable={true}
+        variant="green"
+      />
+
+      <Text
+        style={{
+          fontSize: '18px',
+          color: '#111827',
+          lineHeight: '1.75',
+          marginBottom: '24px',
+          margin: '0 0 24px 0',
+          fontWeight: '500',
+        }}
+      >
+        <strong>Think this is a mistake?</strong>
+        <br />
+        If you did <em>not</em> already have a ticket for this trip, please contact us at {supportEmail} and we'll make
+        it right straight away.
+      </Text>
+
+      <Text
+        style={{
+          fontSize: '18px',
+          color: '#111827',
+          lineHeight: '1.75',
+          marginBottom: '24px',
+          margin: '0 0 24px 0',
+          fontWeight: '500',
+        }}
+      >
+        Thanks for using BunnyBooker. 🐰
+      </Text>
+    </EmailLayout>
+  );
+};
+
+// Preview props for development
+BookingDuplicateEmail.PreviewProps = {
+  baseUrl: 'https://bunnybooker.com',
+  telegramUrl: 'https://t.me/bunnybooker',
+  whatsappUrl: 'https://wa.me/60123456789',
+  supportEmail: 'support@bunnybooker.com',
+  userName: 'John Doe',
+  userEmail: 'john@example.com',
+  bookingId: 'BB123456789',
+  direction: 'Singapore → Johor Bahru',
+  bookingDate: 'Saturday, December 23, 2024',
+  bookingTime: '08:30',
+  duplicateDate: 'Friday, December 22, 2024',
+} as BookingDuplicateEmailProps;
+
+export default BookingDuplicateEmail;

--- a/App/Templates/Email/emails/booking-manual-intervention.tsx
+++ b/App/Templates/Email/emails/booking-manual-intervention.tsx
@@ -1,0 +1,123 @@
+import { Heading, Text } from '@react-email/components';
+import { EmailLayout } from './lib/layout';
+import { BookingDetails } from './lib/booking-details';
+
+interface BookingManualInterventionEmailProps {
+  baseUrl: string;
+  userName: string;
+  userEmail: string;
+  whatsappUrl: string;
+  telegramUrl: string;
+  supportEmail: string;
+  bookingId: string;
+  direction: string;
+  bookingDate: string;
+  bookingTime: string;
+}
+
+export const BookingManualInterventionEmail = ({
+  baseUrl = '{{ baseUrl }}',
+  whatsappUrl = '{{ whatsappUrl }}',
+  telegramUrl = '{{ telegramUrl }}',
+  supportEmail = '{{ supportEmail }}',
+  userName = '{{ userName }}',
+  userEmail = '{{ userEmail }}',
+  bookingId = '{{ bookingId }}',
+  direction = '{{ direction }}',
+  bookingDate = '{{ bookingDate }}',
+  bookingTime = '{{ bookingTime }}',
+}: BookingManualInterventionEmailProps) => {
+  const subject = 'Your Booking Is Under Review';
+  const previewText = `Hi ${userName}, we hit a snag with your booking and our team is looking into it.`;
+
+  return (
+    <EmailLayout
+      baseUrl={baseUrl}
+      supportEmail={supportEmail}
+      whatsappUrl={whatsappUrl}
+      telegramUrl={telegramUrl}
+      subject={subject}
+      previewText={previewText}
+      userEmail={userEmail}
+    >
+      <Heading
+        as="h1"
+        style={{
+          fontSize: '28px',
+          fontWeight: 'bold',
+          color: '#111827',
+          margin: '0 0 24px 0',
+          lineHeight: '1.2',
+        }}
+      >
+        We're Reviewing Your Booking, {userName}
+      </Heading>
+
+      <Text
+        style={{
+          fontSize: '18px',
+          color: '#111827',
+          lineHeight: '1.75',
+          marginBottom: '32px',
+          margin: '0 0 32px 0',
+          fontWeight: '500',
+        }}
+      >
+        We hit a snag while finalising this booking, so we've paused it for a manual check by our team. Your money is
+        safe — nothing has been lost — and we're sorting it out. We'll email you again as soon as it's resolved.
+      </Text>
+
+      <BookingDetails
+        bookingId={bookingId}
+        status="Under Review"
+        direction={direction}
+        bookingDate={bookingDate}
+        bookingTime={bookingTime}
+      />
+
+      <Text
+        style={{
+          fontSize: '18px',
+          color: '#111827',
+          lineHeight: '1.75',
+          marginBottom: '24px',
+          margin: '0 0 24px 0',
+          fontWeight: '500',
+        }}
+      >
+        <strong>Need this sorted urgently, or think it's an error?</strong>
+        <br />
+        Reply to this email or contact us at {supportEmail} with your Booking ID above and we'll prioritise it.
+      </Text>
+
+      <Text
+        style={{
+          fontSize: '18px',
+          color: '#111827',
+          lineHeight: '1.75',
+          marginBottom: '24px',
+          margin: '0 0 24px 0',
+          fontWeight: '500',
+        }}
+      >
+        Thanks for your patience. 🐰
+      </Text>
+    </EmailLayout>
+  );
+};
+
+// Preview props for development
+BookingManualInterventionEmail.PreviewProps = {
+  baseUrl: 'https://bunnybooker.com',
+  telegramUrl: 'https://t.me/bunnybooker',
+  whatsappUrl: 'https://wa.me/60123456789',
+  supportEmail: 'support@bunnybooker.com',
+  userName: 'John Doe',
+  userEmail: 'john@example.com',
+  bookingId: 'BB123456789',
+  direction: 'Singapore → Johor Bahru',
+  bookingDate: 'Saturday, December 23, 2024',
+  bookingTime: '08:30',
+} as BookingManualInterventionEmailProps;
+
+export default BookingManualInterventionEmail;

--- a/App/Templates/Email/emails/index.ts
+++ b/App/Templates/Email/emails/index.ts
@@ -3,6 +3,8 @@ export { default as BookingCompletedEmail } from './booking-completed';
 export { default as BookingCancelledEmail } from './booking-cancelled';
 export { default as BookingTerminatedEmail } from './booking-terminated';
 export { default as BookingRefundedEmail } from './booking-refunded';
+export { default as BookingDuplicateEmail } from './booking-duplicate';
+export { default as BookingManualInterventionEmail } from './booking-manual-intervention';
 
 // Component library
 export * from './lib/header';

--- a/App/Templates/Email/emails/lib/booking-details.tsx
+++ b/App/Templates/Email/emails/lib/booking-details.tsx
@@ -2,7 +2,7 @@ import { Section, Row, Column, Text, Heading } from '@react-email/components';
 
 interface BookingDetailsProps {
   bookingId: string;
-  status: 'Confirmed' | 'Cancelled' | 'Terminated' | 'Refunded';
+  status: 'Confirmed' | 'Cancelled' | 'Terminated' | 'Refunded' | 'Duplicate' | 'Under Review';
   direction: string;
   bookingDate: string;
   bookingTime: string;
@@ -164,6 +164,10 @@ const StatusBadge = ({ status }: { status: string }) => {
         return 'bg-yellow-100 text-yellow-800';
       case 'Refunded':
         return 'bg-blue-100 text-blue-800';
+      case 'Duplicate':
+        return 'bg-blue-100 text-blue-800';
+      case 'Under Review':
+        return 'bg-yellow-100 text-yellow-800';
       default:
         return 'bg-gray-100 text-gray-800';
     }
@@ -188,15 +192,22 @@ const getHeadingTitle = (status: string) => {
       return 'Terminated Booking';
     case 'Refunded':
       return 'Refunded Booking';
+    case 'Duplicate':
+      return 'Duplicate Booking';
+    case 'Under Review':
+      return 'Booking Under Review';
     default:
       return 'Booking';
   }
 };
 
 const getDateLabel = (status: string) => {
-  return status === 'Confirmed' ? 'Travel Date' : 'Original Date';
+  // 'Under Review' is a still-live booking (nothing rescheduled/cancelled), so
+  // show the plain travel date rather than the "Original …" wording that the
+  // terminal states use.
+  return status === 'Confirmed' || status === 'Under Review' ? 'Travel Date' : 'Original Date';
 };
 
 const getTimeLabel = (status: string) => {
-  return status === 'Confirmed' ? 'Departure Time' : 'Original Time';
+  return status === 'Confirmed' || status === 'Under Review' ? 'Departure Time' : 'Original Time';
 };

--- a/Domain/Booking/BookingEmailNotification.cs
+++ b/Domain/Booking/BookingEmailNotification.cs
@@ -7,7 +7,9 @@ public enum BookingEmailNotificationType
   Completed,
   Cancelled,
   Terminated,
-  Refunded
+  Refunded,
+  Duplicate,
+  RequireManualIntervention
 }
 
 public record BookingEmailNotificationRequest

--- a/Domain/Booking/BookingNotificationService.cs
+++ b/Domain/Booking/BookingNotificationService.cs
@@ -85,4 +85,44 @@ public class BookingNotificationService(
 
     return await emailNotifier.SendNotification(message);
   }
+
+  public async Task<Result<Unit>> NotifyBookingDuplicate(Booking booking)
+  {
+    logger.LogInformation("Sending duplicate email for booking {BookingId} - user {UserId}", booking.Principal.Id, booking.User.Id);
+    if (string.IsNullOrWhiteSpace(booking.User.Record.Email))
+    {
+      logger.LogWarning("Cannot send duplicate email for booking {BookingId} - user {UserId} has no email address",
+        booking.Principal.Id, booking.User.Id);
+      return new Unit();
+    }
+
+    var message = new BookingEmailNotificationRequest
+    {
+      User = booking.User,
+      Booking = booking.Principal,
+      Type = BookingEmailNotificationType.Duplicate
+    };
+
+    return await emailNotifier.SendNotification(message);
+  }
+
+  public async Task<Result<Unit>> NotifyBookingManualIntervention(Booking booking)
+  {
+    logger.LogInformation("Sending manual-intervention email for booking {BookingId} - user {UserId}", booking.Principal.Id, booking.User.Id);
+    if (string.IsNullOrWhiteSpace(booking.User.Record.Email))
+    {
+      logger.LogWarning("Cannot send manual-intervention email for booking {BookingId} - user {UserId} has no email address",
+        booking.Principal.Id, booking.User.Id);
+      return new Unit();
+    }
+
+    var message = new BookingEmailNotificationRequest
+    {
+      User = booking.User,
+      Booking = booking.Principal,
+      Type = BookingEmailNotificationType.RequireManualIntervention
+    };
+
+    return await emailNotifier.SendNotification(message);
+  }
 }

--- a/Domain/Booking/IBookingNotificationService.cs
+++ b/Domain/Booking/IBookingNotificationService.cs
@@ -13,4 +13,6 @@ public interface IBookingNotificationService
   Task<Result<Unit>> NotifyBookingCancelled(Booking booking);
   Task<Result<Unit>> NotifyBookingTerminated(Booking booking);
   Task<Result<Unit>> NotifyBookingRefunded(Booking booking);
+  Task<Result<Unit>> NotifyBookingDuplicate(Booking booking);
+  Task<Result<Unit>> NotifyBookingManualIntervention(Booking booking);
 }

--- a/Domain/Booking/Service.cs
+++ b/Domain/Booking/Service.cs
@@ -204,7 +204,24 @@ public class BookingService(
               null
             )
           )
-    );
+          // Error if Null
+          .NullToError(id.ToString())
+          // Re-retrieve full booking (with user) for the notification
+          .ThenAwait(x => repo.Get(null, x.Id))
+      )
+      .NullToError(id.ToString())
+      .DoAwait(DoType.Ignore, x => notificationService.NotifyBookingManualIntervention(x)
+        .Match(s =>
+          {
+            logger.LogInformation("Notify booking manual intervention successfully");
+            return s;
+          },
+          exception =>
+          {
+            logger.LogError(exception, "Failed to notify booking manual intervention");
+            return new Unit();
+          }), Errors.MapNone)
+      .Then(BookingPrincipal? (x) => x.Principal, Errors.MapNone);
   }
 
   // This marks the ticket in the bought status, need to move $$
@@ -439,10 +456,10 @@ public class BookingService(
       )
       .NullToError(id.ToString())
       .DoAwait(DoType.Ignore, _ => cdcRepository.Add("reserve"))
-      .DoAwait(DoType.Ignore, x =>notificationService.NotifyBookingCancelled(x)
+      .DoAwait(DoType.Ignore, x =>notificationService.NotifyBookingDuplicate(x)
         .Match(s =>
           {
-            logger.LogInformation("Notify booking duplicate (cancelled) successfully");
+            logger.LogInformation("Notify booking duplicate successfully");
             return s;
           },
           exception =>


### PR DESCRIPTION
Two recovery-state transitions left customers under-informed:
- **Duplicate** reused the generic "booking cancelled" email — no mention of the duplicate or how to contest it.
- **RequireManualIntervention** sent **no email at all**.

## What this adds
- **`booking-duplicate`** email: explains we found a duplicate ticket for the trip and refunded in full; **"contact us if this is a mistake."** `Service.Duplicate` now sends this (was `NotifyBookingCancelled`).
- **`booking-manual-intervention`** email: explains we hit a snag, their money is safe, we're reviewing it; **"contact us."** `Service.ManualIntervention` was restructured to re-fetch the booking and send this (it previously notified no one).

## Wiring
`BookingEmailNotificationType` (+2), `IBookingNotificationService`/`BookingNotificationService` (+2 methods), `BookingEmailNotifierAdapter` (render + subject arms), two react-email `.tsx` templates (exported in `index.ts`), and the `BookingDetails` status union widened with `Duplicate` + `Under Review` (all four helper switches updated).

## Verification
- Full Docker build (C# compile + `bun run email export`) passes.
- Reviewed via floop (2 rounds, all lenses PASS).

https://claude.ai/code/session_01Xyb9Y7aiWqGwGbtXRAL3ES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email notifications for duplicate bookings and bookings under review.
  * Added new email templates and messaging for these booking statuses.

* **Bug Fixes**
  * Corrected booking notification handling so duplicate bookings send the proper refund email.
  * Updated manual review bookings to send the correct follow-up notification after status changes.

* **Style**
  * Expanded booking status labels and display details to support the new booking states in emails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->