### PR TITLE
feat(booking): admin resolution actions for RequireManualIntervention

### DIFF
--- a/App/Modules/Bookings/API/V1/BookingController.cs
+++ b/App/Modules/Bookings/API/V1/BookingController.cs
@@ -158,6 +158,32 @@ public class BookingController(
     );
   }
 
+  // Complete a RequireManualIntervention booking with an admin-supplied ticket
+  // but WITHOUT collecting the money — the held BookingReserve is left untouched
+  // for manual settlement later.
+  [Authorize(Policy = AuthPolicies.AdminOrTin)]
+  [HttpPost("complete-no-collect/{id:guid}")]
+  [Consumes(MediaTypeNames.Multipart.FormData)]
+  public async Task<ActionResult<BookingPrincipalRes>> CompleteNoCollect(
+    Guid id,
+    string bookingNo,
+    string ticketNo,
+    IFormFile file
+  )
+  {
+    using var stream = new MemoryStream();
+    await file.CopyToAsync(stream);
+    logger.LogInformation("Stream Size: {StreamSize}", stream.Length);
+    var x = await service
+      .CompleteNoCollect(id, bookingNo, ticketNo, stream)
+      .Then(x => x?.ToRes(), Errors.MapAll)
+      .ThenAwait(x => Utils.ToNullableTaskResultOr(x, r => enrich.Enrich(r)));
+    return this.ReturnNullableResult(
+      x,
+      new EntityNotFound("Booking not found", typeof(Booking), id.ToString())
+    );
+  }
+
   [Authorize(Policy = AuthPolicies.AdminOrTin), HttpGet("counts")]
   public async Task<ActionResult<IEnumerable<BookingCountRes>>> CountStatus()
   {

--- a/Domain/Booking/BookingOperations.cs
+++ b/Domain/Booking/BookingOperations.cs
@@ -21,4 +21,6 @@ public static class BookingOperations
   public const string ManualIntervention = "ManualIntervention";
 
   public const string Revert = "Revert";
+
+  public const string CompleteNoCollect = "CompleteNoCollect";
 }

--- a/Domain/Booking/IService.cs
+++ b/Domain/Booking/IService.cs
@@ -32,6 +32,11 @@ public interface IBookingService
     string ticketNo,
     Stream ticketFile);
 
+  Task<Result<BookingPrincipal?>> CompleteNoCollect(Guid id,
+    string bookingNo,
+    string ticketNo,
+    Stream ticketFile);
+
   Task<Result<BookingPrincipal?>> Cancel(string? userId, Guid id);
 
   Task<Result<BookingPrincipal>> Terminate(string? userId, Guid id, DateTime referenceTime);

--- a/Domain/Booking/Service.cs
+++ b/Domain/Booking/Service.cs
@@ -144,12 +144,15 @@ public class BookingService(
             b =>
             {
               if (
-                b.Principal.Status.Status == BookStatus.Buying
+                (
+                  b.Principal.Status.Status == BookStatus.Buying
+                  || b.Principal.Status.Status == BookStatus.RequireManualIntervention
+                )
                 && b.Principal.Complete.BookingNumber == null
               )
                 return Task.FromResult((Result<int>)0);
               var r = new InvalidBookingOperationException(
-                "Revert requires an uncaptured booking in 'Buying' Status",
+                "Revert requires an uncaptured booking in 'Buying' or 'RequireManualIntervention' Status",
                 b.Principal.Status.Status,
                 BookingOperations.Revert
               );
@@ -269,6 +272,85 @@ public class BookingService(
   }
 
   // This marks the ticket in the bought status, need to move $$
+  // CompleteNoCollect is a deliberate ADMIN BYPASS for resolving older/corrupted
+  // RequireManualIntervention bookings: it delivers an admin-supplied ticket and
+  // marks the booking Completed but does NO BookEnd and writes NO ledger row, so
+  // the held BookingReserve is left untouched — the ledger is knowingly left
+  // inconsistent and is reconciled MANUALLY afterwards (per the operator's
+  // decision; see the money-flow note below).
+  //
+  // KNOWN CAVEAT (accepted): a Completed booking normally implies its reserve was
+  // collected, and Terminate assumes that. A CompleteNoCollect booking violates
+  // that invariant (reserve still held), so a subsequent Terminate on it would
+  // fabricate a refund + strand the reserve. This is tolerated because it is an
+  // admin-only bypass for edge/corrupted bookings whose ledger is patched by hand;
+  // do NOT extend this method to normal flows.
+  //
+  // Unlike the other guards it intentionally does NOT require BookingNumber==null:
+  // the corrupted bookings this fixes may already carry a (stale) captured ticket,
+  // and since no money moves there is no double-collect risk in overwriting it.
+  // Guarded to the RequireManualIntervention parking state only.
+  public Task<Result<BookingPrincipal?>> CompleteNoCollect(Guid id,
+    string bookingNo,
+    string ticketNo,
+    Stream file)
+  {
+    return fileRepo
+      .Save(file)
+      .ThenAwait(fileId => transaction.Start(
+          () =>
+            repo.Get(null, id)
+              .NullToError(id.ToString())
+              .DoAwait(
+                DoType.MapErrors,
+                b =>
+                {
+                  if (b.Principal.Status.Status == BookStatus.RequireManualIntervention)
+                    return Task.FromResult((Result<int>)0);
+                  var r = new InvalidBookingOperationException(
+                    "Complete-without-collect requires a booking in 'RequireManualIntervention' Status",
+                    b.Principal.Status.Status,
+                    BookingOperations.CompleteNoCollect
+                  );
+                  return Task.FromResult((Result<int>)r);
+                }
+              )
+              // deliberately NO BookEnd and NO transaction row: the reserve stays
+              // held for manual settlement (per the admin's chosen resolution)
+              .ThenAwait(_ =>
+                repo.Update(
+                  null,
+                  id,
+                  new BookingStatus
+                  {
+                    Status = BookStatus.Completed,
+                    CompletedAt = DateTime.UtcNow,
+                  },
+                  null,
+                  new BookingComplete
+                  {
+                    Ticket = fileId,
+                    BookingNumber = bookingNo,
+                    TicketNumber = ticketNo,
+                  }
+                )
+              )
+              .NullToError(id.ToString())
+              .ThenAwait(x => repo.Get(null, x.Id))
+        )
+      )
+      .NullToError(id.ToString())
+      .DoAwait(DoType.Ignore, _ => cdcRepository.Add("reserve"))
+      .DoAwait(DoType.Ignore, x =>notificationService.NotifyBookingCompleted(x)
+          .Match(s => s,
+            exception =>
+            {
+              logger.LogError(exception, "Failed to notify booking completed (no-collect)");
+              return new Unit();
+            }), Errors.MapNone)
+      .Then(BookingPrincipal? (x) => x.Principal , Errors.MapNone);
+  }
+
   public Task<Result<BookingPrincipal?>> Complete(Guid id,
     string bookingNo,
     string ticketNo,
@@ -294,11 +376,12 @@ public class BookingService(
                       is BookStatus.Pending
                         or BookStatus.Buying
                         or BookStatus.Recovering
+                        or BookStatus.RequireManualIntervention
                     && b.Principal.Complete.BookingNumber == null
                   )
                     return Task.FromResult((Result<int>)0);
                   var r = new InvalidBookingOperationException(
-                    "Completion requires an uncompleted booking in 'Pending', 'Buying' or 'Recovering' Status",
+                    "Completion requires an uncompleted booking in 'Pending', 'Buying', 'Recovering' or 'RequireManualIntervention' Status",
                     b.Principal.Status.Status,
                     BookingOperations.Complete
                   );
@@ -374,10 +457,16 @@ public class BookingService(
               DoType.MapErrors,
               b =>
               {
-                if (b.Principal.Status.Status == BookStatus.Pending)
+                if (
+                  b.Principal.Status.Status == BookStatus.Pending
+                  || (
+                    b.Principal.Status.Status == BookStatus.RequireManualIntervention
+                    && b.Principal.Complete.BookingNumber == null
+                  )
+                )
                   return Task.FromResult((Result<int>)0);
                 var r = new InvalidBookingOperationException(
-                  "Cancellation require booking to be in 'Pending' Status",
+                  "Cancellation requires an uncaptured booking in 'Pending' or 'RequireManualIntervention' Status",
                   b.Principal.Status.Status,
                   BookingOperations.Cancel
                 );

--- a/UnitTest/Bookings/BookingServiceCompleteNoCollectTests.cs
+++ b/UnitTest/Bookings/BookingServiceCompleteNoCollectTests.cs
@@ -11,27 +11,28 @@ using FluentAssertions;
 
 namespace UnitTest.Bookings;
 
-// Guards on BookingService.Revert(id). Revert recycles a stuck 'Buying' booking
-// back to 'Pending' (e.g. after a transient KTMB pay failure where no ticket was
-// bought). The deleted, unguarded reverter could reverse ANY status — including a
-// 'Completed' booking whose reserve was already collected — into 'Pending',
-// corrupting the ledger, and could re-expose a captured ticket into a double-buy.
-// These tests prove the transition is now a guarded, once-only transaction that
-// only fires for an uncaptured 'Buying' booking and writes nothing otherwise.
-public class BookingServiceRevertGuardTests
+// CompleteNoCollect is the admin bypass that finalises a RequireManualIntervention
+// booking WITHOUT moving money — it must never call the wallet or write a ledger
+// row. These tests pin that invariant by passing NULL walletRepo/transactionRepo:
+// if CompleteNoCollect ever touched them the test would NRE. They also prove the
+// guard (RequireManualIntervention only) and that the ticket + Completed status
+// are written.
+public class BookingServiceCompleteNoCollectTests
 {
+  // walletRepo (arg 2) and transactionRepo (arg 3) are deliberately null — the
+  // reserve-untouched invariant means CompleteNoCollect must never invoke them.
   private static BookingService MakeService(FakeBookingRepository repo) =>
     new(
       repo,
-      null!,
+      new FakeStorage(),
       null!,
       null!,
       new PassThroughTransactionManager(),
       null!,
       null!,
       null!,
-      null!,
-      null!,
+      new FakeCdc(),
+      new FakeNotifier(),
       null!
     );
 
@@ -63,7 +64,7 @@ public class BookingServiceRevertGuardTests
         {
           Ticket = bookingNumber == null ? null : "ticket-file",
           BookingNumber = bookingNumber,
-          TicketNumber = bookingNumber == null ? null : "TN-1",
+          TicketNumber = bookingNumber == null ? null : "TN-old",
         },
       },
       User = new UserPrincipal
@@ -89,120 +90,81 @@ public class BookingServiceRevertGuardTests
       {
         Id = Guid.NewGuid(),
         UserId = "user-1",
-        Record = new WalletRecord
-        {
-          Usable = 100m,
-          WithdrawReserve = 0m,
-          BookingReserve = 26m,
-        },
+        Record = new WalletRecord { Usable = 100m, WithdrawReserve = 0m, BookingReserve = 26m },
       },
     };
   }
 
   [Fact]
-  public async Task Revert_from_uncaptured_buying_transitions_to_pending()
-  {
-    var booking = BookingWith(BookStatus.Buying, bookingNumber: null);
-    var repo = new FakeBookingRepository(booking);
-
-    var result = await MakeService(repo).Revert(booking.Principal.Id);
-
-    result.IsSuccess().Should().BeTrue("an uncaptured 'Buying' booking may be reverted to 'Pending'");
-    repo.UpdateCalls.Should().Be(1);
-    repo.LastStatusWritten!.Status.Should().Be(BookStatus.Pending);
-  }
-
-  [Fact]
-  public async Task Revert_from_uncaptured_manual_intervention_transitions_to_pending()
+  public async Task CompleteNoCollect_from_manual_intervention_completes_saves_ticket_and_moves_no_money()
   {
     var booking = BookingWith(BookStatus.RequireManualIntervention, bookingNumber: null);
     var repo = new FakeBookingRepository(booking);
 
-    var result = await MakeService(repo).Revert(booking.Principal.Id);
+    var result = await MakeService(repo)
+      .CompleteNoCollect(booking.Principal.Id, "BN-1", "TN-1", new MemoryStream(new byte[] { 1, 2, 3 }));
 
-    result.IsSuccess().Should().BeTrue("an uncaptured 'RequireManualIntervention' booking may be reverted to 'Pending'");
+    // reaching success at all proves no money path ran (null wallet/transaction repos)
+    result.IsSuccess().Should().BeTrue("an admin may finalise a RequireManualIntervention booking without collecting");
     repo.UpdateCalls.Should().Be(1);
-    repo.LastStatusWritten!.Status.Should().Be(BookStatus.Pending);
+    repo.LastStatusWritten!.Status.Should().Be(BookStatus.Completed);
+    repo.LastCompleteWritten!.BookingNumber.Should().Be("BN-1");
+    repo.LastCompleteWritten!.TicketNumber.Should().Be("TN-1");
   }
 
   [Theory]
   [InlineData(BookStatus.Pending)]
+  [InlineData(BookStatus.Buying)]
+  [InlineData(BookStatus.Recovering)]
   [InlineData(BookStatus.Completed)]
   [InlineData(BookStatus.Cancelled)]
   [InlineData(BookStatus.Refunded)]
   [InlineData(BookStatus.Terminated)]
-  [InlineData(BookStatus.Recovering)]
   [InlineData(BookStatus.Duplicate)]
-  public async Task Revert_from_disallowed_status_is_rejected_and_writes_nothing(BookStatus status)
+  public async Task CompleteNoCollect_from_non_manual_intervention_is_rejected(BookStatus status)
   {
-    // A Completed booking additionally carries a BookingNumber (reserve already
-    // collected); the others carry none. Either way the guard must reject — only
-    // an uncaptured 'Buying' or 'RequireManualIntervention' booking may be reverted.
-    var bookingNumber = status == BookStatus.Completed ? "BN-123" : null;
-    var booking = BookingWith(status, bookingNumber);
+    var booking = BookingWith(status, bookingNumber: null);
     var repo = new FakeBookingRepository(booking);
 
-    var result = await MakeService(repo).Revert(booking.Principal.Id);
+    var result = await MakeService(repo)
+      .CompleteNoCollect(booking.Principal.Id, "BN-1", "TN-1", new MemoryStream(new byte[] { 1 }));
 
-    result.IsSuccess().Should().BeFalse($"a '{status}' booking must not be reverted to 'Pending'");
+    result.IsSuccess().Should().BeFalse($"a '{status}' booking is not in the manual-intervention parking state");
     result.FailureOrDefault().Should().BeOfType<InvalidBookingOperationException>();
     repo.UpdateCalls.Should().Be(0, "no status write may happen when the guard fails");
   }
 
-  [Fact]
-  public async Task Revert_of_captured_manual_intervention_booking_is_rejected()
-  {
-    // A RequireManualIntervention booking that already captured a ticket
-    // (BookingNumber set) must never be reverted — re-exposing it would risk a
-    // double-buy, and its reserve may already be resolved.
-    var booking = BookingWith(BookStatus.RequireManualIntervention, bookingNumber: "BN-777");
-    var repo = new FakeBookingRepository(booking);
-
-    var result = await MakeService(repo).Revert(booking.Principal.Id);
-
-    result.IsSuccess().Should().BeFalse();
-    result.FailureOrDefault().Should().BeOfType<InvalidBookingOperationException>();
-    repo.UpdateCalls.Should().Be(0);
-  }
-
-  [Fact]
-  public async Task Revert_of_captured_buying_booking_is_rejected()
-  {
-    // Defense-in-depth: a 'Buying' booking that already captured a ticket
-    // (BookingNumber set) must never be reverted — re-exposing it to the demand
-    // pool would cause a double-buy / duplicate charge.
-    var booking = BookingWith(BookStatus.Buying, bookingNumber: "BN-999");
-    var repo = new FakeBookingRepository(booking);
-
-    var result = await MakeService(repo).Revert(booking.Principal.Id);
-
-    result.IsSuccess().Should().BeFalse();
-    result.FailureOrDefault().Should().BeOfType<InvalidBookingOperationException>();
-    repo.UpdateCalls.Should().Be(0);
-  }
-
-  [Fact]
-  public async Task Revert_of_missing_booking_is_rejected()
-  {
-    var repo = new FakeBookingRepository(null);
-
-    var result = await MakeService(repo).Revert(Guid.NewGuid());
-
-    result.IsSuccess().Should().BeFalse();
-    repo.UpdateCalls.Should().Be(0);
-  }
-
-  // Runs the wrapped unit of work inline, exactly as the real RepeatableRead
-  // transaction would, so the guard read + status write are exercised end to end.
   private sealed class PassThroughTransactionManager : ITransactionManager
   {
     public Task<Result<T>> Start<T>(Func<Task<Result<T>>> func) => func();
+  }
+
+  private sealed class FakeStorage : IBookingStorage
+  {
+    public Task<Result<string>> Save(Stream stream) => Task.FromResult((Result<string>)"file-id");
+    public Task<Result<string>> Get(string key) => Task.FromResult((Result<string>)"file-url");
+  }
+
+  private sealed class FakeCdc : IBookingCdcRepository
+  {
+    public Task<Result<Unit>> Add(string action) => Task.FromResult((Result<Unit>)new Unit());
+  }
+
+  private sealed class FakeNotifier : IBookingNotificationService
+  {
+    public Task<Result<Unit>> NotifyBookingCompleted(Booking booking) => Task.FromResult((Result<Unit>)new Unit());
+    public Task<Result<Unit>> NotifyBookingCancelled(Booking booking) => throw new NotImplementedException();
+    public Task<Result<Unit>> NotifyBookingTerminated(Booking booking) => throw new NotImplementedException();
+    public Task<Result<Unit>> NotifyBookingRefunded(Booking booking) => throw new NotImplementedException();
+    public Task<Result<Unit>> NotifyBookingDuplicate(Booking booking) => throw new NotImplementedException();
+    public Task<Result<Unit>> NotifyBookingManualIntervention(Booking booking) => throw new NotImplementedException();
   }
 
   private sealed class FakeBookingRepository(Booking? booking) : IBookingRepository
   {
     public int UpdateCalls { get; private set; }
     public BookingStatus? LastStatusWritten { get; private set; }
+    public BookingComplete? LastCompleteWritten { get; private set; }
 
     public Task<Result<Booking?>> Get(string? userId, Guid id) =>
       Task.FromResult((Result<Booking?>)booking);
@@ -217,6 +179,7 @@ public class BookingServiceRevertGuardTests
     {
       UpdateCalls++;
       LastStatusWritten = status;
+      LastCompleteWritten = complete;
       var principal = booking!.Principal with { Status = status! };
       return Task.FromResult((Result<BookingPrincipal?>)principal);
     }


### PR DESCRIPTION
Admin actions to resolve a parked `RequireManualIntervention` booking:

| Action | Money | → |
|---|---|---|
| **Cancel** | full refund | `Cancelled` |
| **Revert** | none | `Pending` |
| **Complete (consume)** | collect reserve | `Completed` |
| **Complete (no-collect)** | **none — reserve left held** | `Completed` |

## Changes
- Extend the `Cancel`, `Revert`, `Complete` service guards to accept `RequireManualIntervention` — all keep their `BookingNumber == null` capture-safety, so no double-collect/re-buy.
- New **`CompleteNoCollect`** + `POST /booking/complete-no-collect/{id}` (multipart, AdminOrTin): saves the admin-uploaded ticket, marks `Completed`, but does **no `BookEnd` and writes no ledger row** — the reserve stays held.

## ⚠️ Accepted design note (documented in code)
`CompleteNoCollect` is a **deliberate admin bypass** for older/corrupted bookings; the operator reconciles the ledger by hand afterwards. It knowingly leaves `Completed`-with-held-reserve, which a later `Terminate` would mishandle — so it must not be used in normal flows (see the method's doc comment). This is per the operator's explicit decision.

## Tests
- New `BookingServiceCompleteNoCollectTests`: proves the no-money-move invariant (null wallet/transaction repos → any money call would throw) + the guard. Revert guard tests updated for the new MI-allowed behaviour. **44 tests pass.** Full Docker build passes.

https://claude.ai/code/session_01Xyb9Y7aiWqGwGbtXRAL3ES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new way for staff to complete certain bookings by uploading a ticket file and entering booking/ticket details.
  * Expanded booking handling so some manual-review bookings can now be completed, canceled, or reverted when eligible.

* **Bug Fixes**
  * Improved validation and status checks to better match allowed booking states.
  * Prevents money-movement steps during the new completion flow, while still recording completion details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->