### PR TITLE
feat(booking): atomic Buying→Pending revert + let tin GET booking (403 fix)

### DIFF
--- a/App/Modules/Bookings/API/V1/BookingController.cs
+++ b/App/Modules/Bookings/API/V1/BookingController.cs
@@ -125,7 +125,7 @@ public class BookingController(
   [Authorize, HttpGet("{id:guid}")]
   public async Task<ActionResult<BookingRes>> Get(Guid id, string? userId)
   {
-    var x = await this.GuardOrAnyAsync(userId, AuthRoles.Field, AuthRoles.Admin)
+    var x = await this.GuardOrAnyAsync(userId, AuthRoles.Field, AuthRoles.Admin, AuthRoles.Tin)
       .ThenAwait(_ => service.Get(userId, id))
       .Then(x => x?.ToRes(), Errors.MapAll)
       .ThenAwait(x => Utils.ToNullableTaskResultOr(x, r => enrich.Enrich(r)));
@@ -182,6 +182,22 @@ public class BookingController(
   {
     var x = await service
       .Buying(id)
+      .Then(x => x?.ToRes(), Errors.MapAll)
+      .ThenAwait(x => Utils.ToNullableTaskResultOr(x, r => enrich.Enrich(r)));
+    return this.ReturnNullableResult(
+      x,
+      new EntityNotFound("Booking not found", typeof(Booking), id.ToString())
+    );
+  }
+
+  // Atomically revert a stuck Buying booking back to Pending (guarded Buying-only
+  // + uncaptured in the service). Used to recycle bookings that failed for a
+  // transient reason such as an insufficient KTMB wallet balance.
+  [Authorize(Policy = AuthPolicies.AdminOrTin), HttpPost("revert/{id:guid}")]
+  public async Task<ActionResult<BookingPrincipalRes>> Revert(Guid id)
+  {
+    var x = await service
+      .Revert(id)
       .Then(x => x?.ToRes(), Errors.MapAll)
       .ThenAwait(x => Utils.ToNullableTaskResultOr(x, r => enrich.Enrich(r)));
     return this.ReturnNullableResult(

--- a/Domain/Booking/BookingOperations.cs
+++ b/Domain/Booking/BookingOperations.cs
@@ -19,4 +19,6 @@ public static class BookingOperations
   public const string Duplicate = "Duplicate";
 
   public const string ManualIntervention = "ManualIntervention";
+
+  public const string Revert = "Revert";
 }

--- a/Domain/Booking/IService.cs
+++ b/Domain/Booking/IService.cs
@@ -25,6 +25,8 @@ public interface IBookingService
 
   Task<Result<BookingPrincipal?>> ManualIntervention(Guid id);
 
+  Task<Result<BookingPrincipal?>> Revert(Guid id);
+
   Task<Result<BookingPrincipal?>> Complete(Guid id,
     string bookingNo,
     string ticketNo,

--- a/Domain/Booking/Service.cs
+++ b/Domain/Booking/Service.cs
@@ -124,6 +124,50 @@ public class BookingService(
     );
   }
 
+  // Revert moves a stuck Buying booking back to Pending so it re-enters the
+  // demand pool for another attempt (e.g. after a transient KTMB failure like
+  // an insufficient wallet balance, where no ticket was ever bought). The guard
+  // and the status write run in ONE transaction and only fire when the booking
+  // is still Buying AND uncaptured (BookingNumber == null): this makes it atomic
+  // — it can never clobber a booking that completed concurrently, nor revert one
+  // that already captured a KTMB ticket into re-buying (the corruption + double
+  // -buy hazards the old unguarded reverter caused). Status-only: no money moves
+  // (both Pending and Buying hold the amount in BookingReserve).
+  public Task<Result<BookingPrincipal?>> Revert(Guid id)
+  {
+    return transaction.Start(
+      () =>
+        repo.Get(null, id)
+          .NullToError(id.ToString())
+          .DoAwait(
+            DoType.MapErrors,
+            b =>
+            {
+              if (
+                b.Principal.Status.Status == BookStatus.Buying
+                && b.Principal.Complete.BookingNumber == null
+              )
+                return Task.FromResult((Result<int>)0);
+              var r = new InvalidBookingOperationException(
+                "Revert requires an uncaptured booking in 'Buying' Status",
+                b.Principal.Status.Status,
+                BookingOperations.Revert
+              );
+              return Task.FromResult((Result<int>)r);
+            }
+          )
+          .ThenAwait(_ =>
+            repo.Update(
+              null,
+              id,
+              new BookingStatus() { Status = BookStatus.Pending, CompletedAt = null },
+              null,
+              null
+            )
+          )
+    );
+  }
+
   // This parks a buying booking whose purchase hit a KTMB conflict (e.g.
   // duplicate passport) until the recoverer resolves it. Wrapped in a
   // transaction so the guard read cannot go stale against a concurrent

--- a/UnitTest/Bookings/BookingServiceRevertGuardTests.cs
+++ b/UnitTest/Bookings/BookingServiceRevertGuardTests.cs
@@ -1,0 +1,218 @@
+using CSharp_Result;
+using Domain;
+using Domain.Booking;
+using Domain.Exceptions;
+using Domain.Passenger;
+using Domain.Timings;
+using Domain.Transaction;
+using Domain.User;
+using Domain.Wallet;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// Guards on BookingService.Revert(id). Revert recycles a stuck 'Buying' booking
+// back to 'Pending' (e.g. after a transient KTMB pay failure where no ticket was
+// bought). The deleted, unguarded reverter could reverse ANY status — including a
+// 'Completed' booking whose reserve was already collected — into 'Pending',
+// corrupting the ledger, and could re-expose a captured ticket into a double-buy.
+// These tests prove the transition is now a guarded, once-only transaction that
+// only fires for an uncaptured 'Buying' booking and writes nothing otherwise.
+public class BookingServiceRevertGuardTests
+{
+  private static BookingService MakeService(FakeBookingRepository repo) =>
+    new(
+      repo,
+      null!,
+      null!,
+      null!,
+      new PassThroughTransactionManager(),
+      null!,
+      null!,
+      null!,
+      null!,
+      null!,
+      null!
+    );
+
+  private static Booking BookingWith(BookStatus status, string? bookingNumber)
+  {
+    var id = Guid.NewGuid();
+    return new Booking
+    {
+      Principal = new BookingPrincipal
+      {
+        Id = id,
+        UserId = "user-1",
+        CreatedAt = DateTime.UtcNow,
+        Record = new BookingRecord
+        {
+          Date = new DateOnly(2026, 7, 3),
+          Time = new TimeOnly(8, 0),
+          Direction = TrainDirection.WToJ,
+          Passenger = new PassengerRecord
+          {
+            FullName = "Test Passenger",
+            Gender = PassengerGender.M,
+            PassportExpiry = new DateOnly(2030, 1, 1),
+            PassportNumber = "P1234567",
+          },
+        },
+        Status = new BookingStatus { Status = status, CompletedAt = null },
+        Complete = new BookingComplete
+        {
+          Ticket = bookingNumber == null ? null : "ticket-file",
+          BookingNumber = bookingNumber,
+          TicketNumber = bookingNumber == null ? null : "TN-1",
+        },
+      },
+      User = new UserPrincipal
+      {
+        Id = "user-1",
+        Record = new UserRecord { Username = "tester" },
+      },
+      Transaction = new TransactionPrincipal
+      {
+        Id = Guid.NewGuid(),
+        CreatedAt = DateTime.UtcNow,
+        Record = new TransactionRecord
+        {
+          Name = "BookingRequest",
+          Description = "reserve",
+          Type = TransactionType.BookingRequest,
+          Amount = 26.0m,
+          From = "Usable",
+          To = "BookingReserve",
+        },
+      },
+      Wallet = new WalletPrincipal
+      {
+        Id = Guid.NewGuid(),
+        UserId = "user-1",
+        Record = new WalletRecord
+        {
+          Usable = 100m,
+          WithdrawReserve = 0m,
+          BookingReserve = 26m,
+        },
+      },
+    };
+  }
+
+  [Fact]
+  public async Task Revert_from_uncaptured_buying_transitions_to_pending()
+  {
+    var booking = BookingWith(BookStatus.Buying, bookingNumber: null);
+    var repo = new FakeBookingRepository(booking);
+
+    var result = await MakeService(repo).Revert(booking.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue("an uncaptured 'Buying' booking may be reverted to 'Pending'");
+    repo.UpdateCalls.Should().Be(1);
+    repo.LastStatusWritten!.Status.Should().Be(BookStatus.Pending);
+  }
+
+  [Theory]
+  [InlineData(BookStatus.Pending)]
+  [InlineData(BookStatus.Completed)]
+  [InlineData(BookStatus.Cancelled)]
+  [InlineData(BookStatus.Refunded)]
+  [InlineData(BookStatus.Terminated)]
+  [InlineData(BookStatus.Recovering)]
+  [InlineData(BookStatus.Duplicate)]
+  [InlineData(BookStatus.RequireManualIntervention)]
+  public async Task Revert_from_non_buying_status_is_rejected_and_writes_nothing(BookStatus status)
+  {
+    // A Completed booking additionally carries a BookingNumber (reserve already
+    // collected); the others carry none. Either way the guard must reject — only
+    // a 'Buying' booking may be reverted.
+    var bookingNumber = status == BookStatus.Completed ? "BN-123" : null;
+    var booking = BookingWith(status, bookingNumber);
+    var repo = new FakeBookingRepository(booking);
+
+    var result = await MakeService(repo).Revert(booking.Principal.Id);
+
+    result.IsSuccess().Should().BeFalse($"a '{status}' booking must not be reverted to 'Pending'");
+    result.FailureOrDefault().Should().BeOfType<InvalidBookingOperationException>();
+    repo.UpdateCalls.Should().Be(0, "no status write may happen when the guard fails");
+  }
+
+  [Fact]
+  public async Task Revert_of_captured_buying_booking_is_rejected()
+  {
+    // Defense-in-depth: a 'Buying' booking that already captured a ticket
+    // (BookingNumber set) must never be reverted — re-exposing it to the demand
+    // pool would cause a double-buy / duplicate charge.
+    var booking = BookingWith(BookStatus.Buying, bookingNumber: "BN-999");
+    var repo = new FakeBookingRepository(booking);
+
+    var result = await MakeService(repo).Revert(booking.Principal.Id);
+
+    result.IsSuccess().Should().BeFalse();
+    result.FailureOrDefault().Should().BeOfType<InvalidBookingOperationException>();
+    repo.UpdateCalls.Should().Be(0);
+  }
+
+  [Fact]
+  public async Task Revert_of_missing_booking_is_rejected()
+  {
+    var repo = new FakeBookingRepository(null);
+
+    var result = await MakeService(repo).Revert(Guid.NewGuid());
+
+    result.IsSuccess().Should().BeFalse();
+    repo.UpdateCalls.Should().Be(0);
+  }
+
+  // Runs the wrapped unit of work inline, exactly as the real RepeatableRead
+  // transaction would, so the guard read + status write are exercised end to end.
+  private sealed class PassThroughTransactionManager : ITransactionManager
+  {
+    public Task<Result<T>> Start<T>(Func<Task<Result<T>>> func) => func();
+  }
+
+  private sealed class FakeBookingRepository(Booking? booking) : IBookingRepository
+  {
+    public int UpdateCalls { get; private set; }
+    public BookingStatus? LastStatusWritten { get; private set; }
+
+    public Task<Result<Booking?>> Get(string? userId, Guid id) =>
+      Task.FromResult((Result<Booking?>)booking);
+
+    public Task<Result<BookingPrincipal?>> Update(
+      string? userId,
+      Guid id,
+      BookingStatus? status,
+      BookingRecord? record,
+      BookingComplete? complete
+    )
+    {
+      UpdateCalls++;
+      LastStatusWritten = status;
+      var principal = booking!.Principal with { Status = status! };
+      return Task.FromResult((Result<BookingPrincipal?>)principal);
+    }
+
+    public Task<Result<IEnumerable<BookingPrincipal>>> Search(BookingSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingPrincipal>>> RefundList(DateOnly date, TimeOnly time) =>
+      throw new NotImplementedException();
+
+    public Task<Result<BookingPrincipal>> Create(string userId, Guid transactionId, BookingRecord record) =>
+      throw new NotImplementedException();
+
+    public Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly time) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Unit?>> Delete(string? userId, Guid id) =>
+      throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingCount>>> Count(
+      DateOnly date,
+      TimeOnly time,
+      DateOnly? filterDate,
+      TrainDirection? filterDirection
+    ) => throw new NotImplementedException();
+  }
+}


### PR DESCRIPTION
Two recovery-pipeline fixes.

## 1. Atomic, guarded `Revert(id)` (re-adds revert, safely)
Moves a stuck `Buying` booking back to `Pending` so it re-enters the demand pool for another attempt — e.g. after a transient KTMB failure like **"wallet balance insufficient"** (Pay failed, so no ticket was bought). Bookings that hit this today get stuck in `Buying` with money held and nothing recycles them.

Safe, unlike the deleted unguarded reverter:
- Guard (`status == Buying && BookingNumber == null`) + the status write run in **one transaction** → atomic; can't clobber a booking that completed concurrently (the old `Completed→Pending` ledger corruption), and can't re-buy a booking that already captured a ticket (double-charge).
- **Status-only, no money move** (both `Pending` and `Buying` hold in `BookingReserve`).
- `POST /booking/revert/{id}` (`AdminOrTin`), so both the buyer (tin) and admins can call it.
- New `BookingServiceRevertGuardTests` (mirrors the Buying guard suite): happy path, rejection for every non-Buying status, rejection of a captured Buying booking, missing booking. 22 tests pass.

## 2. 403 fix: recoverer couldn't GET bookings
`GET /booking/{id}` allowed `Field | Admin` but not `Tin`. The recoverer (tin role) calls it on every recover item → **403 → 5 retries → dumped to `RequireManualIntervention`** without recovering. Added `AuthRoles.Tin` (matching `Search`). Confirmed getBooking was the sole gap — recovering/duplicate/manual-intervention/complete/search already allow tin.

## Verification
- Full Docker build (C# + react-email export) passes.
- Unit tests: 22 pass. floop 2 rounds, all lenses PASS.

https://claude.ai/code/session_01Xyb9Y7aiWqGwGbtXRAL3ES