### PR TITLE
feat(withdrawal): 4% fee and automated Airwallex PayNow payouts

### DIFF
--- a/App/Config/schema.json
+++ b/App/Config/schema.json
@@ -116,6 +116,7 @@
       "additionalProperties": false,
       "required": [
         "RefundPercentage",
+        "WithdrawFeePercentage",
         "BaseUrl",
         "WhatsAppUrl",
         "TelegramUrl",
@@ -125,6 +126,12 @@
         "RefundPercentage": {
           "type": "integer",
           "format": "int32"
+        },
+        "WithdrawFeePercentage": {
+          "type": "number",
+          "format": "decimal",
+          "maximum": 100.0,
+          "minimum": 0.0
         },
         "BaseUrl": {
           "type": "string",

--- a/App/Config/settings.yaml
+++ b/App/Config/settings.yaml
@@ -7,6 +7,7 @@ Kestrel:
       Url: http://+:9002
 Domain:
   RefundPercentage: 50
+  WithdrawFeePercentage: 4
   BaseUrl: https://bunnybooker.com
   WhatsAppUrl: 'https://wa.me/6588178504'
   TelegramUrl: 'https://t.me/bunnybooker'

--- a/App/Error/V1/InvalidWithdrawalOperation.cs
+++ b/App/Error/V1/InvalidWithdrawalOperation.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+using App.Modules.Withdrawals.API.V1;
+using Domain.Withdrawal;
+
+namespace App.Error.V1;
+
+[Description(
+  "The withdrawal operation attempted (Approve, Complete, Cancel, Reject etc) is not valid for the current withdrawal state"
+)]
+public class InvalidWithdrawalOperation : IDomainProblem
+{
+  public InvalidWithdrawalOperation() { }
+
+  public InvalidWithdrawalOperation(string detail, WithdrawStatus withdrawStatus, string operation)
+  {
+    this.Detail = detail;
+    this.WithdrawStatus = withdrawStatus.ToRes();
+    this.Operation = operation;
+  }
+
+  [JsonIgnore]
+  public string Id { get; } = "invalid_withdrawal_operation";
+
+  [JsonIgnore]
+  public string Title { get; } = "Invalid Withdrawal Operation";
+
+  [JsonIgnore]
+  public string Version { get; } = "v1";
+
+  public string Detail { get; } = string.Empty;
+
+  [Description(
+    "The current status of the withdrawal that was invalid for the operation attempted"
+  )]
+  public string WithdrawStatus { get; } = string.Empty;
+
+  [Description("The operation that was invalid")]
+  public string Operation { get; } = string.Empty;
+}

--- a/App/Migrations/20260708060802_AddWithdrawalPayoutAndBookingLastBuyingAt.Designer.cs
+++ b/App/Migrations/20260708060802_AddWithdrawalPayoutAndBookingLastBuyingAt.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using App.StartUp.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace App.Migrations
 {
     [DbContext(typeof(MainDbContext))]
-    partial class MainDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260708060802_AddWithdrawalPayoutAndBookingLastBuyingAt")]
+    partial class AddWithdrawalPayoutAndBookingLastBuyingAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/App/Migrations/20260708060802_AddWithdrawalPayoutAndBookingLastBuyingAt.cs
+++ b/App/Migrations/20260708060802_AddWithdrawalPayoutAndBookingLastBuyingAt.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace App.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWithdrawalPayoutAndBookingLastBuyingAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Costs",
+                keyColumn: "Id",
+                keyValue: new Guid("28c43132-a71a-464f-bb9c-31717c509a3a"));
+
+            migrationBuilder.AddColumn<string>(
+                name: "ConfirmationNumber",
+                table: "Withdrawals",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "Fee",
+                table: "Withdrawals",
+                type: "numeric(16,8)",
+                precision: 16,
+                scale: 8,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PayoutAttempt",
+                table: "Withdrawals",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastBuyingAt",
+                table: "Bookings",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.InsertData(
+                table: "Costs",
+                columns: ["Id", "Cost", "CreatedAt"],
+                values: [new Guid("5aa07550-fc00-48bd-bb0c-35eeaf8a1362"), 14m, new DateTime(2026, 7, 8, 6, 8, 2, 518, DateTimeKind.Utc).AddTicks(7650)]);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Costs",
+                keyColumn: "Id",
+                keyValue: new Guid("5aa07550-fc00-48bd-bb0c-35eeaf8a1362"));
+
+            migrationBuilder.DropColumn(
+                name: "ConfirmationNumber",
+                table: "Withdrawals");
+
+            migrationBuilder.DropColumn(
+                name: "Fee",
+                table: "Withdrawals");
+
+            migrationBuilder.DropColumn(
+                name: "PayoutAttempt",
+                table: "Withdrawals");
+
+            migrationBuilder.DropColumn(
+                name: "LastBuyingAt",
+                table: "Bookings");
+
+            migrationBuilder.InsertData(
+                table: "Costs",
+                columns: ["Id", "Cost", "CreatedAt"],
+                values: [new Guid("28c43132-a71a-464f-bb9c-31717c509a3a"), 14m, new DateTime(2025, 7, 30, 2, 3, 58, 932, DateTimeKind.Utc).AddTicks(1630)]);
+        }
+    }
+}

--- a/App/Modules/Announcements/API/V1/AnnouncementController.cs
+++ b/App/Modules/Announcements/API/V1/AnnouncementController.cs
@@ -1,0 +1,36 @@
+using System.Net.Mime;
+using App.Modules.Common;
+using App.StartUp.Registry;
+using App.StartUp.Services.Auth;
+using Asp.Versioning;
+using CSharp_Result;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace App.Modules.Announcements.API.V1;
+
+[ApiVersion(1.0)]
+[ApiController]
+[Consumes(MediaTypeNames.Application.Json)]
+[Route("api/v{version:apiVersion}/[controller]")]
+public class AnnouncementController(IAnnouncementService service, IAuthHelper h)
+  : AtomiControllerBase(h)
+{
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpPost("withdrawal-fee/{userId}")]
+  public async Task<ActionResult<AnnouncementSentRes>> SendWithdrawalFee(string userId)
+  {
+    var x = await service
+      .SendWithdrawalFeeAnnouncement(userId)
+      .Then(u => u.ToSentRes(), Errors.MapNone);
+    return this.ReturnResult(x);
+  }
+
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpPost("withdrawal-fee")]
+  public async Task<ActionResult<AnnouncementBroadcastRes>> BroadcastWithdrawalFee()
+  {
+    var x = await service
+      .BroadcastWithdrawalFeeAnnouncement()
+      .Then(r => r.ToRes(), Errors.MapNone);
+    return this.ReturnResult(x);
+  }
+}

--- a/App/Modules/Announcements/API/V1/AnnouncementMapper.cs
+++ b/App/Modules/Announcements/API/V1/AnnouncementMapper.cs
@@ -1,0 +1,12 @@
+using Domain.User;
+
+namespace App.Modules.Announcements.API.V1;
+
+public static class AnnouncementMapper
+{
+  public static AnnouncementSentRes ToSentRes(this UserPrincipal user) =>
+    new(user.Id, user.Record.Email ?? string.Empty);
+
+  public static AnnouncementBroadcastRes ToRes(this AnnouncementBroadcastResult result) =>
+    new(result.Sent, result.Failed, result.FailedUserIds);
+}

--- a/App/Modules/Announcements/API/V1/AnnouncementModel.cs
+++ b/App/Modules/Announcements/API/V1/AnnouncementModel.cs
@@ -1,0 +1,6 @@
+namespace App.Modules.Announcements.API.V1;
+
+// RESP
+public record AnnouncementSentRes(string UserId, string Email);
+
+public record AnnouncementBroadcastRes(int Sent, int Failed, string[] FailedUserIds);

--- a/App/Modules/Announcements/AnnouncementService.cs
+++ b/App/Modules/Announcements/AnnouncementService.cs
@@ -128,10 +128,10 @@ public class AnnouncementService(
             Body = html,
             IsHtml = true,
           };
+          // user id only: email addresses are PII and do not belong in logs
           logger.LogInformation(
-            "Sending withdrawal fee announcement email to user {UserId} ({Email})",
-            user.Id,
-            user.Record.Email
+            "Sending withdrawal fee announcement email to user {UserId}",
+            user.Id
           );
           return await smtpClient.SendAsync(smtpMessage);
         },

--- a/App/Modules/Announcements/AnnouncementService.cs
+++ b/App/Modules/Announcements/AnnouncementService.cs
@@ -32,10 +32,12 @@ public class AnnouncementService(
       if (user == null)
         return new EntityNotFound("User Not Found", typeof(UserPrincipal), userId).ToException();
       if (string.IsNullOrWhiteSpace(user.Email))
-        return new EntityNotFound(
+        return new ValidationError(
           "User does not have an email address",
-          typeof(UserPrincipal),
-          userId
+          new Dictionary<string, string[]>
+          {
+            ["Email"] = ["The user exists but has no email address to send to"],
+          }
         ).ToException();
 
       var principal = user.ToPrincipal();

--- a/App/Modules/Announcements/AnnouncementService.cs
+++ b/App/Modules/Announcements/AnnouncementService.cs
@@ -1,0 +1,139 @@
+using App.Error.V1;
+using App.Modules.Users.Data;
+using App.StartUp.Database;
+using App.StartUp.Email;
+using App.StartUp.Options;
+using App.StartUp.Registry;
+using App.StartUp.Smtp;
+using App.Utility;
+using CSharp_Result;
+using Domain;
+using Domain.User;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace App.Modules.Announcements;
+
+public class AnnouncementService(
+  MainDbContext db,
+  ISmtpClientFactory smtpClientFactory,
+  IEmailRenderer emailRenderer,
+  IOptionsMonitor<DomainOptions> options,
+  IFeeCalculator feeCalculator,
+  ILogger<AnnouncementService> logger
+) : IAnnouncementService
+{
+  public async Task<Result<UserPrincipal>> SendWithdrawalFeeAnnouncement(string userId)
+  {
+    try
+    {
+      logger.LogInformation("Sending withdrawal fee announcement to user {UserId}", userId);
+      var user = await db.Users.Where(x => x.Id == userId).FirstOrDefaultAsync();
+      if (user == null)
+        return new EntityNotFound("User Not Found", typeof(UserPrincipal), userId).ToException();
+      if (string.IsNullOrWhiteSpace(user.Email))
+        return new EntityNotFound(
+          "User does not have an email address",
+          typeof(UserPrincipal),
+          userId
+        ).ToException();
+
+      var principal = user.ToPrincipal();
+      return await this.Send(principal).Then(_ => principal, Errors.MapNone);
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to send withdrawal fee announcement to user {UserId}", userId);
+      return e;
+    }
+  }
+
+  public async Task<Result<AnnouncementBroadcastResult>> BroadcastWithdrawalFeeAnnouncement()
+  {
+    try
+    {
+      var users = await db.Users.Where(x => x.Email != null && x.Email != "").ToArrayAsync();
+      logger.LogInformation(
+        "Broadcasting withdrawal fee announcement to {Count} users",
+        users.Length
+      );
+
+      var sent = 0;
+      var failed = new List<string>();
+      foreach (var user in users)
+      {
+        var r = await this.Send(user.ToPrincipal());
+        if (r.IsSuccess())
+        {
+          sent++;
+        }
+        else
+        {
+          logger.LogWarning(
+            r.FailureOrDefault(),
+            "Failed to send withdrawal fee announcement to user {UserId}",
+            user.Id
+          );
+          failed.Add(user.Id);
+        }
+      }
+
+      logger.LogInformation(
+        "Withdrawal fee announcement broadcast complete: {Sent} sent, {Failed} failed",
+        sent,
+        failed.Count
+      );
+      return new AnnouncementBroadcastResult
+      {
+        Sent = sent,
+        Failed = failed.Count,
+        FailedUserIds = [.. failed],
+      };
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to broadcast withdrawal fee announcement");
+      return e;
+    }
+  }
+
+  private async Task<Result<Unit>> Send(UserPrincipal user)
+  {
+    var o = options.CurrentValue;
+    var feePercent = (feeCalculator.WithdrawFeeRate * 100).ToString("0.##");
+    var smtpClient = smtpClientFactory.Get(SmtpProviders.Transactional);
+    return await emailRenderer
+      .RenderEmail(
+        "withdrawal-fee-announcement",
+        new
+        {
+          baseUrl = o.BaseUrl,
+          whatsappUrl = o.WhatsAppUrl,
+          telegramUrl = o.TelegramUrl,
+          supportEmail = o.SupportEmail,
+          userName = user.Record.Username.CapitalizeUsername(),
+          userEmail = user.Record.Email,
+          feePercent,
+        }
+      )
+      .ThenAwait(
+        async html =>
+        {
+          var smtpMessage = new SmtpEmailMessage
+          {
+            To = user.Record.Email!,
+            Subject = $"BunnyBooker - Introducing a {feePercent}% Withdrawal Fee",
+            Body = html,
+            IsHtml = true,
+          };
+          logger.LogInformation(
+            "Sending withdrawal fee announcement email to user {UserId} ({Email})",
+            user.Id,
+            user.Record.Email
+          );
+          return await smtpClient.SendAsync(smtpMessage);
+        },
+        Errors.MapNone
+      );
+  }
+}

--- a/App/Modules/Announcements/IAnnouncementService.cs
+++ b/App/Modules/Announcements/IAnnouncementService.cs
@@ -1,0 +1,20 @@
+using CSharp_Result;
+using Domain.User;
+
+namespace App.Modules.Announcements;
+
+public record AnnouncementBroadcastResult
+{
+  public required int Sent { get; init; }
+
+  public required int Failed { get; init; }
+
+  public required string[] FailedUserIds { get; init; }
+}
+
+public interface IAnnouncementService
+{
+  Task<Result<UserPrincipal>> SendWithdrawalFeeAnnouncement(string userId);
+
+  Task<Result<AnnouncementBroadcastResult>> BroadcastWithdrawalFeeAnnouncement();
+}

--- a/App/Modules/Bookings/API/V1/BookingController.cs
+++ b/App/Modules/Bookings/API/V1/BookingController.cs
@@ -219,11 +219,14 @@ public class BookingController(
   // Atomically revert a stuck Buying booking back to Pending (guarded Buying-only
   // + uncaptured in the service). Used to recycle bookings that failed for a
   // transient reason such as an insufficient KTMB wallet balance.
+  // force=false (default, used by the reverter cron) additionally requires the
+  // booking to have been in Buying for over 5 minutes; force=true (admin UI)
+  // skips the age check and also accepts RequireManualIntervention.
   [Authorize(Policy = AuthPolicies.AdminOrTin), HttpPost("revert/{id:guid}")]
-  public async Task<ActionResult<BookingPrincipalRes>> Revert(Guid id)
+  public async Task<ActionResult<BookingPrincipalRes>> Revert(Guid id, [FromQuery] bool force = false)
   {
     var x = await service
-      .Revert(id)
+      .Revert(id, force)
       .Then(x => x?.ToRes(), Errors.MapAll)
       .ThenAwait(x => Utils.ToNullableTaskResultOr(x, r => enrich.Enrich(r)));
     return this.ReturnNullableResult(

--- a/App/Modules/Bookings/API/V1/BookingMapper.cs
+++ b/App/Modules/Bookings/API/V1/BookingMapper.cs
@@ -111,7 +111,23 @@ public static class BookingMapper
       Direction = query.Direction?.DirectionToDomain(),
       UserId = query.UserId,
       PassportNumber = query.PassportNumber,
+      // resolved to an absolute cutoff server-side so callers (e.g. the
+      // reverter cron) need no clock agreement with zinc
+      BuyingBefore =
+        query.StuckForMinutes != null
+          ? DateTime.UtcNow.AddMinutes(-query.StuckForMinutes.Value)
+          : null,
+      Sort = query.SortBy?.ToBookingSort(),
       Limit = query.Limit ?? 20,
       Skip = query.Skip ?? 0,
+    };
+
+  public static BookingSort ToBookingSort(this string sort) =>
+    sort switch
+    {
+      "Timing" => BookingSort.Timing,
+      "PassengerName" => BookingSort.PassengerName,
+      "PassportNumber" => BookingSort.PassportNumber,
+      _ => throw new ArgumentOutOfRangeException(nameof(sort), sort, null),
     };
 }

--- a/App/Modules/Bookings/API/V1/BookingMapper.cs
+++ b/App/Modules/Bookings/API/V1/BookingMapper.cs
@@ -33,6 +33,7 @@ public static class BookingMapper
   {
     return new BookingPrincipalRes(
       p.Id,
+      p.UserId,
       p.Record.Date.ToStandardDateFormat(),
       p.Record.Time.ToStandardTimeFormat(),
       p.Record.Direction.ToRes(),

--- a/App/Modules/Bookings/API/V1/BookingModel.cs
+++ b/App/Modules/Bookings/API/V1/BookingModel.cs
@@ -9,6 +9,8 @@ public record SearchBookingQuery(
   string? Time,
   string? UserId,
   string? PassportNumber,
+  int? StuckForMinutes,
+  string? SortBy,
   int? Limit,
   int? Skip
 );

--- a/App/Modules/Bookings/API/V1/BookingModel.cs
+++ b/App/Modules/Bookings/API/V1/BookingModel.cs
@@ -51,6 +51,7 @@ public record BookingPassengerRes(
 
 public record BookingPrincipalRes(
   Guid Id,
+  string UserId,
   string Date,
   string Time,
   string Direction,

--- a/App/Modules/Bookings/API/V1/BookingValidator.cs
+++ b/App/Modules/Bookings/API/V1/BookingValidator.cs
@@ -48,6 +48,13 @@ public class BookingSearchQueryValidator : AbstractValidator<SearchBookingQuery>
       .MaximumLength(20)
       .Matches("^([a-zA-Z0-9]+)$")
       .When(x => x.PassportNumber != null);
+    this.RuleFor(x => x.StuckForMinutes)
+      .GreaterThanOrEqualTo(1)
+      .When(x => x.StuckForMinutes != null);
+    this.RuleFor(x => x.SortBy)
+      .Must(x => x is "Timing" or "PassengerName" or "PassportNumber")
+      .WithMessage("SortBy must be one of: Timing, PassengerName, PassportNumber")
+      .When(x => x.SortBy != null);
     this.RuleFor(x => x.Limit).Limit();
     this.RuleFor(x => x.Skip).Skip();
   }

--- a/App/Modules/Bookings/API/V1/BookingValidator.cs
+++ b/App/Modules/Bookings/API/V1/BookingValidator.cs
@@ -48,8 +48,10 @@ public class BookingSearchQueryValidator : AbstractValidator<SearchBookingQuery>
       .MaximumLength(20)
       .Matches("^([a-zA-Z0-9]+)$")
       .When(x => x.PassportNumber != null);
+    // upper bound keeps DateTime.UtcNow.AddMinutes(-x) in range (a 500 otherwise)
     this.RuleFor(x => x.StuckForMinutes)
       .GreaterThanOrEqualTo(1)
+      .LessThanOrEqualTo(525600)
       .When(x => x.StuckForMinutes != null);
     this.RuleFor(x => x.SortBy)
       .Must(x => x is "Timing" or "PassengerName" or "PassportNumber")

--- a/App/Modules/Bookings/Data/BookingData.cs
+++ b/App/Modules/Bookings/Data/BookingData.cs
@@ -30,6 +30,9 @@ public class BookingData
 
   public DateTime? CompletedAt { get; set; }
 
+  // when the booking last entered Buying (null for rows predating the column)
+  public DateTime? LastBuyingAt { get; set; }
+
   // record
   public DateOnly Date { get; set; }
 

--- a/App/Modules/Bookings/Data/BookingMapper.cs
+++ b/App/Modules/Bookings/Data/BookingMapper.cs
@@ -29,7 +29,12 @@ public static class BookingMapper
     };
 
   public static BookingStatus ToStatus(this BookingData data) =>
-    new() { Status = (BookStatus)data.Status, CompletedAt = data.CompletedAt };
+    new()
+    {
+      Status = (BookStatus)data.Status,
+      CompletedAt = data.CompletedAt,
+      LastBuyingAt = data.LastBuyingAt,
+    };
 
   public static BookingComplete ToComplete(this BookingData data) =>
     new()
@@ -88,6 +93,10 @@ public static class BookingMapper
 
   public static BookingData UpdateData(this BookingData data, BookingStatus status)
   {
+    // stamp the Buying entry time at the single status-write choke point;
+    // callers cannot set it and other transitions preserve the last stamp
+    if (status.Status == BookStatus.Buying && (BookStatus)data.Status != BookStatus.Buying)
+      data.LastBuyingAt = DateTime.UtcNow;
     data.Status = (byte)status.Status;
     data.CompletedAt = status.CompletedAt;
     return data;

--- a/App/Modules/Bookings/Data/BookingRepository.cs
+++ b/App/Modules/Bookings/Data/BookingRepository.cs
@@ -48,12 +48,18 @@ public class BookingRepository(
           x.LastBuyingAt != null && x.LastBuyingAt < search.BuyingBefore
         );
 
+      // Id tiebreaker everywhere: Skip/Take pagination needs a stable total
+      // order, and none of the sort keys are unique
       var sorted = search.Sort switch
       {
-        BookingSort.Timing => query.OrderBy(x => x.Date).ThenBy(x => x.Time),
-        BookingSort.PassengerName => query.OrderBy(x => x.Passenger.FullName),
-        BookingSort.PassportNumber => query.OrderBy(x => x.Passenger.PassportNumber),
-        _ => query.OrderByDescending(x => x.Date),
+        BookingSort.Timing => query.OrderBy(x => x.Date).ThenBy(x => x.Time).ThenBy(x => x.Id),
+        BookingSort.PassengerName => query
+          .OrderBy(x => x.Passenger.FullName)
+          .ThenBy(x => x.Id),
+        BookingSort.PassportNumber => query
+          .OrderBy(x => x.Passenger.PassportNumber)
+          .ThenBy(x => x.Id),
+        _ => query.OrderByDescending(x => x.Date).ThenBy(x => x.Id),
       };
 
       var result = await sorted.Skip(search.Skip).Take(search.Limit).ToArrayAsync();

--- a/App/Modules/Bookings/Data/BookingRepository.cs
+++ b/App/Modules/Bookings/Data/BookingRepository.cs
@@ -43,11 +43,20 @@ public class BookingRepository(
       if (!string.IsNullOrWhiteSpace(search.PassportNumber))
         query = query.Where(x => x.Passenger.PassportNumber == search.PassportNumber);
 
-      var result = await query
-        .OrderByDescending(x => x.Date)
-        .Skip(search.Skip)
-        .Take(search.Limit)
-        .ToArrayAsync();
+      if (search.BuyingBefore != null)
+        query = query.Where(x =>
+          x.LastBuyingAt != null && x.LastBuyingAt < search.BuyingBefore
+        );
+
+      var sorted = search.Sort switch
+      {
+        BookingSort.Timing => query.OrderBy(x => x.Date).ThenBy(x => x.Time),
+        BookingSort.PassengerName => query.OrderBy(x => x.Passenger.FullName),
+        BookingSort.PassportNumber => query.OrderBy(x => x.Passenger.PassportNumber),
+        _ => query.OrderByDescending(x => x.Date),
+      };
+
+      var result = await sorted.Skip(search.Skip).Take(search.Limit).ToArrayAsync();
 
       return result.Select(x => x.ToPrincipal()).ToResult();
     }

--- a/App/Modules/Common/BaseController.cs
+++ b/App/Modules/Common/BaseController.cs
@@ -54,6 +54,10 @@ public class AtomiControllerBase(IAuthHelper h) : ControllerBase
         HttpStatusCode.BadRequest,
         new InvalidBookingOperation(iboe.Message, iboe.BookStatus, iboe.Operation)
       ),
+      InvalidWithdrawalOperationException iwoe => this.Error(
+        HttpStatusCode.BadRequest,
+        new InvalidWithdrawalOperation(iwoe.Message, iwoe.WithdrawStatus, iwoe.Operation)
+      ),
       NotFoundException nfe => this.Error(
         HttpStatusCode.NotFound,
         new EntityNotFound(nfe.Message, nfe.Type, nfe.RequestIdentifier)

--- a/App/Modules/DomainServices.cs
+++ b/App/Modules/DomainServices.cs
@@ -12,6 +12,7 @@ using App.Modules.Timings.Data;
 using App.Modules.Transactions.Data;
 using App.Modules.Users.Data;
 using App.Modules.Wallets.Data;
+using App.Modules.Withdrawals;
 using App.Modules.Withdrawals.API.V1;
 using App.Modules.Withdrawals.Data;
 using App.StartUp.Services;
@@ -100,6 +101,10 @@ public static class DomainServices
     s.AddScoped<IWithdrawalImageEnricher, WithdrawalImageEnricher>()
       .AutoTrace<IWithdrawalImageEnricher>();
 
+    s.AddScoped<IFeeCalculator, FeeCalculator>().AutoTrace<IFeeCalculator>();
+
+    s.AddScoped<IPayoutGateway, AirwallexPayoutGateway>().AutoTrace<IPayoutGateway>();
+
     // Cost
     s.AddScoped<ICostCalculator, CostCalculator>().AutoTrace<ICostCalculator>();
 
@@ -138,7 +143,10 @@ public static class DomainServices
       .AutoTrace<IBookingEmailNotifier>();
     s.AddScoped<IBookingNotificationService, BookingNotificationService>()
       .AutoTrace<IBookingNotificationService>();
-    
+
+    // Announcements
+    s.AddScoped<Announcements.IAnnouncementService, Announcements.AnnouncementService>()
+      .AutoTrace<Announcements.IAnnouncementService>();
 
     return s;
   }

--- a/App/Modules/Payments/Airwallex/AirwallexEventAdapter.cs
+++ b/App/Modules/Payments/Airwallex/AirwallexEventAdapter.cs
@@ -46,10 +46,12 @@ public class AirwallexEventAdapter
 
   // Transfer request ids are "{withdrawalId}-{attempt}"; the number after the
   // last dash is the attempt counter, everything before it the withdrawal id.
-  // Attempt is null for ids not minted by us (e.g. a bare guid) — the service
-  // then skips the attempt fence.
+  // WithdrawalId is null for ids not minted by us (e.g. a transfer created by
+  // hand in the Airwallex dashboard) — such events must be acknowledged and
+  // ignored, never crash the webhook into a redelivery loop. Attempt is null
+  // for a bare-guid id — the service then skips the attempt fence.
   public (
-    Guid WithdrawalId,
+    Guid? WithdrawalId,
     string TransferId,
     int? Attempt,
     TransferOutcome Outcome
@@ -57,15 +59,15 @@ public class AirwallexEventAdapter
   {
     var requestId = evt.Data.Object.RequestId;
     var cut = requestId.LastIndexOf('-');
-    Guid withdrawalId;
+    Guid? withdrawalId = null;
     int? attempt = null;
     if (Guid.TryParse(requestId, out var bare))
     {
       withdrawalId = bare;
     }
-    else
+    else if (cut > 0 && Guid.TryParse(requestId[..cut], out var prefixed))
     {
-      withdrawalId = Guid.Parse(requestId[..cut]);
+      withdrawalId = prefixed;
       if (int.TryParse(requestId[(cut + 1)..], out var n))
         attempt = n;
     }

--- a/App/Modules/Payments/Airwallex/AirwallexEventAdapter.cs
+++ b/App/Modules/Payments/Airwallex/AirwallexEventAdapter.cs
@@ -3,11 +3,29 @@ using Domain.Payment;
 
 namespace App.Modules.Payments.Airwallex;
 
+public enum TransferOutcome
+{
+  // non-terminal statuses (e.g. NEW, PROCESSING, SENT): acknowledge and wait
+  InFlight = 0,
+  Settled = 1,
+  Failed = 2,
+}
+
 public class AirwallexEventAdapter
 {
+  private static readonly string[] SettledStatuses = ["PAID", "SETTLED"];
+
+  private static readonly string[] FailedStatuses =
+  [
+    "FAILED",
+    "CANCELLED",
+    "REJECTED",
+    "RETURNED",
+  ];
+
   public (Guid, PaymentRecord, bool) ProcessEvent(AirwallexEvent evt)
   {
-    var id = evt.Data.Object.RequestId;
+    var id = Guid.Parse(evt.Data.Object.RequestId);
     var record = new PaymentRecord
     {
       Amount = evt.Data.Object.Amount,
@@ -19,5 +37,30 @@ public class AirwallexEventAdapter
     };
     var complete = evt.Data.Object.Status == "SUCCEEDED";
     return (id, record, complete);
+  }
+
+  // True for payout (transfer.*) events, which resolve a Withdrawal instead
+  // of a Payment
+  public static bool IsTransferEvent(AirwallexEvent evt) =>
+    evt.Name.StartsWith("transfer", StringComparison.OrdinalIgnoreCase);
+
+  // Transfer request ids are "{withdrawalId}-{attempt}"; the id after the
+  // last dash is the attempt counter, everything before it the withdrawal id
+  public (Guid WithdrawalId, string TransferId, TransferOutcome Outcome) ProcessTransferEvent(
+    AirwallexEvent evt
+  )
+  {
+    var requestId = evt.Data.Object.RequestId;
+    var cut = requestId.LastIndexOf('-');
+    var withdrawalId = Guid.TryParse(requestId, out var bare)
+      ? bare
+      : Guid.Parse(requestId[..cut]);
+
+    var status = evt.Data.Object.Status.ToUpperInvariant();
+    var outcome = SettledStatuses.Contains(status) ? TransferOutcome.Settled
+      : FailedStatuses.Contains(status) ? TransferOutcome.Failed
+      : TransferOutcome.InFlight;
+
+    return (withdrawalId, evt.Data.Object.Id, outcome);
   }
 }

--- a/App/Modules/Payments/Airwallex/AirwallexEventAdapter.cs
+++ b/App/Modules/Payments/Airwallex/AirwallexEventAdapter.cs
@@ -44,23 +44,37 @@ public class AirwallexEventAdapter
   public static bool IsTransferEvent(AirwallexEvent evt) =>
     evt.Name.StartsWith("transfer", StringComparison.OrdinalIgnoreCase);
 
-  // Transfer request ids are "{withdrawalId}-{attempt}"; the id after the
-  // last dash is the attempt counter, everything before it the withdrawal id
-  public (Guid WithdrawalId, string TransferId, TransferOutcome Outcome) ProcessTransferEvent(
-    AirwallexEvent evt
-  )
+  // Transfer request ids are "{withdrawalId}-{attempt}"; the number after the
+  // last dash is the attempt counter, everything before it the withdrawal id.
+  // Attempt is null for ids not minted by us (e.g. a bare guid) — the service
+  // then skips the attempt fence.
+  public (
+    Guid WithdrawalId,
+    string TransferId,
+    int? Attempt,
+    TransferOutcome Outcome
+  ) ProcessTransferEvent(AirwallexEvent evt)
   {
     var requestId = evt.Data.Object.RequestId;
     var cut = requestId.LastIndexOf('-');
-    var withdrawalId = Guid.TryParse(requestId, out var bare)
-      ? bare
-      : Guid.Parse(requestId[..cut]);
+    Guid withdrawalId;
+    int? attempt = null;
+    if (Guid.TryParse(requestId, out var bare))
+    {
+      withdrawalId = bare;
+    }
+    else
+    {
+      withdrawalId = Guid.Parse(requestId[..cut]);
+      if (int.TryParse(requestId[(cut + 1)..], out var n))
+        attempt = n;
+    }
 
     var status = evt.Data.Object.Status.ToUpperInvariant();
     var outcome = SettledStatuses.Contains(status) ? TransferOutcome.Settled
       : FailedStatuses.Contains(status) ? TransferOutcome.Failed
       : TransferOutcome.InFlight;
 
-    return (withdrawalId, evt.Data.Object.Id, outcome);
+    return (withdrawalId, evt.Data.Object.Id, attempt, outcome);
   }
 }

--- a/App/Modules/Payments/Airwallex/AirwallexWebhookService.cs
+++ b/App/Modules/Payments/Airwallex/AirwallexWebhookService.cs
@@ -2,6 +2,7 @@ using App.Error.Common;
 using App.Error.V1;
 using App.Utility;
 using CSharp_Result;
+using Domain.Exceptions;
 using Domain.Payment;
 using Domain.Withdrawal;
 
@@ -51,26 +52,47 @@ public class AirwallexWebhookService(
   }
 
   // Payouts: transfer.* events resolve a Withdrawal
-  private Task<Result<Unit>> ProcessTransfer(AirwallexEvent evt)
+  private async Task<Result<Unit>> ProcessTransfer(AirwallexEvent evt)
   {
-    var (withdrawalId, transferId, outcome) = adapter.ProcessTransferEvent(evt);
+    var (withdrawalId, transferId, attempt, outcome) = adapter.ProcessTransferEvent(evt);
     logger.LogInformation(
-      "Airwallex transfer event '{Name}' for Withdrawal '{WithdrawalId}' (transfer '{TransferId}'): {Outcome}",
+      "Airwallex transfer event '{Name}' for Withdrawal '{WithdrawalId}' (transfer '{TransferId}', attempt {Attempt}): {Outcome}",
       evt.Name,
       withdrawalId,
       transferId,
+      attempt,
       outcome
     );
-    return outcome switch
+    var result = await (
+      outcome switch
+      {
+        TransferOutcome.Settled => withdrawalService
+          .CompletePayout(withdrawalId, transferId, attempt)
+          .Then(_ => new Unit(), Errors.MapNone),
+        TransferOutcome.Failed => withdrawalService
+          .FailPayout(
+            withdrawalId,
+            $"Airwallex transfer '{transferId}' ended as '{evt.Name}'",
+            attempt
+          )
+          .Then(_ => new Unit(), Errors.MapNone),
+        // NEW / PROCESSING / SENT etc: acknowledge, settlement decides later
+        _ => Task.FromResult(new Unit().ToResult()),
+      }
+    );
+
+    // stale events (superseded attempt, already-terminal withdrawal) must be
+    // acknowledged with 2xx or the gateway redelivers them forever
+    if (result.IsFailure() && result.FailureOrDefault() is StalePayoutEventException stale)
     {
-      TransferOutcome.Settled => withdrawalService
-        .CompletePayout(withdrawalId, transferId)
-        .Then(_ => new Unit(), Errors.MapNone),
-      TransferOutcome.Failed => withdrawalService
-        .FailPayout(withdrawalId, $"Airwallex transfer '{transferId}' ended as '{evt.Name}'")
-        .Then(_ => new Unit(), Errors.MapNone),
-      // NEW / PROCESSING / SENT etc: acknowledge, settlement decides later
-      _ => Task.FromResult(new Unit().ToResult()),
-    };
+      logger.LogWarning(
+        "Ignoring stale Airwallex transfer event '{Name}' for Withdrawal '{WithdrawalId}': {Reason}",
+        evt.Name,
+        withdrawalId,
+        stale.Message
+      );
+      return new Unit();
+    }
+    return result;
   }
 }

--- a/App/Modules/Payments/Airwallex/AirwallexWebhookService.cs
+++ b/App/Modules/Payments/Airwallex/AirwallexWebhookService.cs
@@ -3,11 +3,13 @@ using App.Error.V1;
 using App.Utility;
 using CSharp_Result;
 using Domain.Payment;
+using Domain.Withdrawal;
 
 namespace App.Modules.Payments.Airwallex;
 
 public class AirwallexWebhookService(
   IPaymentService paymentService,
+  IWithdrawalService withdrawalService,
   AirwallexEventAdapter adapter,
   AirwallexHmacCalculator airwallexHmacCalculator,
   ILogger<AirwallexWebhookService> logger
@@ -32,13 +34,43 @@ public class AirwallexWebhookService(
             [new Scope("x-signature", x)]
           ).ToException()
       )
-      .Then(_ => adapter.ProcessEvent(evt), Errors.MapNone)
-      .ThenAwait(x =>
-      {
-        var (guid, record, complete) = x;
-        return complete
-          ? paymentService.CompleteById(guid, record).Then(_ => new Unit(), Errors.MapNone)
-          : paymentService.UpdateById(guid, record).Then(_ => new Unit(), Errors.MapNone);
-      });
+      .ThenAwait(_ =>
+        AirwallexEventAdapter.IsTransferEvent(evt)
+          ? this.ProcessTransfer(evt)
+          : this.ProcessPayment(evt)
+      );
+  }
+
+  // Deposits: payment_intent.* events resolve a Payment
+  private Task<Result<Unit>> ProcessPayment(AirwallexEvent evt)
+  {
+    var (guid, record, complete) = adapter.ProcessEvent(evt);
+    return complete
+      ? paymentService.CompleteById(guid, record).Then(_ => new Unit(), Errors.MapNone)
+      : paymentService.UpdateById(guid, record).Then(_ => new Unit(), Errors.MapNone);
+  }
+
+  // Payouts: transfer.* events resolve a Withdrawal
+  private Task<Result<Unit>> ProcessTransfer(AirwallexEvent evt)
+  {
+    var (withdrawalId, transferId, outcome) = adapter.ProcessTransferEvent(evt);
+    logger.LogInformation(
+      "Airwallex transfer event '{Name}' for Withdrawal '{WithdrawalId}' (transfer '{TransferId}'): {Outcome}",
+      evt.Name,
+      withdrawalId,
+      transferId,
+      outcome
+    );
+    return outcome switch
+    {
+      TransferOutcome.Settled => withdrawalService
+        .CompletePayout(withdrawalId, transferId)
+        .Then(_ => new Unit(), Errors.MapNone),
+      TransferOutcome.Failed => withdrawalService
+        .FailPayout(withdrawalId, $"Airwallex transfer '{transferId}' ended as '{evt.Name}'")
+        .Then(_ => new Unit(), Errors.MapNone),
+      // NEW / PROCESSING / SENT etc: acknowledge, settlement decides later
+      _ => Task.FromResult(new Unit().ToResult()),
+    };
   }
 }

--- a/App/Modules/Payments/Airwallex/AirwallexWebhookService.cs
+++ b/App/Modules/Payments/Airwallex/AirwallexWebhookService.cs
@@ -63,15 +63,29 @@ public class AirwallexWebhookService(
       attempt,
       outcome
     );
+
+    // a transfer we did not mint (e.g. created by hand in the Airwallex
+    // dashboard): acknowledge and ignore
+    if (withdrawalId == null)
+    {
+      logger.LogWarning(
+        "Ignoring Airwallex transfer event '{Name}' with foreign request id '{RequestId}' (transfer '{TransferId}')",
+        evt.Name,
+        evt.Data.Object.RequestId,
+        transferId
+      );
+      return new Unit();
+    }
+
     var result = await (
       outcome switch
       {
         TransferOutcome.Settled => withdrawalService
-          .CompletePayout(withdrawalId, transferId, attempt)
+          .CompletePayout(withdrawalId.Value, transferId, attempt)
           .Then(_ => new Unit(), Errors.MapNone),
         TransferOutcome.Failed => withdrawalService
           .FailPayout(
-            withdrawalId,
+            withdrawalId.Value,
             $"Airwallex transfer '{transferId}' ended as '{evt.Name}'",
             attempt
           )

--- a/App/Modules/Payments/Airwallex/Client.cs
+++ b/App/Modules/Payments/Airwallex/Client.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Headers;
 using App.StartUp.Registry;
 using App.Utility;
 using CSharp_Result;
+using Domain.Exceptions;
 
 namespace App.Modules.Payments.Airwallex;
 
@@ -64,28 +65,36 @@ public class AirWallexClient(
           Headers = { Authorization = new AuthenticationHeaderValue("Bearer", token) },
           Content = JsonContent.Create(req),
         };
-        using var response = await this.HttpClient.SendAsync(request);
-
-        var body = await response.Content.ReadAsStringAsync();
+        // every failure below is returned as a failed Result, never thrown:
+        // Approve's compensation logic must be able to classify it
         try
         {
-          response.EnsureSuccessStatusCode();
-        }
-        catch (HttpRequestException e)
-        {
+          using var response = await this.HttpClient.SendAsync(request);
+          var body = await response.Content.ReadAsStringAsync();
+          if (response.IsSuccessStatusCode)
+            return body.ToObj<AirwallexTransferRes>().ToResult();
+
           logger.LogError(
-            e,
-            "Failed to create transfer with Airwallex (HTTP Error), Response: {Body}",
+            "Failed to create transfer with Airwallex, Status: {Status}, Response: {Body}",
+            (int)response.StatusCode,
             body
           );
-          return e;
+          // a definitive validation rejection proves no transfer was created;
+          // 408/429 give no such proof and stay ambiguous, like 5xx/network
+          var status = (int)response.StatusCode;
+          if (status is >= 400 and < 500 and not 408 and not 429)
+            return (Result<AirwallexTransferRes>)
+              new PayoutRejectedException($"Airwallex rejected the transfer ({status}): {body}");
+          return (Result<AirwallexTransferRes>)
+            new HttpRequestException($"Airwallex transfer creation failed ({status}): {body}");
         }
         catch (Exception e)
         {
-          logger.LogError(e, "Failed to create transfer with Airwallex");
-          throw;
+          // network fault / timeout: the transfer may or may not exist —
+          // ambiguous by definition
+          logger.LogError(e, "Failed to create transfer with Airwallex (transport error)");
+          return (Result<AirwallexTransferRes>)e;
         }
-        return body.ToObj<AirwallexTransferRes>().ToResult();
       });
   }
 }

--- a/App/Modules/Payments/Airwallex/Client.cs
+++ b/App/Modules/Payments/Airwallex/Client.cs
@@ -50,4 +50,42 @@ public class AirWallexClient(
         return body.ToObj<AirwallexCreateIntentRes>().ToResult();
       });
   }
+
+  public Task<Result<AirwallexTransferRes>> CreateTransfer(AirwallexCreateTransferReq req)
+  {
+    return authenticator
+      .GetToken()
+      .ThenAwait(async token =>
+      {
+        var request = new HttpRequestMessage
+        {
+          Method = HttpMethod.Post,
+          RequestUri = new Uri("api/v1/transfers/create", UriKind.Relative),
+          Headers = { Authorization = new AuthenticationHeaderValue("Bearer", token) },
+          Content = JsonContent.Create(req),
+        };
+        using var response = await this.HttpClient.SendAsync(request);
+
+        var body = await response.Content.ReadAsStringAsync();
+        try
+        {
+          response.EnsureSuccessStatusCode();
+        }
+        catch (HttpRequestException e)
+        {
+          logger.LogError(
+            e,
+            "Failed to create transfer with Airwallex (HTTP Error), Response: {Body}",
+            body
+          );
+          return e;
+        }
+        catch (Exception e)
+        {
+          logger.LogError(e, "Failed to create transfer with Airwallex");
+          throw;
+        }
+        return body.ToObj<AirwallexTransferRes>().ToResult();
+      });
+  }
 }

--- a/App/Modules/Payments/Airwallex/EventModels.cs
+++ b/App/Modules/Payments/Airwallex/EventModels.cs
@@ -64,8 +64,10 @@ public record AirwallexEventDataObject
   [JsonPropertyName("merchant_order_id")]
   public Guid MerchantOrderId { get; set; }
 
+  // string, not Guid: payment intents use a bare Guid, but transfer (payout)
+  // request ids are "{withdrawalId}-{attempt}" and would fail Guid parsing
   [JsonPropertyName("request_id")]
-  public Guid RequestId { get; set; }
+  public string RequestId { get; set; } = string.Empty;
 
   [JsonPropertyName("status")]
   public string Status { get; set; } = string.Empty;

--- a/App/Modules/Payments/Airwallex/ReqModels.cs
+++ b/App/Modules/Payments/Airwallex/ReqModels.cs
@@ -16,3 +16,57 @@ public record AirwallexCreateIntentReq
   [JsonPropertyName("merchant_order_id")]
   public Guid MerchantOrderId { get; set; }
 }
+
+// Payouts (Transfers) API — PayNow payout is an Airwallex Beta feature that
+// must be enabled by the account manager; the beneficiary shape below follows
+// the documented SG payout network (PayNow ID via account_routing_type1)
+public record AirwallexCreateTransferReq
+{
+  [JsonPropertyName("request_id")]
+  public string RequestId { get; set; } = null!;
+
+  [JsonPropertyName("source_currency")]
+  public string SourceCurrency { get; set; } = null!;
+
+  [JsonPropertyName("transfer_currency")]
+  public string TransferCurrency { get; set; } = null!;
+
+  [JsonPropertyName("transfer_amount")]
+  public decimal TransferAmount { get; set; }
+
+  [JsonPropertyName("transfer_method")]
+  public string TransferMethod { get; set; } = null!;
+
+  [JsonPropertyName("reason")]
+  public string Reason { get; set; } = null!;
+
+  [JsonPropertyName("reference")]
+  public string Reference { get; set; } = null!;
+
+  [JsonPropertyName("beneficiary")]
+  public AirwallexTransferBeneficiary Beneficiary { get; set; } = null!;
+}
+
+public record AirwallexTransferBeneficiary
+{
+  [JsonPropertyName("entity_type")]
+  public string EntityType { get; set; } = null!;
+
+  [JsonPropertyName("bank_details")]
+  public AirwallexTransferBankDetails BankDetails { get; set; } = null!;
+}
+
+public record AirwallexTransferBankDetails
+{
+  [JsonPropertyName("account_currency")]
+  public string AccountCurrency { get; set; } = null!;
+
+  [JsonPropertyName("bank_country_code")]
+  public string BankCountryCode { get; set; } = null!;
+
+  [JsonPropertyName("account_routing_type1")]
+  public string AccountRoutingType1 { get; set; } = null!;
+
+  [JsonPropertyName("account_routing_value1")]
+  public string AccountRoutingValue1 { get; set; } = null!;
+}

--- a/App/Modules/Payments/Airwallex/ResModel.cs
+++ b/App/Modules/Payments/Airwallex/ResModel.cs
@@ -55,3 +55,18 @@ public record AirwallexCreateIntentRes
   [JsonPropertyName("base_currency")]
   public string BaseCurrency { get; set; } = null!;
 }
+
+public record AirwallexTransferRes
+{
+  [JsonPropertyName("id")]
+  public string Id { get; set; } = null!;
+
+  [JsonPropertyName("request_id")]
+  public string RequestId { get; set; } = null!;
+
+  [JsonPropertyName("status")]
+  public string Status { get; set; } = null!;
+
+  [JsonPropertyName("short_reference_id")]
+  public string? ShortReferenceId { get; set; }
+}

--- a/App/Modules/Transactions/API/V1/TransactionMapper.cs
+++ b/App/Modules/Transactions/API/V1/TransactionMapper.cs
@@ -24,6 +24,7 @@ public static class TransactionMapper
       TransactionType.Transfer => TransactionTypes.Transfer,
       TransactionType.WithdrawRejected => TransactionTypes.WithdrawRejected,
       TransactionType.WithdrawCancelled => TransactionTypes.WithdrawCancelled,
+      TransactionType.WithdrawFee => TransactionTypes.WithdrawFee,
       _ => throw new ArgumentOutOfRangeException(nameof(type), type, null),
     };
 
@@ -59,6 +60,7 @@ public static class TransactionMapper
       TransactionTypes.Transfer => TransactionType.Transfer,
       TransactionTypes.WithdrawRejected => TransactionType.WithdrawRejected,
       TransactionTypes.WithdrawCancelled => TransactionType.WithdrawCancelled,
+      TransactionTypes.WithdrawFee => TransactionType.WithdrawFee,
       _ => throw new ArgumentOutOfRangeException(nameof(type), type, null),
     };
 

--- a/App/Modules/Withdrawals/API/V1/WithdrawalController.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalController.cs
@@ -128,6 +128,19 @@ public class WithdrawalController(
     return this.ReturnResult(x);
   }
 
+  // Admin escape hatch: finalize a confirmed Processing withdrawal whose
+  // settled webhook was permanently lost, after checking the transfer on the
+  // Airwallex dashboard. Idempotent — takes the same path the webhook would.
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpPost("{id:guid}/complete-payout")]
+  public async Task<ActionResult<WithdrawalPrincipalRes>> ForceCompletePayout(Guid id)
+  {
+    var x = await service
+      .ForceCompletePayout(id)
+      .Then(w => w.ToRes(), Errors.MapNone)
+      .ThenAwait(enrich.Enrich);
+    return this.ReturnResult(x);
+  }
+
   [Authorize(Policy = AuthPolicies.OnlyAdmin)]
   [HttpPost("{id:guid}/complete")]
   [Consumes(MediaTypeNames.Multipart.FormData)]

--- a/App/Modules/Withdrawals/API/V1/WithdrawalController.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalController.cs
@@ -134,8 +134,9 @@ public class WithdrawalController(
   [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpPost("{id:guid}/complete-payout")]
   public async Task<ActionResult<WithdrawalPrincipalRes>> ForceCompletePayout(Guid id)
   {
+    var userId = this.Sub();
     var x = await service
-      .ForceCompletePayout(id)
+      .ForceCompletePayout(id, userId!)
       .Then(w => w.ToRes(), Errors.MapNone)
       .ThenAwait(enrich.Enrich);
     return this.ReturnResult(x);

--- a/App/Modules/Withdrawals/API/V1/WithdrawalController.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalController.cs
@@ -6,6 +6,7 @@ using App.StartUp.Services.Auth;
 using App.Utility;
 using Asp.Versioning;
 using CSharp_Result;
+using Domain;
 using Domain.Wallet;
 using Domain.Withdrawal;
 using Microsoft.AspNetCore.Authorization;
@@ -24,9 +25,17 @@ public class WithdrawalController(
   CancelWithdrawalReqValidator cancelWithdrawalReqValidator,
   SearchWithdrawalQueryValidator searchWithdrawalQueryValidator,
   IWithdrawalImageEnricher enrich,
+  IFeeCalculator feeCalculator,
   IAuthHelper h
 ) : AtomiControllerBase(h)
 {
+  // the withdrawal fee rate, e.g. 0.04 = 4%, for pre-submission display
+  [Authorize, HttpGet("fee")]
+  public ActionResult<FeeRes> Fee()
+  {
+    return this.Ok(new FeeRes(feeCalculator.WithdrawFeeRate));
+  }
+
   [Authorize, HttpGet]
   public async Task<ActionResult<IEnumerable<WithdrawalPrincipalRes>>> Search(
     [FromQuery] SearchWithdrawalQuery query
@@ -107,6 +116,16 @@ public class WithdrawalController(
       .ThenAwait(enrich.Enrich);
 
     return this.ReturnResult(withdrawal);
+  }
+
+  // Initiates the automated Airwallex payout: Pending -> Processing; the
+  // transfer webhook completes (or fails) the withdrawal. Callable by admins
+  // (argon Approve button) and by tin's nightly withdrawer sweep.
+  [Authorize(Policy = AuthPolicies.AdminOrTin), HttpPost("{id:guid}/approve")]
+  public async Task<ActionResult<WithdrawalPrincipalRes>> Approve(Guid id)
+  {
+    var x = await service.Approve(id).Then(w => w.ToRes(), Errors.MapNone).ThenAwait(enrich.Enrich);
+    return this.ReturnResult(x);
   }
 
   [Authorize(Policy = AuthPolicies.OnlyAdmin)]

--- a/App/Modules/Withdrawals/API/V1/WithdrawalMapper.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalMapper.cs
@@ -15,6 +15,7 @@ public static class WithdrawalMapper
       WithdrawStatus.Completed => "Completed",
       WithdrawStatus.Rejected => "Rejected",
       WithdrawStatus.Cancel => "Cancel",
+      WithdrawStatus.Processing => "Processing",
       _ => throw new ArgumentOutOfRangeException(nameof(status), status, null),
     };
 
@@ -27,8 +28,18 @@ public static class WithdrawalMapper
   public static WithdrawalRecordRes ToRes(this WithdrawalRecord record) =>
     new(record.Amount, record.PayNowNumber);
 
+  public static WithdrawalPayoutRes ToRes(this WithdrawalPayout payout) =>
+    new(payout.ConfirmationNumber, payout.Fee);
+
   public static WithdrawalPrincipalRes ToRes(this WithdrawalPrincipal w) =>
-    new(w.Id, w.CreatedAt, w.Status.ToRes(), w.Record.ToRes(), w.Complete?.ToRes());
+    new(
+      w.Id,
+      w.CreatedAt,
+      w.Status.ToRes(),
+      w.Record.ToRes(),
+      w.Complete?.ToRes(),
+      w.Payout?.ToRes()
+    );
 
   public static WithdrawalRes ToRes(this Withdrawal w) =>
     new(w.Principal.ToRes(), w.User.ToRes(), w.Completer?.ToRes(), w.Wallet.ToRes());
@@ -41,6 +52,7 @@ public static class WithdrawalMapper
       "Completed" => WithdrawStatus.Completed,
       "Rejected" => WithdrawStatus.Rejected,
       "Cancel" => WithdrawStatus.Cancel,
+      "Processing" => WithdrawStatus.Processing,
       _ => throw new ArgumentOutOfRangeException(nameof(status), status, null),
     };
 

--- a/App/Modules/Withdrawals/API/V1/WithdrawalModel.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalModel.cs
@@ -29,13 +29,18 @@ public record WithdrawalCompleteRes(DateTime CompletedAt, string Note, string? R
 
 public record WithdrawalRecordRes(decimal Amount, string PayNowNumber);
 
+public record WithdrawalPayoutRes(string? ConfirmationNumber, decimal Fee);
+
 public record WithdrawalPrincipalRes(
   Guid Id,
   DateTime CreateAt,
   WithdrawalStatusRes Status,
   WithdrawalRecordRes Record,
-  WithdrawalCompleteRes? Complete
+  WithdrawalCompleteRes? Complete,
+  WithdrawalPayoutRes? Payout
 );
+
+public record FeeRes(decimal WithdrawFeeRate);
 
 public record WithdrawalRes(
   WithdrawalPrincipalRes Principal,

--- a/App/Modules/Withdrawals/API/V1/WithdrawalValidator.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalValidator.cs
@@ -23,7 +23,9 @@ public class CreateWithdrawalReqValidator : AbstractValidator<CreateWithdrawalRe
   public CreateWithdrawalReqValidator()
   {
     this.RuleFor(x => x.Amount).GreaterThan(0);
-    this.RuleFor(x => x.PayNowNumber).NotEmpty().MaximumLength(64);
+    // exactly 8 digits: an SG PayNow mobile number, matching the UI rule and
+    // the +65 normalization the payout gateway applies
+    this.RuleFor(x => x.PayNowNumber).NotEmpty().Matches("^[0-9]{8}$");
   }
 }
 

--- a/App/Modules/Withdrawals/Data/AirwallexPayoutGateway.cs
+++ b/App/Modules/Withdrawals/Data/AirwallexPayoutGateway.cs
@@ -1,0 +1,43 @@
+using App.Modules.Payments.Airwallex;
+using CSharp_Result;
+using Domain.Withdrawal;
+
+namespace App.Modules.Withdrawals.Data;
+
+public class AirwallexPayoutGateway(AirWallexClient client) : IPayoutGateway
+{
+  private const string Currency = "SGD";
+
+  public Task<Result<PayoutConfirmation>> CreatePayout(PayoutRequest request)
+  {
+    var req = new AirwallexCreateTransferReq
+    {
+      RequestId = request.RequestId,
+      SourceCurrency = Currency,
+      TransferCurrency = Currency,
+      TransferAmount = request.Amount,
+      TransferMethod = "LOCAL",
+      Reason = "personal_funds_transfer",
+      Reference = "BunnyBooker Withdrawal",
+      Beneficiary = new AirwallexTransferBeneficiary
+      {
+        EntityType = "PERSONAL",
+        BankDetails = new AirwallexTransferBankDetails
+        {
+          AccountCurrency = Currency,
+          BankCountryCode = "SG",
+          AccountRoutingType1 = "paynow_id",
+          AccountRoutingValue1 = ToPayNowId(request.PayNowNumber),
+        },
+      },
+    };
+    return client
+      .CreateTransfer(req)
+      .Then(res => new PayoutConfirmation { Id = res.Id }, Errors.MapNone);
+  }
+
+  // PayNow mobile IDs are addressed in E.164 form; local 8-digit numbers get
+  // the Singapore country prefix
+  private static string ToPayNowId(string payNowNumber) =>
+    payNowNumber.StartsWith('+') ? payNowNumber : $"+65{payNowNumber}";
+}

--- a/App/Modules/Withdrawals/Data/WithdrawalData.cs
+++ b/App/Modules/Withdrawals/Data/WithdrawalData.cs
@@ -30,6 +30,15 @@ public class WithdrawalData
   [MaxLength(64)]
   public string? Receipt { get; set; }
 
+  // Payout (automated withdrawal bookkeeping; null Fee = never approved)
+  [MaxLength(64)]
+  public string? ConfirmationNumber { get; set; }
+
+  [Precision(16, 8)]
+  public decimal? Fee { get; set; }
+
+  public int PayoutAttempt { get; set; }
+
   // References
   public string? CompleterId { get; set; }
   public UserData? Completer { get; set; }

--- a/App/Modules/Withdrawals/Data/WithdrawalMapper.cs
+++ b/App/Modules/Withdrawals/Data/WithdrawalMapper.cs
@@ -20,9 +20,21 @@ public static class WithdrawalMapper
     return new WithdrawalComplete
     {
       CompletedAt = data.CompletedAt.Value,
-      CompleterId = data.CompleterId ?? "",
+      CompleterId = data.CompleterId,
       Note = data.Note ?? "",
       Receipt = data.Receipt,
+    };
+  }
+
+  public static WithdrawalPayout? ToPayout(this WithdrawalData data)
+  {
+    if (data.Fee == null)
+      return null;
+    return new WithdrawalPayout
+    {
+      ConfirmationNumber = data.ConfirmationNumber,
+      Fee = data.Fee.Value,
+      Attempt = data.PayoutAttempt,
     };
   }
 
@@ -33,6 +45,7 @@ public static class WithdrawalMapper
       Record = data.ToRecord(),
       Complete = data.ToComplete(),
       Status = data.ToStatus(),
+      Payout = data.ToPayout(),
       CreatedAt = data.CreatedAt,
     };
 
@@ -65,6 +78,14 @@ public static class WithdrawalMapper
     data.CompleterId = record.CompleterId;
     data.Note = record.Note;
     data.Receipt = record.Receipt;
+    return data;
+  }
+
+  public static WithdrawalData Update(this WithdrawalData data, WithdrawalPayout record)
+  {
+    data.ConfirmationNumber = record.ConfirmationNumber;
+    data.Fee = record.Fee;
+    data.PayoutAttempt = record.Attempt;
     return data;
   }
 }

--- a/App/Modules/Withdrawals/Data/WithdrawalRepository.cs
+++ b/App/Modules/Withdrawals/Data/WithdrawalRepository.cs
@@ -145,18 +145,20 @@ public class WithdrawalRepository(MainDbContext db, ILogger<WithdrawalRepository
     Guid id,
     WithdrawalRecord? record,
     WithdrawalStatus? status,
-    WithdrawalComplete? complete
+    WithdrawalComplete? complete,
+    WithdrawalPayout? payout = null
   )
   {
     try
     {
       logger.LogInformation(
-        "Updating Withdrawal '{Id}' under User '{UserId}' with: {@Record}, {@Status} and {@Complete}",
+        "Updating Withdrawal '{Id}' under User '{UserId}' with: {@Record}, {@Status}, {@Complete} and {@Payout}",
         id,
         userId ?? "null",
         record?.ToJson() ?? "null",
         status?.ToJson() ?? "null",
-        complete?.ToJson() ?? "null"
+        complete?.ToJson() ?? "null",
+        payout?.ToJson() ?? "null"
       );
       var v1 = await db
         .Withdrawals.Include(x => x.Wallet)
@@ -172,6 +174,8 @@ public class WithdrawalRepository(MainDbContext db, ILogger<WithdrawalRepository
         v1 = v1.Update(status);
       if (complete is not null)
         v1 = v1.Update(complete);
+      if (payout is not null)
+        v1 = v1.Update(payout);
 
       var updated = db.Withdrawals.Update(v1);
       await db.SaveChangesAsync();

--- a/App/Modules/Withdrawals/FeeCalculator.cs
+++ b/App/Modules/Withdrawals/FeeCalculator.cs
@@ -1,0 +1,18 @@
+using App.StartUp.Options;
+using Domain;
+using Microsoft.Extensions.Options;
+
+namespace App.Modules.Withdrawals;
+
+public class FeeCalculator(IOptions<DomainOptions> d) : IFeeCalculator
+{
+  private decimal Nn => d.Value.WithdrawFeePercentage;
+  private static decimal Dd => 100;
+
+  public decimal WithdrawFeeRate => this.Nn / Dd;
+
+  // Rounded to cents so the ledger, the payout and the user-visible numbers
+  // always agree
+  public decimal WithdrawFee(decimal amount) =>
+    Math.Round(amount * this.WithdrawFeeRate, 2, MidpointRounding.ToEven);
+}

--- a/App/StartUp/Options/DomainOptions.cs
+++ b/App/StartUp/Options/DomainOptions.cs
@@ -8,7 +8,12 @@ public class DomainOptions
 
   [Required]
   public int RefundPercentage { get; set; } = 50;
-  
+
+  // Withdrawal fee, in percent of the requested amount (deducted from the
+  // amount before payout), e.g. 4 = 4%
+  [Required, Range(0, 100)]
+  public decimal WithdrawFeePercentage { get; set; } = 4;
+
   [Required, Url]
   public string BaseUrl { get; set; } = string.Empty;
   

--- a/App/Templates/Email/emails/index.ts
+++ b/App/Templates/Email/emails/index.ts
@@ -5,6 +5,7 @@ export { default as BookingTerminatedEmail } from './booking-terminated';
 export { default as BookingRefundedEmail } from './booking-refunded';
 export { default as BookingDuplicateEmail } from './booking-duplicate';
 export { default as BookingManualInterventionEmail } from './booking-manual-intervention';
+export { default as WithdrawalFeeAnnouncementEmail } from './withdrawal-fee-announcement';
 
 // Component library
 export * from './lib/header';

--- a/App/Templates/Email/emails/withdrawal-fee-announcement.tsx
+++ b/App/Templates/Email/emails/withdrawal-fee-announcement.tsx
@@ -1,0 +1,171 @@
+import { Heading, Section, Text } from '@react-email/components';
+import { EmailLayout } from './lib/layout';
+
+interface WithdrawalFeeAnnouncementEmailProps {
+  baseUrl: string;
+  userName: string;
+  userEmail: string;
+  whatsappUrl: string;
+  telegramUrl: string;
+  supportEmail: string;
+  feePercent: string;
+}
+
+export const WithdrawalFeeAnnouncementEmail = ({
+  baseUrl = '{{ baseUrl }}',
+  whatsappUrl = '{{ whatsappUrl }}',
+  telegramUrl = '{{ telegramUrl }}',
+  supportEmail = '{{ supportEmail }}',
+  userName = '{{ userName }}',
+  userEmail = '{{ userEmail }}',
+  feePercent = '{{ feePercent }}',
+}: WithdrawalFeeAnnouncementEmailProps) => {
+  const subject = `Introducing a ${feePercent}% Withdrawal Fee`;
+  const previewText = `Hi ${userName}, an important update about wallet withdrawals on BunnyBooker.`;
+
+  return (
+    <EmailLayout
+      baseUrl={baseUrl}
+      supportEmail={supportEmail}
+      whatsappUrl={whatsappUrl}
+      telegramUrl={telegramUrl}
+      subject={subject}
+      previewText={previewText}
+      userEmail={userEmail}
+    >
+      <Heading
+        as="h1"
+        style={{
+          fontSize: '28px',
+          fontWeight: 'bold',
+          color: '#111827',
+          margin: '0 0 24px 0',
+          lineHeight: '1.2',
+        }}
+      >
+        An Important Update on Withdrawals, {userName}
+      </Heading>
+
+      <Text
+        style={{
+          fontSize: '18px',
+          color: '#111827',
+          lineHeight: '1.75',
+          marginBottom: '32px',
+          margin: '0 0 32px 0',
+          fontWeight: '500',
+        }}
+      >
+        We're writing to let you know about a change to how withdrawals from your BunnyBooker wallet work. We don't make
+        changes like this lightly, and we want to be upfront about why.
+      </Text>
+
+      <Text
+        style={{
+          fontSize: '18px',
+          color: '#111827',
+          lineHeight: '1.75',
+          marginBottom: '32px',
+          margin: '0 0 32px 0',
+          fontWeight: '500',
+        }}
+      >
+        Recently, we've seen widespread abuse of our wallet system, with large sums being deposited and withdrawn purely
+        to churn funds through the platform. This activity drives up costs for everyone and puts the smooth, reliable
+        service you count on at risk. To protect the platform and the community of genuine travelers who use it, we're
+        introducing a small fee on withdrawals.
+      </Text>
+
+      <Section
+        style={{
+          background: 'linear-gradient(to right, #fef7ec, #fef3c7)',
+          borderRadius: '16px',
+          border: '1px solid #fed7aa',
+          padding: '24px 28px',
+          margin: '0 0 32px 0',
+        }}
+      >
+        <Heading
+          as="h3"
+          style={{
+            color: '#111827',
+            fontSize: '20px',
+            fontWeight: '600',
+            margin: '0 0 16px 0',
+          }}
+        >
+          What's changing
+        </Heading>
+        <Text
+          style={{
+            fontSize: '16px',
+            color: '#111827',
+            lineHeight: '1.75',
+            margin: '0',
+            fontWeight: '500',
+          }}
+        >
+          • A <strong>{feePercent}% fee</strong> now applies to all wallet withdrawals
+          <br />• The fee is <strong>deducted from the withdrawn amount</strong>
+          <br />• <strong>Deposits remain completely free</strong>
+          <br />• This change is <strong>effective immediately</strong>
+        </Text>
+      </Section>
+
+      <Text
+        style={{
+          fontSize: '18px',
+          color: '#111827',
+          lineHeight: '1.75',
+          marginBottom: '24px',
+          margin: '0 0 24px 0',
+          fontWeight: '500',
+        }}
+      >
+        Nothing else changes: your credits, bookings and refunds all work exactly as before, and using your wallet
+        balance for bookings stays free.
+      </Text>
+
+      <Text
+        style={{
+          fontSize: '18px',
+          color: '#111827',
+          lineHeight: '1.75',
+          marginBottom: '24px',
+          margin: '0 0 24px 0',
+          fontWeight: '500',
+        }}
+      >
+        We're sorry for any inconvenience this causes, especially to those of you who have always used the wallet as
+        intended. This step is necessary to keep BunnyBooker sustainable and fair for everyone.
+      </Text>
+
+      <Text
+        style={{
+          fontSize: '18px',
+          color: '#111827',
+          lineHeight: '1.75',
+          marginBottom: '24px',
+          margin: '0 0 24px 0',
+          fontWeight: '500',
+        }}
+      >
+        If you have any questions, our support team is happy to help. Thank you for your understanding and for being
+        part of BunnyBooker. 🐰
+      </Text>
+    </EmailLayout>
+  );
+};
+
+// Preview props for development
+WithdrawalFeeAnnouncementEmail.PreviewProps = {
+  baseUrl: 'https://bunnybooker.com',
+  telegramUrl: 'https://t.me/bunnybooker',
+  whatsappUrl: 'https://wa.me/60123456789',
+  supportEmail: 'support@bunnybooker.com',
+  userName: 'John Doe',
+  userEmail: 'john@example.com',
+  feePercent: '4',
+} as WithdrawalFeeAnnouncementEmailProps;
+
+export default WithdrawalFeeAnnouncementEmail;

--- a/Domain/Booking/IService.cs
+++ b/Domain/Booking/IService.cs
@@ -25,7 +25,7 @@ public interface IBookingService
 
   Task<Result<BookingPrincipal?>> ManualIntervention(Guid id);
 
-  Task<Result<BookingPrincipal?>> Revert(Guid id);
+  Task<Result<BookingPrincipal?>> Revert(Guid id, bool force);
 
   Task<Result<BookingPrincipal?>> Complete(Guid id,
     string bookingNo,

--- a/Domain/Booking/Model.cs
+++ b/Domain/Booking/Model.cs
@@ -37,6 +37,14 @@ public record BookingCountSearch
   public TrainDirection Direction { get; init; }
 }
 
+public enum BookingSort
+{
+  // travel date + time, soonest first
+  Timing = 0,
+  PassengerName = 1,
+  PassportNumber = 2,
+}
+
 public record BookingSearch
 {
   public DateOnly? Date { get; init; }
@@ -50,6 +58,13 @@ public record BookingSearch
   public string? UserId { get; init; }
 
   public string? PassportNumber { get; init; }
+
+  // only bookings whose last entry into Buying is older than this; lets the
+  // reverter cron list stuck-Buying bookings without racing live purchases
+  public DateTime? BuyingBefore { get; init; }
+
+  // null = created-date descending (the historical default)
+  public BookingSort? Sort { get; init; }
 
   public int Limit { get; init; }
 
@@ -94,6 +109,10 @@ public record BookingStatus
   public required BookStatus Status { get; init; } = BookStatus.Pending;
 
   public required DateTime? CompletedAt { get; init; } = null;
+
+  // when the booking last entered Buying; stamped by the data layer on the
+  // Pending -> Buying transition (read-only for callers)
+  public DateTime? LastBuyingAt { get; init; }
 }
 
 public record BookingRecord

--- a/Domain/Booking/Model.cs
+++ b/Domain/Booking/Model.cs
@@ -63,7 +63,7 @@ public record BookingSearch
   // reverter cron list stuck-Buying bookings without racing live purchases
   public DateTime? BuyingBefore { get; init; }
 
-  // null = created-date descending (the historical default)
+  // null = travel-date descending (the historical default ordering)
   public BookingSort? Sort { get; init; }
 
   public int Limit { get; init; }

--- a/Domain/Booking/Service.cs
+++ b/Domain/Booking/Service.cs
@@ -133,7 +133,16 @@ public class BookingService(
   // that already captured a KTMB ticket into re-buying (the corruption + double
   // -buy hazards the old unguarded reverter caused). Status-only: no money moves
   // (both Pending and Buying hold the amount in BookingReserve).
-  public Task<Result<BookingPrincipal?>> Revert(Guid id)
+  //
+  // force = false (automation, e.g. helium's reverter cron): additionally
+  // requires the booking to have sat in Buying for more than StuckThreshold,
+  // so the cron can never race the buyer's live purchase window. Bookings
+  // predating the LastBuyingAt column (null stamp) are refused — never guess.
+  // force = true (admin UI): no age check, and RequireManualIntervention is
+  // also accepted; a human has judged the booking safe to re-expose.
+  public static readonly TimeSpan StuckThreshold = TimeSpan.FromMinutes(5);
+
+  public Task<Result<BookingPrincipal?>> Revert(Guid id, bool force)
   {
     return transaction.Start(
       () =>
@@ -143,16 +152,21 @@ public class BookingService(
             DoType.MapErrors,
             b =>
             {
-              if (
-                (
-                  b.Principal.Status.Status == BookStatus.Buying
-                  || b.Principal.Status.Status == BookStatus.RequireManualIntervention
-                )
-                && b.Principal.Complete.BookingNumber == null
-              )
+              var status = b.Principal.Status.Status;
+              var uncaptured = b.Principal.Complete.BookingNumber == null;
+              var allowed = force
+                ? (status == BookStatus.Buying || status == BookStatus.RequireManualIntervention)
+                  && uncaptured
+                : status == BookStatus.Buying
+                  && uncaptured
+                  && b.Principal.Status.LastBuyingAt != null
+                  && DateTime.UtcNow - b.Principal.Status.LastBuyingAt > StuckThreshold;
+              if (allowed)
                 return Task.FromResult((Result<int>)0);
               var r = new InvalidBookingOperationException(
-                "Revert requires an uncaptured booking in 'Buying' or 'RequireManualIntervention' Status",
+                force
+                  ? "Revert requires an uncaptured booking in 'Buying' or 'RequireManualIntervention' Status"
+                  : "Revert (non-force) requires an uncaptured booking stuck in 'Buying' Status for more than 5 minutes",
                 b.Principal.Status.Status,
                 BookingOperations.Revert
               );

--- a/Domain/Exceptions/InvalidWithdrawalOperationException.cs
+++ b/Domain/Exceptions/InvalidWithdrawalOperationException.cs
@@ -1,0 +1,39 @@
+using Domain.Withdrawal;
+
+namespace Domain.Exceptions;
+
+public class InvalidWithdrawalOperationException : Exception
+{
+  public InvalidWithdrawalOperationException(WithdrawStatus withdrawStatus, string operation)
+  {
+    this.WithdrawStatus = withdrawStatus;
+    this.Operation = operation;
+  }
+
+  public InvalidWithdrawalOperationException(
+    string? message,
+    WithdrawStatus withdrawStatus,
+    string operation
+  )
+    : base(message)
+  {
+    this.WithdrawStatus = withdrawStatus;
+    this.Operation = operation;
+  }
+
+  public InvalidWithdrawalOperationException(
+    string? message,
+    Exception? innerException,
+    WithdrawStatus withdrawStatus,
+    string operation
+  )
+    : base(message, innerException)
+  {
+    this.WithdrawStatus = withdrawStatus;
+    this.Operation = operation;
+  }
+
+  public WithdrawStatus WithdrawStatus { get; init; }
+
+  public string Operation { get; init; }
+}

--- a/Domain/Exceptions/PayoutRejectedException.cs
+++ b/Domain/Exceptions/PayoutRejectedException.cs
@@ -1,0 +1,9 @@
+namespace Domain.Exceptions;
+
+// The payout gateway DEFINITIVELY refused to create the payout (a validation
+// rejection): no transfer exists for the request id, so the withdrawal may
+// safely return to Pending and a later attempt may use a fresh request id.
+// Any failure that does NOT prove non-creation (timeout, 5xx, connection
+// reset) must NOT use this type — those are ambiguous and the withdrawal has
+// to stay claimed so the retry reuses the same request id.
+public class PayoutRejectedException(string? message) : Exception(message);

--- a/Domain/Exceptions/StalePayoutEventException.cs
+++ b/Domain/Exceptions/StalePayoutEventException.cs
@@ -1,0 +1,7 @@
+namespace Domain.Exceptions;
+
+// A payout webhook event refers to a superseded attempt or an already-settled
+// withdrawal: it must be acknowledged (2xx) so the gateway stops redelivering,
+// but it must not mutate any state. The webhook layer converts this into a
+// logged no-op.
+public class StalePayoutEventException(string? message) : Exception(message);

--- a/Domain/IFeeCalculator.cs
+++ b/Domain/IFeeCalculator.cs
@@ -1,0 +1,8 @@
+namespace Domain;
+
+public interface IFeeCalculator
+{
+  decimal WithdrawFeeRate { get; }
+
+  decimal WithdrawFee(decimal amount);
+}

--- a/Domain/Transaction/Accounts.cs
+++ b/Domain/Transaction/Accounts.cs
@@ -9,4 +9,8 @@ public static class Accounts
   public static Account WithdrawReserve = new("WITHDRAW_RESERVE", "Withdraw Reserve");
   public static Account BookingReserve = new("USER_BOOKING_RESERVE", "Booking Reserve");
   public static Account BunnyBooker = new("BUNNY_BOOKER", "Bunny Booker");
+  public static Account WithdrawalFee = new(
+    "BUNNY_BOOKER_WITHDRAWAL_FEE",
+    "BunnyBooker Withdrawal Fee"
+  );
 }

--- a/Domain/Transaction/Generator.cs
+++ b/Domain/Transaction/Generator.cs
@@ -28,7 +28,9 @@ public interface ITransactionGenerator
   // Withdrawal
   public TransactionRecord CreateWithdrawalRequest(WithdrawalRecord record);
 
-  public TransactionRecord CompleteWithdrawalRequest(WithdrawalRecord record);
+  public TransactionRecord CompleteWithdrawalRequest(WithdrawalRecord record, decimal fee);
+
+  public TransactionRecord WithdrawalFeeCharge(WithdrawalRecord record, decimal fee);
 
   public TransactionRecord CancelWithdrawalRequest(WithdrawalRecord record);
 
@@ -200,20 +202,39 @@ public class TransactionGenerator(IRefundCalculator calculator) : ITransactionGe
     };
   }
 
-  public TransactionRecord CompleteWithdrawalRequest(WithdrawalRecord record)
+  public TransactionRecord CompleteWithdrawalRequest(WithdrawalRecord record, decimal fee)
   {
     var amount = record.Amount;
+    var net = amount - fee;
     return new TransactionRecord
     {
       Name = "Withdrawal Completed",
       Description =
         $"BunnyBooker has completed your withdrawal request of SGD {amount:0.00} to the PayNow "
-        + $"account {record.PayNowNumber}. SGD {amount:0.00} has been collected from your "
+        + $"account {record.PayNowNumber}. SGD {net:0.00} has been paid out to you and, together "
+        + $"with the SGD {fee:0.00} withdrawal fee, SGD {amount:0.00} has been collected from your "
         + $"Withdrawal Reserve Account.",
-      Amount = amount,
+      Amount = net,
       Type = TransactionType.WithdrawComplete,
       From = Accounts.WithdrawReserve.DisplayName,
       To = Accounts.BunnyBooker.DisplayName,
+    };
+  }
+
+  public TransactionRecord WithdrawalFeeCharge(WithdrawalRecord record, decimal fee)
+  {
+    var amount = record.Amount;
+    return new TransactionRecord
+    {
+      Name = "Withdrawal Fee",
+      Description =
+        $"A withdrawal fee of SGD {fee:0.00} has been charged on your withdrawal request of "
+        + $"SGD {amount:0.00} to the PayNow account {record.PayNowNumber}. The fee has been "
+        + $"collected from your Withdrawal Reserve Account.",
+      Amount = fee,
+      Type = TransactionType.WithdrawFee,
+      From = Accounts.WithdrawReserve.DisplayName,
+      To = Accounts.WithdrawalFee.DisplayName,
     };
   }
 

--- a/Domain/Transaction/Model.cs
+++ b/Domain/Transaction/Model.cs
@@ -18,6 +18,7 @@ public static class TransactionTypes
   public const string WithdrawComplete = "WithdrawComplete";
   public const string WithdrawRejected = "WithdrawRejected";
   public const string WithdrawCancelled = "WithdrawCancelled";
+  public const string WithdrawFee = "WithdrawFee";
 
   // Additional
   public const string Promotional = "Promotional";
@@ -38,6 +39,7 @@ public static class TransactionTypes
     Promotional,
     Transfer,
     BookingDuplicate,
+    WithdrawFee,
   ];
 }
 
@@ -63,6 +65,9 @@ public enum TransactionType
 
   // Product related (appended to preserve stored smallint values)
   BookingDuplicate = 12,
+
+  // Wallet Related (appended to preserve stored smallint values)
+  WithdrawFee = 13,
 }
 
 public record TransactionSearch

--- a/Domain/Withdrawal/IPayoutGateway.cs
+++ b/Domain/Withdrawal/IPayoutGateway.cs
@@ -1,0 +1,27 @@
+using CSharp_Result;
+
+namespace Domain.Withdrawal;
+
+public record PayoutRequest
+{
+  // Unique per attempt; the gateway deduplicates on this, so a retried attempt
+  // can never create a second payout for the same request id
+  public required string RequestId { get; init; }
+
+  // Net amount actually paid out (gross minus withdrawal fee)
+  public required decimal Amount { get; init; }
+
+  public required string PayNowNumber { get; init; }
+}
+
+// Confirmation of a created payout; Id is the gateway's transfer identifier and
+// doubles as the withdrawal's confirmation number
+public record PayoutConfirmation
+{
+  public required string Id { get; init; }
+}
+
+public interface IPayoutGateway
+{
+  Task<Result<PayoutConfirmation>> CreatePayout(PayoutRequest request);
+}

--- a/Domain/Withdrawal/IService.cs
+++ b/Domain/Withdrawal/IService.cs
@@ -31,14 +31,21 @@ public interface IWithdrawalService
   // attempt (parsed from the gateway request id) fences off events from
   // superseded attempts; duplicates of the settling event are acknowledged
   // idempotently, stale events fail with StalePayoutEventException.
-  Task<Result<WithdrawalPrincipal>> CompletePayout(Guid id, string confirmationNumber, int? attempt);
+  // completerId is null for the webhook; the admin force-complete passes the
+  // acting admin for the audit trail.
+  Task<Result<WithdrawalPrincipal>> CompletePayout(
+    Guid id,
+    string confirmationNumber,
+    int? attempt,
+    string? completerId = null
+  );
 
   // Gateway webhook: payout failed, return the withdrawal to Pending for retry
   Task<Result<WithdrawalPrincipal>> FailPayout(Guid id, string reason, int? attempt);
 
   // Admin only: finalize a confirmed Processing withdrawal whose settled
   // webhook was permanently lost (verified against the gateway dashboard)
-  Task<Result<WithdrawalPrincipal>> ForceCompletePayout(Guid id);
+  Task<Result<WithdrawalPrincipal>> ForceCompletePayout(Guid id, string completerId);
 
   Task<Result<Unit?>> Delete(Guid id);
 }

--- a/Domain/Withdrawal/IService.cs
+++ b/Domain/Withdrawal/IService.cs
@@ -36,5 +36,9 @@ public interface IWithdrawalService
   // Gateway webhook: payout failed, return the withdrawal to Pending for retry
   Task<Result<WithdrawalPrincipal>> FailPayout(Guid id, string reason, int? attempt);
 
+  // Admin only: finalize a confirmed Processing withdrawal whose settled
+  // webhook was permanently lost (verified against the gateway dashboard)
+  Task<Result<WithdrawalPrincipal>> ForceCompletePayout(Guid id);
+
   Task<Result<Unit?>> Delete(Guid id);
 }

--- a/Domain/Withdrawal/IService.cs
+++ b/Domain/Withdrawal/IService.cs
@@ -23,5 +23,15 @@ public interface IWithdrawalService
     Stream receipt
   );
 
+  // Admin or automation initiated: creates a payout at the gateway and moves
+  // the withdrawal to Processing; the gateway webhook completes or fails it
+  Task<Result<WithdrawalPrincipal>> Approve(Guid id);
+
+  // Gateway webhook: payout settled, collect the reserve and finalize
+  Task<Result<WithdrawalPrincipal>> CompletePayout(Guid id, string confirmationNumber);
+
+  // Gateway webhook: payout failed, return the withdrawal to Pending for retry
+  Task<Result<WithdrawalPrincipal>> FailPayout(Guid id, string reason);
+
   Task<Result<Unit?>> Delete(Guid id);
 }

--- a/Domain/Withdrawal/IService.cs
+++ b/Domain/Withdrawal/IService.cs
@@ -27,11 +27,14 @@ public interface IWithdrawalService
   // the withdrawal to Processing; the gateway webhook completes or fails it
   Task<Result<WithdrawalPrincipal>> Approve(Guid id);
 
-  // Gateway webhook: payout settled, collect the reserve and finalize
-  Task<Result<WithdrawalPrincipal>> CompletePayout(Guid id, string confirmationNumber);
+  // Gateway webhook: payout settled, collect the reserve and finalize.
+  // attempt (parsed from the gateway request id) fences off events from
+  // superseded attempts; duplicates of the settling event are acknowledged
+  // idempotently, stale events fail with StalePayoutEventException.
+  Task<Result<WithdrawalPrincipal>> CompletePayout(Guid id, string confirmationNumber, int? attempt);
 
   // Gateway webhook: payout failed, return the withdrawal to Pending for retry
-  Task<Result<WithdrawalPrincipal>> FailPayout(Guid id, string reason);
+  Task<Result<WithdrawalPrincipal>> FailPayout(Guid id, string reason, int? attempt);
 
   Task<Result<Unit?>> Delete(Guid id);
 }

--- a/Domain/Withdrawal/Model.cs
+++ b/Domain/Withdrawal/Model.cs
@@ -31,6 +31,10 @@ public enum WithdrawStatus
   Completed = 1,
   Rejected = 2,
   Cancel = 3,
+
+  // payout initiated at the gateway, awaiting settlement confirmation via
+  // webhook (appended to preserve stored byte values)
+  Processing = 4,
 }
 
 public record Withdrawal
@@ -52,6 +56,8 @@ public record WithdrawalPrincipal
   public required WithdrawalRecord Record { get; init; }
 
   public required WithdrawalComplete? Complete { get; init; }
+
+  public required WithdrawalPayout? Payout { get; init; }
 }
 
 public record WithdrawalStatus
@@ -63,11 +69,29 @@ public record WithdrawalComplete
 {
   public required DateTime CompletedAt { get; init; }
 
-  public required string CompleterId { get; init; }
+  // null when the withdrawal was completed by the automated payout flow
+  // (no human completer exists)
+  public required string? CompleterId { get; init; }
 
   public required string Note { get; init; }
 
   public required string? Receipt { get; init; }
+}
+
+// Automated-payout bookkeeping, written when an approve attempt fires.
+// ConfirmationNumber is the gateway transfer id proving the payout exists.
+public record WithdrawalPayout
+{
+  public required string? ConfirmationNumber { get; init; }
+
+  // Fee snapshotted at approval so the ledger always matches the transfer
+  // actually created, even if the configured rate changes mid-flight
+  public required decimal Fee { get; init; }
+
+  // Number of approve attempts; makes each gateway request id unique so a
+  // genuinely failed payout can be retried without colliding with the
+  // gateway's idempotency window
+  public required int Attempt { get; init; }
 }
 
 public record WithdrawalRecord

--- a/Domain/Withdrawal/Repository.cs
+++ b/Domain/Withdrawal/Repository.cs
@@ -15,7 +15,8 @@ public interface IWithdrawalRepository
     Guid id,
     WithdrawalRecord? record,
     WithdrawalStatus? status,
-    WithdrawalComplete? complete
+    WithdrawalComplete? complete,
+    WithdrawalPayout? payout = null
   );
 
   Task<Result<Unit?>> Delete(Guid id);

--- a/Domain/Withdrawal/Service.cs
+++ b/Domain/Withdrawal/Service.cs
@@ -1,4 +1,5 @@
 using CSharp_Result;
+using Domain.Exceptions;
 using Domain.Transaction;
 using Domain.Wallet;
 
@@ -10,7 +11,9 @@ public class WithdrawalService(
   ITransactionRepository transactionRepository,
   ITransactionGenerator generator,
   IWithdrawalStorage withdrawalStorage,
-  ITransactionManager transactionManager
+  ITransactionManager transactionManager,
+  IFeeCalculator feeCalculator,
+  IPayoutGateway payoutGateway
 ) : IWithdrawalService
 {
   public Task<Result<IEnumerable<WithdrawalPrincipal>>> Search(WithdrawalSearch search)
@@ -49,6 +52,7 @@ public class WithdrawalService(
       () =>
         repo.Get(id, userId)
           .NullToError(id.ToString())
+          .DoAwait(DoType.MapErrors, w => GuardStatus(w, WithdrawalOperations.Cancel))
           // update wallet
           .DoAwait(
             DoType.MapErrors,
@@ -92,6 +96,7 @@ public class WithdrawalService(
       () =>
         repo.Get(id, null)
           .NullToError(id.ToString())
+          .DoAwait(DoType.MapErrors, w => GuardStatus(w, WithdrawalOperations.Reject))
           // update wallet
           .DoAwait(
             DoType.MapErrors,
@@ -140,37 +145,200 @@ public class WithdrawalService(
       () =>
         repo.Get(id, null)
           .NullToError(id.ToString())
-          // update wallet
-          .DoAwait(
-            DoType.MapErrors,
-            w =>
-              walletRepo
-                .Withdraw(w.Wallet.Id, w.Principal.Record.Amount)
-                .NullToError(w.Wallet.Id.ToString())
-          )
-          // update transaction
-          .DoAwait(
-            DoType.MapErrors,
-            w =>
-              transactionRepository.Create(
-                w.Wallet.Id,
-                generator.CompleteWithdrawalRequest(w.Principal.Record)
+          .DoAwait(DoType.MapErrors, w => GuardStatus(w, WithdrawalOperations.Complete))
+          .ThenAwait(w =>
+          {
+            // manual completion charges the same fee as the automated payout:
+            // the admin pays out the net amount and the fee is collected into
+            // the fee account, so both paths produce an identical ledger
+            var fee =
+              w.Principal.Payout?.Fee ?? feeCalculator.WithdrawFee(w.Principal.Record.Amount);
+            return CollectReserve(w, fee)
+              .ThenAwait(_ => withdrawalStorage.Save(receipt))
+              .ThenAwait(link =>
+                repo.Update(
+                    null,
+                    id,
+                    null,
+                    new WithdrawalStatus { Status = WithdrawStatus.Completed },
+                    new WithdrawalComplete
+                    {
+                      Note = note,
+                      Receipt = link,
+                      CompletedAt = DateTime.UtcNow,
+                      CompleterId = completerId,
+                    },
+                    new WithdrawalPayout
+                    {
+                      ConfirmationNumber = w.Principal.Payout?.ConfirmationNumber,
+                      Fee = fee,
+                      Attempt = w.Principal.Payout?.Attempt ?? 0,
+                    }
+                  )
+                  .NullToError(id.ToString())
+              );
+          })
+    );
+  }
+
+  public async Task<Result<WithdrawalPrincipal>> Approve(Guid id)
+  {
+    // Phase 1 (claim): Pending -> Processing with a fresh attempt number, in
+    // ONE transaction so two concurrent approves can never both claim the
+    // withdrawal. No money moves here; the reserve is collected only when the
+    // gateway confirms the payout via webhook.
+    var claim = await transactionManager.Start(
+      () =>
+        repo.Get(id, null)
+          .NullToError(id.ToString())
+          .DoAwait(DoType.MapErrors, w => GuardStatus(w, WithdrawalOperations.Approve))
+          .ThenAwait(w =>
+          {
+            var payout = new WithdrawalPayout
+            {
+              ConfirmationNumber = w.Principal.Payout?.ConfirmationNumber,
+              Fee = feeCalculator.WithdrawFee(w.Principal.Record.Amount),
+              Attempt = (w.Principal.Payout?.Attempt ?? 0) + 1,
+            };
+            return repo.Update(
+                null,
+                id,
+                null,
+                new WithdrawalStatus { Status = WithdrawStatus.Processing },
+                null,
+                payout
               )
+              .NullToError(id.ToString())
+              .Then(_ => (Withdrawal: w, Payout: payout), Errors.MapNone);
+          })
+    );
+    if (claim.IsFailure())
+      return claim.FailureOrDefault();
+
+    var (withdrawal, claimed) = claim.SuccessOrDefault();
+
+    // Phase 2: create the payout at the gateway, outside any DB transaction.
+    // The request id is unique per attempt, so the gateway's idempotency
+    // guarantees a retried attempt cannot create a second payout.
+    var created = await payoutGateway.CreatePayout(
+      new PayoutRequest
+      {
+        RequestId = $"{id}-{claimed.Attempt}",
+        Amount = withdrawal.Principal.Record.Amount - claimed.Fee,
+        PayNowNumber = withdrawal.Principal.Record.PayNowNumber,
+      }
+    );
+
+    if (created.IsFailure())
+    {
+      // Roll the claim back so the withdrawal can be retried (next attempt
+      // gets a fresh request id). The attempt counter stays incremented.
+      var release = await transactionManager.Start(
+        () =>
+          repo.Update(
+              null,
+              id,
+              null,
+              new WithdrawalStatus { Status = WithdrawStatus.Pending },
+              null,
+              null
+            )
+            .NullToError(id.ToString())
+      );
+      if (release.IsFailure())
+        return release.FailureOrDefault();
+      return created.FailureOrDefault();
+    }
+
+    // Phase 3: persist the confirmation number. If this write is lost (e.g.
+    // the pod dies), the webhook still resolves the withdrawal via the
+    // request id, so the payout is never orphaned.
+    return await transactionManager.Start(
+      () =>
+        repo.Update(
+            null,
+            id,
+            null,
+            null,
+            null,
+            claimed with
+            {
+              ConfirmationNumber = created.SuccessOrDefault().Id,
+            }
           )
-          .ThenAwait(_ => withdrawalStorage.Save(receipt))
-          .ThenAwait(link =>
+          .NullToError(id.ToString())
+    );
+  }
+
+  public Task<Result<WithdrawalPrincipal>> CompletePayout(Guid id, string confirmationNumber)
+  {
+    return transactionManager.Start(
+      () =>
+        repo.Get(id, null)
+          .NullToError(id.ToString())
+          .DoAwait(
+            DoType.MapErrors,
+            w => GuardStatus(w, WithdrawalOperations.Complete, WithdrawStatus.Processing)
+          )
+          .ThenAwait(w =>
+          {
+            var payout = w.Principal.Payout;
+            if (payout == null)
+              return Task.FromResult(
+                (Result<WithdrawalPrincipal>)
+                  new InvalidWithdrawalOperationException(
+                    "Payout completion requires an approved withdrawal with payout bookkeeping",
+                    w.Principal.Status.Status,
+                    WithdrawalOperations.Complete
+                  )
+              );
+            return CollectReserve(w, payout.Fee)
+              .ThenAwait(_ =>
+                repo.Update(
+                    null,
+                    id,
+                    null,
+                    new WithdrawalStatus { Status = WithdrawStatus.Completed },
+                    new WithdrawalComplete
+                    {
+                      Note =
+                        $"Automatically paid out via Airwallex transfer '{confirmationNumber}'",
+                      Receipt = null,
+                      CompletedAt = DateTime.UtcNow,
+                      CompleterId = null,
+                    },
+                    payout with
+                    {
+                      ConfirmationNumber = confirmationNumber,
+                    }
+                  )
+                  .NullToError(id.ToString())
+              );
+          })
+    );
+  }
+
+  public Task<Result<WithdrawalPrincipal>> FailPayout(Guid id, string reason)
+  {
+    // Status-only: the reserve was never collected, so returning to Pending
+    // makes the withdrawal eligible for another approve attempt (which will
+    // use a fresh gateway request id)
+    return transactionManager.Start(
+      () =>
+        repo.Get(id, null)
+          .NullToError(id.ToString())
+          .DoAwait(
+            DoType.MapErrors,
+            w => GuardStatus(w, WithdrawalOperations.PayoutFailed, WithdrawStatus.Processing)
+          )
+          .ThenAwait(_ =>
             repo.Update(
                 null,
                 id,
                 null,
-                new WithdrawalStatus { Status = WithdrawStatus.Completed },
-                new WithdrawalComplete
-                {
-                  Note = note,
-                  Receipt = link,
-                  CompletedAt = DateTime.UtcNow,
-                  CompleterId = completerId,
-                }
+                new WithdrawalStatus { Status = WithdrawStatus.Pending },
+                null,
+                null
               )
               .NullToError(id.ToString())
           )
@@ -180,5 +348,48 @@ public class WithdrawalService(
   public Task<Result<Unit?>> Delete(Guid id)
   {
     return repo.Delete(id);
+  }
+
+  // Collects the full reserved amount: net to BunnyBooker (paid out to the
+  // user) and fee to the withdrawal-fee account, as two ledger transactions
+  private Task<Result<Withdrawal>> CollectReserve(Withdrawal w, decimal fee)
+  {
+    return walletRepo
+      .Withdraw(w.Wallet.Id, w.Principal.Record.Amount)
+      .NullToError(w.Wallet.Id.ToString())
+      .ThenAwait(_ =>
+        transactionRepository.Create(
+          w.Wallet.Id,
+          generator.CompleteWithdrawalRequest(w.Principal.Record, fee)
+        )
+      )
+      .ThenAwait(_ =>
+        transactionRepository.Create(
+          w.Wallet.Id,
+          generator.WithdrawalFeeCharge(w.Principal.Record, fee)
+        )
+      )
+      .Then(_ => w, Errors.MapNone);
+  }
+
+  // Withdrawal state machine guard: the operation may only fire from the
+  // given statuses (defaults to Pending). Runs inside the surrounding
+  // RepeatableRead transaction so the read cannot go stale.
+  private static Task<Result<int>> GuardStatus(
+    Withdrawal w,
+    string operation,
+    params WithdrawStatus[] allowed
+  )
+  {
+    if (allowed.Length == 0)
+      allowed = [WithdrawStatus.Pending];
+    if (allowed.Contains(w.Principal.Status.Status))
+      return Task.FromResult((Result<int>)0);
+    var r = new InvalidWithdrawalOperationException(
+      $"{operation} requires the withdrawal to be in status(es): {string.Join(", ", allowed)}",
+      w.Principal.Status.Status,
+      operation
+    );
+    return Task.FromResult((Result<int>)r);
   }
 }

--- a/Domain/Withdrawal/Service.cs
+++ b/Domain/Withdrawal/Service.cs
@@ -319,7 +319,8 @@ public class WithdrawalService(
   public Task<Result<WithdrawalPrincipal>> CompletePayout(
     Guid id,
     string confirmationNumber,
-    int? attempt
+    int? attempt,
+    string? completerId = null
   )
   {
     return transactionManager.Start(
@@ -371,10 +372,12 @@ public class WithdrawalService(
                     new WithdrawalComplete
                     {
                       Note =
-                        $"Automatically paid out via Airwallex transfer '{confirmationNumber}'",
+                        completerId == null
+                          ? $"Automatically paid out via Airwallex transfer '{confirmationNumber}'"
+                          : $"Force-completed against Airwallex transfer '{confirmationNumber}' after webhook loss",
                       Receipt = null,
                       CompletedAt = DateTime.UtcNow,
-                      CompleterId = null,
+                      CompleterId = completerId,
                     },
                     payout with
                     {
@@ -392,7 +395,7 @@ public class WithdrawalService(
   // Airwallex dashboard, an admin finalizes it through the same idempotent
   // path the webhook would have taken (the transactional Processing guard
   // still prevents any race with a late webhook).
-  public Task<Result<WithdrawalPrincipal>> ForceCompletePayout(Guid id)
+  public Task<Result<WithdrawalPrincipal>> ForceCompletePayout(Guid id, string completerId)
   {
     return repo.Get(id, null)
       .NullToError(id.ToString())
@@ -411,7 +414,7 @@ public class WithdrawalService(
                 WithdrawalOperations.CompletePayout
               )
           );
-        return this.CompletePayout(id, payout.ConfirmationNumber, payout.Attempt);
+        return this.CompletePayout(id, payout.ConfirmationNumber, payout.Attempt, completerId);
       });
   }
 

--- a/Domain/Withdrawal/Service.cs
+++ b/Domain/Withdrawal/Service.cs
@@ -278,8 +278,9 @@ public class WithdrawalService(
     }
 
     // Phase 3: persist the confirmation number. If this write is lost (e.g.
-    // the pod dies), the webhook still resolves the withdrawal via the
-    // request id, so the payout is never orphaned.
+    // the pod dies), the webhook normally resolves the withdrawal via the
+    // request id; should the webhook ALSO be lost permanently, the admin
+    // force-complete endpoint is the escape hatch (see ForceCompletePayout).
     return await transactionManager.Start(
       () =>
         repo.Update(
@@ -368,6 +369,34 @@ public class WithdrawalService(
     );
   }
 
+  // Admin escape hatch for a confirmed Processing withdrawal whose settled
+  // webhook was permanently lost: after verifying the transfer on the
+  // Airwallex dashboard, an admin finalizes it through the same idempotent
+  // path the webhook would have taken (the transactional Processing guard
+  // still prevents any race with a late webhook).
+  public Task<Result<WithdrawalPrincipal>> ForceCompletePayout(Guid id)
+  {
+    return repo.Get(id, null)
+      .NullToError(id.ToString())
+      .ThenAwait(w =>
+      {
+        var payout = w.Principal.Payout;
+        if (
+          w.Principal.Status.Status != WithdrawStatus.Processing
+          || payout?.ConfirmationNumber == null
+        )
+          return Task.FromResult(
+            (Result<WithdrawalPrincipal>)
+              new InvalidWithdrawalOperationException(
+                "Force-completion requires a 'Processing' withdrawal with a confirmed transfer",
+                w.Principal.Status.Status,
+                WithdrawalOperations.CompletePayout
+              )
+          );
+        return this.CompletePayout(id, payout.ConfirmationNumber, payout.Attempt);
+      });
+  }
+
   public Task<Result<WithdrawalPrincipal>> FailPayout(Guid id, string reason, int? attempt)
   {
     // Status-only: the reserve was never collected, so returning to Pending
@@ -398,13 +427,17 @@ public class WithdrawalService(
                 $"failure event for attempt {attempt} of withdrawal '{id}', current attempt is {payout.Attempt}"
               );
 
+            // the confirmation number belongs to the transfer that just
+            // failed; clear it so later flows can never present a dead
+            // transfer as proof of payment (attempt and fee are kept — the
+            // attempt counter guarantees request-id uniqueness)
             return repo.Update(
                 null,
                 id,
                 null,
                 new WithdrawalStatus { Status = WithdrawStatus.Pending },
                 null,
-                null
+                payout == null ? null : payout with { ConfirmationNumber = null }
               )
               .NullToError(id.ToString());
           })

--- a/Domain/Withdrawal/Service.cs
+++ b/Domain/Withdrawal/Service.cs
@@ -185,21 +185,39 @@ public class WithdrawalService(
   {
     // Phase 1 (claim): Pending -> Processing with a fresh attempt number, in
     // ONE transaction so two concurrent approves can never both claim the
-    // withdrawal. No money moves here; the reserve is collected only when the
-    // gateway confirms the payout via webhook.
+    // withdrawal. A withdrawal already Processing WITHOUT a confirmation
+    // number may be re-driven: it keeps its attempt — and therefore its
+    // gateway request id — so the gateway's idempotency collapses the retry
+    // into the original transfer instead of paying twice. No money moves
+    // here; the reserve is collected only when the gateway confirms via
+    // webhook.
     var claim = await transactionManager.Start(
       () =>
         repo.Get(id, null)
           .NullToError(id.ToString())
-          .DoAwait(DoType.MapErrors, w => GuardStatus(w, WithdrawalOperations.Approve))
           .ThenAwait(w =>
           {
-            var payout = new WithdrawalPayout
+            var status = w.Principal.Status.Status;
+            var redrive =
+              status == WithdrawStatus.Processing
+              && w.Principal.Payout is { ConfirmationNumber: null };
+            if (status != WithdrawStatus.Pending && !redrive)
             {
-              ConfirmationNumber = w.Principal.Payout?.ConfirmationNumber,
-              Fee = feeCalculator.WithdrawFee(w.Principal.Record.Amount),
-              Attempt = (w.Principal.Payout?.Attempt ?? 0) + 1,
-            };
+              var r = new InvalidWithdrawalOperationException(
+                "Approve requires the withdrawal to be 'Pending', or 'Processing' without a confirmation number (re-drive)",
+                status,
+                WithdrawalOperations.Approve
+              );
+              return Task.FromResult((Result<(Withdrawal, WithdrawalPayout, bool)>)r);
+            }
+            var payout = redrive
+              ? w.Principal.Payout!
+              : new WithdrawalPayout
+              {
+                ConfirmationNumber = null,
+                Fee = feeCalculator.WithdrawFee(w.Principal.Record.Amount),
+                Attempt = (w.Principal.Payout?.Attempt ?? 0) + 1,
+              };
             return repo.Update(
                 null,
                 id,
@@ -209,17 +227,17 @@ public class WithdrawalService(
                 payout
               )
               .NullToError(id.ToString())
-              .Then(_ => (Withdrawal: w, Payout: payout), Errors.MapNone);
+              .Then(_ => (w, payout, redrive), Errors.MapNone);
           })
     );
     if (claim.IsFailure())
       return claim.FailureOrDefault();
 
-    var (withdrawal, claimed) = claim.SuccessOrDefault();
+    var (withdrawal, claimed, redrive) = claim.SuccessOrDefault();
 
     // Phase 2: create the payout at the gateway, outside any DB transaction.
-    // The request id is unique per attempt, so the gateway's idempotency
-    // guarantees a retried attempt cannot create a second payout.
+    // The request id is deterministic per attempt, so a re-send of the same
+    // attempt can never create a second payout.
     var created = await payoutGateway.CreatePayout(
       new PayoutRequest
       {
@@ -231,23 +249,32 @@ public class WithdrawalService(
 
     if (created.IsFailure())
     {
-      // Roll the claim back so the withdrawal can be retried (next attempt
-      // gets a fresh request id). The attempt counter stays incremented.
-      var release = await transactionManager.Start(
-        () =>
-          repo.Update(
-              null,
-              id,
-              null,
-              new WithdrawalStatus { Status = WithdrawStatus.Pending },
-              null,
-              null
-            )
-            .NullToError(id.ToString())
-      );
-      if (release.IsFailure())
-        return release.FailureOrDefault();
-      return created.FailureOrDefault();
+      var failure = created.FailureOrDefault();
+      // Only a definitive gateway rejection of a FIRST send proves no
+      // transfer exists — that alone may return the withdrawal to Pending
+      // (whose next approve mints a fresh attempt). Everything else is
+      // ambiguous — timeout, 5xx, or any failure of a re-send (a 4xx there
+      // may just be the gateway deduplicating the original request id) — so
+      // the withdrawal stays Processing and is re-driven later with the SAME
+      // request id, or resolved by the original transfer's webhook.
+      if (!redrive && failure is PayoutRejectedException)
+      {
+        var release = await transactionManager.Start(
+          () =>
+            repo.Update(
+                null,
+                id,
+                null,
+                new WithdrawalStatus { Status = WithdrawStatus.Pending },
+                null,
+                null
+              )
+              .NullToError(id.ToString())
+        );
+        if (release.IsFailure())
+          return release.FailureOrDefault();
+      }
+      return failure;
     }
 
     // Phase 3: persist the confirmation number. If this write is lost (e.g.
@@ -270,28 +297,51 @@ public class WithdrawalService(
     );
   }
 
-  public Task<Result<WithdrawalPrincipal>> CompletePayout(Guid id, string confirmationNumber)
+  public Task<Result<WithdrawalPrincipal>> CompletePayout(
+    Guid id,
+    string confirmationNumber,
+    int? attempt
+  )
   {
     return transactionManager.Start(
       () =>
         repo.Get(id, null)
           .NullToError(id.ToString())
-          .DoAwait(
-            DoType.MapErrors,
-            w => GuardStatus(w, WithdrawalOperations.Complete, WithdrawStatus.Processing)
-          )
           .ThenAwait(w =>
           {
             var payout = w.Principal.Payout;
+            var status = w.Principal.Status.Status;
+
+            // idempotent redelivery: this exact transfer already completed
+            // the withdrawal, acknowledge without moving money again
+            if (
+              status == WithdrawStatus.Completed
+              && payout?.ConfirmationNumber == confirmationNumber
+            )
+              return Task.FromResult((Result<WithdrawalPrincipal>)w.Principal);
+
+            if (status != WithdrawStatus.Processing)
+              return Stale(
+                $"settled event for transfer '{confirmationNumber}' but withdrawal '{id}' is '{status}'"
+              );
+
             if (payout == null)
               return Task.FromResult(
                 (Result<WithdrawalPrincipal>)
                   new InvalidWithdrawalOperationException(
                     "Payout completion requires an approved withdrawal with payout bookkeeping",
-                    w.Principal.Status.Status,
-                    WithdrawalOperations.Complete
+                    status,
+                    WithdrawalOperations.CompletePayout
                   )
               );
+
+            // an event for a superseded attempt must never settle the current
+            // one — its transfer is not the money that is in flight now
+            if (attempt != null && attempt != payout.Attempt)
+              return Stale(
+                $"settled event for attempt {attempt} of withdrawal '{id}', current attempt is {payout.Attempt}"
+              );
+
             return CollectReserve(w, payout.Fee)
               .ThenAwait(_ =>
                 repo.Update(
@@ -318,21 +368,37 @@ public class WithdrawalService(
     );
   }
 
-  public Task<Result<WithdrawalPrincipal>> FailPayout(Guid id, string reason)
+  public Task<Result<WithdrawalPrincipal>> FailPayout(Guid id, string reason, int? attempt)
   {
     // Status-only: the reserve was never collected, so returning to Pending
-    // makes the withdrawal eligible for another approve attempt (which will
-    // use a fresh gateway request id)
+    // makes the withdrawal eligible for another approve attempt (which mints
+    // a fresh gateway request id — safe, because the gateway reported this
+    // attempt's transfer as terminally failed)
     return transactionManager.Start(
       () =>
         repo.Get(id, null)
           .NullToError(id.ToString())
-          .DoAwait(
-            DoType.MapErrors,
-            w => GuardStatus(w, WithdrawalOperations.PayoutFailed, WithdrawStatus.Processing)
-          )
-          .ThenAwait(_ =>
-            repo.Update(
+          .ThenAwait(w =>
+          {
+            var status = w.Principal.Status.Status;
+            var payout = w.Principal.Payout;
+
+            // idempotent redelivery: an earlier failure event already
+            // returned it to Pending
+            if (status == WithdrawStatus.Pending)
+              return Task.FromResult((Result<WithdrawalPrincipal>)w.Principal);
+
+            if (status != WithdrawStatus.Processing)
+              return Stale($"failure event for withdrawal '{id}' in '{status}': {reason}");
+
+            // a failure event for a superseded attempt must not release the
+            // claim of the attempt currently in flight
+            if (payout != null && attempt != null && attempt != payout.Attempt)
+              return Stale(
+                $"failure event for attempt {attempt} of withdrawal '{id}', current attempt is {payout.Attempt}"
+              );
+
+            return repo.Update(
                 null,
                 id,
                 null,
@@ -340,10 +406,13 @@ public class WithdrawalService(
                 null,
                 null
               )
-              .NullToError(id.ToString())
-          )
+              .NullToError(id.ToString());
+          })
     );
   }
+
+  private static Task<Result<WithdrawalPrincipal>> Stale(string message) =>
+    Task.FromResult((Result<WithdrawalPrincipal>)new StalePayoutEventException(message));
 
   public Task<Result<Unit?>> Delete(Guid id)
   {

--- a/Domain/Withdrawal/Service.cs
+++ b/Domain/Withdrawal/Service.cs
@@ -277,24 +277,42 @@ public class WithdrawalService(
       return failure;
     }
 
-    // Phase 3: persist the confirmation number. If this write is lost (e.g.
-    // the pod dies), the webhook normally resolves the withdrawal via the
-    // request id; should the webhook ALSO be lost permanently, the admin
-    // force-complete endpoint is the escape hatch (see ForceCompletePayout).
+    // Phase 3: persist the confirmation number — conditionally. The claim may
+    // have been legitimately released or superseded while the gateway call
+    // was in flight (e.g. a fast transfer.failed webhook already returned the
+    // withdrawal to Pending, or a re-approve minted a newer attempt); writing
+    // the stale phase-1 snapshot over that state would resurrect a dead
+    // confirmation or strand the live attempt. If the write is skipped or
+    // lost (e.g. the pod dies), the webhook normally resolves the withdrawal
+    // via the request id; should the webhook ALSO be lost permanently, the
+    // admin force-complete endpoint is the escape hatch (ForceCompletePayout).
     return await transactionManager.Start(
       () =>
-        repo.Update(
-            null,
-            id,
-            null,
-            null,
-            null,
-            claimed with
-            {
-              ConfirmationNumber = created.SuccessOrDefault().Id,
-            }
-          )
+        repo.Get(id, null)
           .NullToError(id.ToString())
+          .ThenAwait(w =>
+          {
+            var payout = w.Principal.Payout;
+            if (
+              w.Principal.Status.Status != WithdrawStatus.Processing
+              || payout == null
+              || payout.Attempt != claimed.Attempt
+              || payout.ConfirmationNumber != null
+            )
+              return Task.FromResult((Result<WithdrawalPrincipal>)w.Principal);
+            return repo.Update(
+                null,
+                id,
+                null,
+                null,
+                null,
+                payout with
+                {
+                  ConfirmationNumber = created.SuccessOrDefault().Id,
+                }
+              )
+              .NullToError(id.ToString());
+          })
     );
   }
 

--- a/Domain/Withdrawal/WithdrawalOperations.cs
+++ b/Domain/Withdrawal/WithdrawalOperations.cs
@@ -1,0 +1,14 @@
+namespace Domain.Withdrawal;
+
+public static class WithdrawalOperations
+{
+  public const string Cancel = "Cancel";
+
+  public const string Reject = "Reject";
+
+  public const string Complete = "Complete";
+
+  public const string Approve = "Approve";
+
+  public const string PayoutFailed = "PayoutFailed";
+}

--- a/Domain/Withdrawal/WithdrawalOperations.cs
+++ b/Domain/Withdrawal/WithdrawalOperations.cs
@@ -11,6 +11,4 @@ public static class WithdrawalOperations
   public const string Approve = "Approve";
 
   public const string CompletePayout = "CompletePayout";
-
-  public const string PayoutFailed = "PayoutFailed";
 }

--- a/Domain/Withdrawal/WithdrawalOperations.cs
+++ b/Domain/Withdrawal/WithdrawalOperations.cs
@@ -10,5 +10,7 @@ public static class WithdrawalOperations
 
   public const string Approve = "Approve";
 
+  public const string CompletePayout = "CompletePayout";
+
   public const string PayoutFailed = "PayoutFailed";
 }

--- a/UnitTest/Bookings/BookingServiceCompleteNoCollectTests.cs
+++ b/UnitTest/Bookings/BookingServiceCompleteNoCollectTests.cs
@@ -102,7 +102,7 @@ public class BookingServiceCompleteNoCollectTests
     var repo = new FakeBookingRepository(booking);
 
     var result = await MakeService(repo)
-      .CompleteNoCollect(booking.Principal.Id, "BN-1", "TN-1", new MemoryStream(new byte[] { 1, 2, 3 }));
+      .CompleteNoCollect(booking.Principal.Id, "BN-1", "TN-1", new MemoryStream([1, 2, 3]));
 
     // reaching success at all proves no money path ran (null wallet/transaction repos)
     result.IsSuccess().Should().BeTrue("an admin may finalise a RequireManualIntervention booking without collecting");
@@ -127,7 +127,7 @@ public class BookingServiceCompleteNoCollectTests
     var repo = new FakeBookingRepository(booking);
 
     var result = await MakeService(repo)
-      .CompleteNoCollect(booking.Principal.Id, "BN-1", "TN-1", new MemoryStream(new byte[] { 1 }));
+      .CompleteNoCollect(booking.Principal.Id, "BN-1", "TN-1", new MemoryStream([1]));
 
     result.IsSuccess().Should().BeFalse($"a '{status}' booking is not in the manual-intervention parking state");
     result.FailureOrDefault().Should().BeOfType<InvalidBookingOperationException>();

--- a/UnitTest/Bookings/BookingServiceRevertGuardTests.cs
+++ b/UnitTest/Bookings/BookingServiceRevertGuardTests.cs
@@ -35,7 +35,11 @@ public class BookingServiceRevertGuardTests
       null!
     );
 
-  private static Booking BookingWith(BookStatus status, string? bookingNumber)
+  private static Booking BookingWith(
+    BookStatus status,
+    string? bookingNumber,
+    DateTime? lastBuyingAt = null
+  )
   {
     var id = Guid.NewGuid();
     return new Booking
@@ -58,7 +62,12 @@ public class BookingServiceRevertGuardTests
             PassportNumber = "P1234567",
           },
         },
-        Status = new BookingStatus { Status = status, CompletedAt = null },
+        Status = new BookingStatus
+        {
+          Status = status,
+          CompletedAt = null,
+          LastBuyingAt = lastBuyingAt,
+        },
         Complete = new BookingComplete
         {
           Ticket = bookingNumber == null ? null : "ticket-file",
@@ -105,7 +114,7 @@ public class BookingServiceRevertGuardTests
     var booking = BookingWith(BookStatus.Buying, bookingNumber: null);
     var repo = new FakeBookingRepository(booking);
 
-    var result = await MakeService(repo).Revert(booking.Principal.Id);
+    var result = await MakeService(repo).Revert(booking.Principal.Id, force: true);
 
     result.IsSuccess().Should().BeTrue("an uncaptured 'Buying' booking may be reverted to 'Pending'");
     repo.UpdateCalls.Should().Be(1);
@@ -118,7 +127,7 @@ public class BookingServiceRevertGuardTests
     var booking = BookingWith(BookStatus.RequireManualIntervention, bookingNumber: null);
     var repo = new FakeBookingRepository(booking);
 
-    var result = await MakeService(repo).Revert(booking.Principal.Id);
+    var result = await MakeService(repo).Revert(booking.Principal.Id, force: true);
 
     result.IsSuccess().Should().BeTrue("an uncaptured 'RequireManualIntervention' booking may be reverted to 'Pending'");
     repo.UpdateCalls.Should().Be(1);
@@ -142,7 +151,7 @@ public class BookingServiceRevertGuardTests
     var booking = BookingWith(status, bookingNumber);
     var repo = new FakeBookingRepository(booking);
 
-    var result = await MakeService(repo).Revert(booking.Principal.Id);
+    var result = await MakeService(repo).Revert(booking.Principal.Id, force: true);
 
     result.IsSuccess().Should().BeFalse($"a '{status}' booking must not be reverted to 'Pending'");
     result.FailureOrDefault().Should().BeOfType<InvalidBookingOperationException>();
@@ -158,7 +167,7 @@ public class BookingServiceRevertGuardTests
     var booking = BookingWith(BookStatus.RequireManualIntervention, bookingNumber: "BN-777");
     var repo = new FakeBookingRepository(booking);
 
-    var result = await MakeService(repo).Revert(booking.Principal.Id);
+    var result = await MakeService(repo).Revert(booking.Principal.Id, force: true);
 
     result.IsSuccess().Should().BeFalse();
     result.FailureOrDefault().Should().BeOfType<InvalidBookingOperationException>();
@@ -174,7 +183,100 @@ public class BookingServiceRevertGuardTests
     var booking = BookingWith(BookStatus.Buying, bookingNumber: "BN-999");
     var repo = new FakeBookingRepository(booking);
 
-    var result = await MakeService(repo).Revert(booking.Principal.Id);
+    var result = await MakeService(repo).Revert(booking.Principal.Id, force: true);
+
+    result.IsSuccess().Should().BeFalse();
+    result.FailureOrDefault().Should().BeOfType<InvalidBookingOperationException>();
+    repo.UpdateCalls.Should().Be(0);
+  }
+
+  // Non-force reverts are what the automated reverter cron issues: they must
+  // additionally prove the booking is genuinely stuck (in Buying for more than
+  // the 5-minute threshold) so the cron can never race a live purchase.
+
+  [Fact]
+  public async Task NonForce_revert_of_stale_uncaptured_buying_transitions_to_pending()
+  {
+    var booking = BookingWith(
+      BookStatus.Buying,
+      bookingNumber: null,
+      lastBuyingAt: DateTime.UtcNow.AddMinutes(-10)
+    );
+    var repo = new FakeBookingRepository(booking);
+
+    var result = await MakeService(repo).Revert(booking.Principal.Id, force: false);
+
+    result.IsSuccess().Should().BeTrue("a booking stuck in 'Buying' for over 5 minutes may be reverted");
+    repo.UpdateCalls.Should().Be(1);
+    repo.LastStatusWritten!.Status.Should().Be(BookStatus.Pending);
+  }
+
+  [Fact]
+  public async Task NonForce_revert_of_fresh_buying_is_rejected()
+  {
+    // 1 minute into Buying: the buyer may still be mid-purchase — exactly the
+    // race that corrupted bookings under the old unguarded reverter
+    var booking = BookingWith(
+      BookStatus.Buying,
+      bookingNumber: null,
+      lastBuyingAt: DateTime.UtcNow.AddMinutes(-1)
+    );
+    var repo = new FakeBookingRepository(booking);
+
+    var result = await MakeService(repo).Revert(booking.Principal.Id, force: false);
+
+    result.IsSuccess().Should().BeFalse();
+    result.FailureOrDefault().Should().BeOfType<InvalidBookingOperationException>();
+    repo.UpdateCalls.Should().Be(0);
+  }
+
+  [Fact]
+  public async Task NonForce_revert_without_buying_timestamp_is_rejected()
+  {
+    // Rows predating the LastBuyingAt column have no stamp; the cron must not
+    // guess their age
+    var booking = BookingWith(BookStatus.Buying, bookingNumber: null, lastBuyingAt: null);
+    var repo = new FakeBookingRepository(booking);
+
+    var result = await MakeService(repo).Revert(booking.Principal.Id, force: false);
+
+    result.IsSuccess().Should().BeFalse();
+    result.FailureOrDefault().Should().BeOfType<InvalidBookingOperationException>();
+    repo.UpdateCalls.Should().Be(0);
+  }
+
+  [Fact]
+  public async Task NonForce_revert_of_manual_intervention_is_rejected()
+  {
+    // RequireManualIntervention is a human-judgement state; only a forced
+    // (admin) revert may re-expose it
+    var booking = BookingWith(
+      BookStatus.RequireManualIntervention,
+      bookingNumber: null,
+      lastBuyingAt: DateTime.UtcNow.AddMinutes(-30)
+    );
+    var repo = new FakeBookingRepository(booking);
+
+    var result = await MakeService(repo).Revert(booking.Principal.Id, force: false);
+
+    result.IsSuccess().Should().BeFalse();
+    result.FailureOrDefault().Should().BeOfType<InvalidBookingOperationException>();
+    repo.UpdateCalls.Should().Be(0);
+  }
+
+  [Fact]
+  public async Task NonForce_revert_of_stale_captured_buying_is_rejected()
+  {
+    // Stuck AND captured: the ticket exists on KITS, so re-buying would
+    // double-charge — recovery must handle it instead
+    var booking = BookingWith(
+      BookStatus.Buying,
+      bookingNumber: "BN-555",
+      lastBuyingAt: DateTime.UtcNow.AddMinutes(-30)
+    );
+    var repo = new FakeBookingRepository(booking);
+
+    var result = await MakeService(repo).Revert(booking.Principal.Id, force: false);
 
     result.IsSuccess().Should().BeFalse();
     result.FailureOrDefault().Should().BeOfType<InvalidBookingOperationException>();
@@ -186,7 +288,7 @@ public class BookingServiceRevertGuardTests
   {
     var repo = new FakeBookingRepository(null);
 
-    var result = await MakeService(repo).Revert(Guid.NewGuid());
+    var result = await MakeService(repo).Revert(Guid.NewGuid(), force: true);
 
     result.IsSuccess().Should().BeFalse();
     repo.UpdateCalls.Should().Be(0);

--- a/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
@@ -319,6 +319,74 @@ public class WithdrawalServiceGuardTests
     repo.StatusWrites.Should().BeEmpty();
   }
 
+  [Fact]
+  public async Task FailPayout_clears_the_dead_transfers_confirmation_number()
+  {
+    // a failed transfer's id must never survive as "proof of payment" for a
+    // later manual completion
+    var w = WithdrawalWith(
+      WithdrawStatus.Processing,
+      new WithdrawalPayout { ConfirmationNumber = "transfer-dead", Fee = Fee, Attempt = 1 }
+    );
+    var (service, repo, _, _, _) = Make(w);
+
+    var result = await service.FailPayout(w.Principal.Id, "transfer failed", 1);
+
+    result.IsSuccess().Should().BeTrue();
+    repo.LastPayoutWritten!.ConfirmationNumber.Should().BeNull();
+    repo.LastPayoutWritten.Attempt.Should().Be(1, "the attempt counter must survive for uniqueness");
+  }
+
+  // ---- ForceCompletePayout (admin escape hatch) ----
+
+  [Fact]
+  public async Task ForceComplete_finalizes_a_confirmed_processing_withdrawal()
+  {
+    var w = WithdrawalWith(
+      WithdrawStatus.Processing,
+      new WithdrawalPayout { ConfirmationNumber = "transfer-9", Fee = Fee, Attempt = 1 }
+    );
+    var (service, repo, wallet, txn, _) = Make(w);
+
+    var result = await service.ForceCompletePayout(w.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    wallet.LastWithdrawAmount.Should().Be(Amount);
+    txn.Records.Should().HaveCount(2);
+    repo.StatusWrites.Should().ContainSingle(s => s.Status == WithdrawStatus.Completed);
+  }
+
+  [Fact]
+  public async Task ForceComplete_of_unconfirmed_processing_is_rejected()
+  {
+    // without a confirmation number there is no verified transfer to settle
+    // against — the re-drive path handles these instead
+    var w = WithdrawalWith(
+      WithdrawStatus.Processing,
+      new WithdrawalPayout { ConfirmationNumber = null, Fee = Fee, Attempt = 1 }
+    );
+    var (service, _, wallet, txn, _) = Make(w);
+
+    var result = await service.ForceCompletePayout(w.Principal.Id);
+
+    result.IsSuccess().Should().BeFalse();
+    result.FailureOrDefault().Should().BeOfType<InvalidWithdrawalOperationException>();
+    wallet.WithdrawCalls.Should().Be(0);
+    txn.Records.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task ForceComplete_of_pending_is_rejected()
+  {
+    var w = WithdrawalWith(WithdrawStatus.Pending);
+    var (service, _, wallet, _, _) = Make(w);
+
+    var result = await service.ForceCompletePayout(w.Principal.Id);
+
+    result.IsSuccess().Should().BeFalse();
+    wallet.WithdrawCalls.Should().Be(0);
+  }
+
   // ---- Webhook idempotency and attempt fencing ----
 
   [Fact]

--- a/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
@@ -18,18 +18,25 @@ public class WithdrawalServiceGuardTests
   private const decimal Amount = 100m;
   private const decimal Fee = 4m;
 
+  private enum GatewayMode
+  {
+    Succeeds,
+    RejectsDefinitively,
+    FailsAmbiguously,
+  }
+
   private static (
     WithdrawalService Service,
     FakeWithdrawalRepository Repo,
     FakeWalletRepository Wallet,
     FakeTransactionRepository Txn,
     FakePayoutGateway Gateway
-  ) Make(Withdrawal? withdrawal, bool gatewayFails = false)
+  ) Make(Withdrawal? withdrawal, GatewayMode mode = GatewayMode.Succeeds)
   {
     var repo = new FakeWithdrawalRepository(withdrawal);
     var wallet = new FakeWalletRepository();
     var txn = new FakeTransactionRepository();
-    var gateway = new FakePayoutGateway(gatewayFails);
+    var gateway = new FakePayoutGateway(mode);
     var service = new WithdrawalService(
       repo,
       wallet,
@@ -120,10 +127,10 @@ public class WithdrawalServiceGuardTests
   }
 
   [Fact]
-  public async Task Approve_releases_claim_when_gateway_fails()
+  public async Task Approve_releases_claim_only_on_definitive_gateway_rejection()
   {
     var w = WithdrawalWith(WithdrawStatus.Pending);
-    var (service, repo, wallet, _, gateway) = Make(w, gatewayFails: true);
+    var (service, repo, wallet, _, gateway) = Make(w, GatewayMode.RejectsDefinitively);
 
     var result = await service.Approve(w.Principal.Id);
 
@@ -136,7 +143,82 @@ public class WithdrawalServiceGuardTests
   }
 
   [Fact]
-  public async Task Approve_retry_after_failure_uses_a_fresh_request_id()
+  public async Task Approve_keeps_claim_on_ambiguous_gateway_failure()
+  {
+    // A timeout/5xx does not prove the transfer was not created: releasing
+    // the claim here would let a retry mint a fresh request id and pay twice
+    var w = WithdrawalWith(WithdrawStatus.Pending);
+    var (service, repo, wallet, _, gateway) = Make(w, GatewayMode.FailsAmbiguously);
+
+    var result = await service.Approve(w.Principal.Id);
+
+    result.IsSuccess().Should().BeFalse();
+    gateway.Requests.Should().ContainSingle();
+    repo.StatusWrites.Select(s => s.Status)
+      .Should()
+      .Equal([WithdrawStatus.Processing], "the withdrawal must stay claimed in Processing");
+    wallet.WithdrawCalls.Should().Be(0);
+  }
+
+  [Fact]
+  public async Task Approve_redrives_processing_without_confirmation_reusing_the_request_id()
+  {
+    // After an ambiguous failure the withdrawal sits in Processing with no
+    // confirmation number; a re-drive must reuse the SAME request id so the
+    // gateway's idempotency collapses it into the original transfer
+    var w = WithdrawalWith(
+      WithdrawStatus.Processing,
+      new WithdrawalPayout { ConfirmationNumber = null, Fee = Fee, Attempt = 1 }
+    );
+    var (service, repo, _, _, gateway) = Make(w);
+
+    var result = await service.Approve(w.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    gateway.Requests[0].RequestId.Should().Be($"{w.Principal.Id}-1", "the attempt is reused");
+    repo.LastPayoutWritten!.Attempt.Should().Be(1);
+    repo.LastPayoutWritten.ConfirmationNumber.Should().Be("transfer-1");
+  }
+
+  [Fact]
+  public async Task Approve_redrive_failure_never_releases_the_claim()
+  {
+    // On a re-drive even a definitive-looking 4xx may just be the gateway
+    // deduplicating the original request id — the claim must survive
+    var w = WithdrawalWith(
+      WithdrawStatus.Processing,
+      new WithdrawalPayout { ConfirmationNumber = null, Fee = Fee, Attempt = 1 }
+    );
+    var (service, repo, _, _, _) = Make(w, GatewayMode.RejectsDefinitively);
+
+    var result = await service.Approve(w.Principal.Id);
+
+    result.IsSuccess().Should().BeFalse();
+    repo.StatusWrites.Select(s => s.Status)
+      .Should()
+      .Equal([WithdrawStatus.Processing], "no rollback to Pending on a re-drive");
+  }
+
+  [Fact]
+  public async Task Approve_of_processing_with_confirmation_is_rejected()
+  {
+    // A confirmed transfer is in flight; approving again is meaningless and
+    // must not touch the gateway
+    var w = WithdrawalWith(
+      WithdrawStatus.Processing,
+      new WithdrawalPayout { ConfirmationNumber = "transfer-1", Fee = Fee, Attempt = 1 }
+    );
+    var (service, _, _, _, gateway) = Make(w);
+
+    var result = await service.Approve(w.Principal.Id);
+
+    result.IsSuccess().Should().BeFalse();
+    result.FailureOrDefault().Should().BeOfType<InvalidWithdrawalOperationException>();
+    gateway.Requests.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task Approve_retry_after_definitive_rejection_uses_a_fresh_request_id()
   {
     var w = WithdrawalWith(
       WithdrawStatus.Pending,
@@ -149,7 +231,7 @@ public class WithdrawalServiceGuardTests
     result.IsSuccess().Should().BeTrue();
     gateway.Requests[0].RequestId
       .Should()
-      .Be($"{w.Principal.Id}-2", "each attempt must be unique at the gateway");
+      .Be($"{w.Principal.Id}-2", "a rejected attempt's request id is burned");
   }
 
   // ---- CompletePayout (webhook success) ----
@@ -163,7 +245,7 @@ public class WithdrawalServiceGuardTests
     );
     var (service, repo, wallet, txn, _) = Make(w);
 
-    var result = await service.CompletePayout(w.Principal.Id, "transfer-9");
+    var result = await service.CompletePayout(w.Principal.Id, "transfer-9", 1);
 
     result.IsSuccess().Should().BeTrue();
     wallet.WithdrawCalls.Should().Be(1);
@@ -185,13 +267,15 @@ public class WithdrawalServiceGuardTests
   [InlineData(WithdrawStatus.Cancel)]
   public async Task CompletePayout_from_disallowed_status_moves_no_money(WithdrawStatus status)
   {
+    // stored confirmation differs from the event's transfer, so even the
+    // Completed case is NOT the idempotent-redelivery path (covered below)
     var w = WithdrawalWith(
       status,
-      new WithdrawalPayout { ConfirmationNumber = "transfer-9", Fee = Fee, Attempt = 1 }
+      new WithdrawalPayout { ConfirmationNumber = "transfer-orig", Fee = Fee, Attempt = 1 }
     );
     var (service, _, wallet, txn, _) = Make(w);
 
-    var result = await service.CompletePayout(w.Principal.Id, "transfer-9");
+    var result = await service.CompletePayout(w.Principal.Id, "transfer-9", 1);
 
     result.IsSuccess().Should().BeFalse(
       $"a '{status}' withdrawal must not be completed by the webhook (double-collect protection)"
@@ -211,7 +295,7 @@ public class WithdrawalServiceGuardTests
     );
     var (service, repo, wallet, txn, _) = Make(w);
 
-    var result = await service.FailPayout(w.Principal.Id, "transfer failed");
+    var result = await service.FailPayout(w.Principal.Id, "transfer failed", 1);
 
     result.IsSuccess().Should().BeTrue();
     repo.StatusWrites.Should().ContainSingle(s => s.Status == WithdrawStatus.Pending);
@@ -229,9 +313,78 @@ public class WithdrawalServiceGuardTests
     );
     var (service, repo, _, _, _) = Make(w);
 
-    var result = await service.FailPayout(w.Principal.Id, "late failure event");
+    var result = await service.FailPayout(w.Principal.Id, "late failure event", 1);
 
     result.IsSuccess().Should().BeFalse("a settled withdrawal must never be reopened");
+    repo.StatusWrites.Should().BeEmpty();
+  }
+
+  // ---- Webhook idempotency and attempt fencing ----
+
+  [Fact]
+  public async Task CompletePayout_redelivered_settled_event_acks_without_moving_money()
+  {
+    var w = WithdrawalWith(
+      WithdrawStatus.Completed,
+      new WithdrawalPayout { ConfirmationNumber = "transfer-9", Fee = Fee, Attempt = 1 }
+    );
+    var (service, repo, wallet, txn, _) = Make(w);
+
+    var result = await service.CompletePayout(w.Principal.Id, "transfer-9", 1);
+
+    result.IsSuccess().Should().BeTrue("gateways redeliver webhooks at least once");
+    wallet.WithdrawCalls.Should().Be(0);
+    txn.Records.Should().BeEmpty();
+    repo.StatusWrites.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task CompletePayout_for_superseded_attempt_is_stale_and_moves_no_money()
+  {
+    var w = WithdrawalWith(
+      WithdrawStatus.Processing,
+      new WithdrawalPayout { ConfirmationNumber = null, Fee = Fee, Attempt = 2 }
+    );
+    var (service, _, wallet, txn, _) = Make(w);
+
+    var result = await service.CompletePayout(w.Principal.Id, "transfer-old", 1);
+
+    result.IsSuccess().Should().BeFalse();
+    result.FailureOrDefault().Should().BeOfType<StalePayoutEventException>();
+    wallet.WithdrawCalls.Should().Be(0);
+    txn.Records.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task FailPayout_redelivered_failure_event_acks_idempotently()
+  {
+    var w = WithdrawalWith(
+      WithdrawStatus.Pending,
+      new WithdrawalPayout { ConfirmationNumber = null, Fee = Fee, Attempt = 1 }
+    );
+    var (service, repo, _, _, _) = Make(w);
+
+    var result = await service.FailPayout(w.Principal.Id, "redelivered failure", 1);
+
+    result.IsSuccess().Should().BeTrue();
+    repo.StatusWrites.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task FailPayout_for_superseded_attempt_never_releases_the_live_claim()
+  {
+    // a late failure event for attempt 1 must not knock attempt 2's live
+    // claim back to Pending — that reopens the double-payout window
+    var w = WithdrawalWith(
+      WithdrawStatus.Processing,
+      new WithdrawalPayout { ConfirmationNumber = "transfer-2", Fee = Fee, Attempt = 2 }
+    );
+    var (service, repo, _, _, _) = Make(w);
+
+    var result = await service.FailPayout(w.Principal.Id, "late failure for attempt 1", 1);
+
+    result.IsSuccess().Should().BeFalse();
+    result.FailureOrDefault().Should().BeOfType<StalePayoutEventException>();
     repo.StatusWrites.Should().BeEmpty();
   }
 
@@ -346,19 +499,20 @@ public class WithdrawalServiceGuardTests
     public Task<Result<string>> Get(string key) => Task.FromResult((Result<string>)"url");
   }
 
-  private sealed class FakePayoutGateway(bool fails) : IPayoutGateway
+  private sealed class FakePayoutGateway(GatewayMode mode) : IPayoutGateway
   {
     public List<PayoutRequest> Requests { get; } = [];
 
     public Task<Result<PayoutConfirmation>> CreatePayout(PayoutRequest request)
     {
       Requests.Add(request);
-      if (fails)
-        return Task.FromResult(
-          (Result<PayoutConfirmation>)new InvalidOperationException("gateway down")
-        );
-      return Task.FromResult(
-        (Result<PayoutConfirmation>)new PayoutConfirmation { Id = "transfer-1" }
+      return Task.FromResult<Result<PayoutConfirmation>>(
+        mode switch
+        {
+          GatewayMode.RejectsDefinitively => new PayoutRejectedException("invalid beneficiary"),
+          GatewayMode.FailsAmbiguously => new HttpRequestException("gateway timeout"),
+          _ => new PayoutConfirmation { Id = "transfer-1" },
+        }
       );
     }
   }

--- a/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
@@ -234,6 +234,28 @@ public class WithdrawalServiceGuardTests
       .Be($"{w.Principal.Id}-2", "a rejected attempt's request id is burned");
   }
 
+  [Fact]
+  public async Task Approve_phase3_never_clobbers_a_concurrent_transition()
+  {
+    // While the gateway call is in flight, a fast transfer.failed webhook
+    // returns the withdrawal to Pending and clears the dead confirmation.
+    // Phase 3 must NOT resurrect it by writing its stale snapshot.
+    var w = WithdrawalWith(WithdrawStatus.Pending);
+    var (service, repo, _, _, _) = Make(w);
+    repo.AfterFirstUpdate = r =>
+      r.MutateState(
+        WithdrawStatus.Pending,
+        new WithdrawalPayout { ConfirmationNumber = null, Fee = Fee, Attempt = 1 }
+      );
+
+    var result = await service.Approve(w.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue("the withdrawal simply moved on; nothing to report");
+    repo.LastPayoutWritten!.ConfirmationNumber
+      .Should()
+      .BeNull("the stale snapshot must not overwrite the concurrent transition");
+  }
+
   // ---- CompletePayout (webhook success) ----
 
   [Fact]
@@ -588,16 +610,29 @@ public class WithdrawalServiceGuardTests
   private sealed class FakeWithdrawalRepository(Withdrawal? withdrawal) : IWithdrawalRepository
   {
     private WithdrawStatus? current;
+    private WithdrawalPayout? currentPayout = withdrawal?.Principal.Payout;
+    private bool payoutTouched;
 
     public List<WithdrawalStatus> StatusWrites { get; } = [];
     public WithdrawalPayout? LastPayoutWritten { get; private set; }
     public WithdrawalComplete? LastCompleteWritten { get; private set; }
 
+    // simulates a concurrent, committed transition (e.g. a webhook) landing
+    // between the caller's transactions
+    public Action<FakeWithdrawalRepository>? AfterFirstUpdate { get; set; }
+
+    public void MutateState(WithdrawStatus status, WithdrawalPayout? payout)
+    {
+      current = status;
+      currentPayout = payout;
+      payoutTouched = true;
+    }
+
     public Task<Result<Withdrawal?>> Get(Guid id, string? userId)
     {
       if (withdrawal == null)
         return Task.FromResult((Result<Withdrawal?>)(Withdrawal?)null);
-      // reflect prior status writes, as the DB would inside the transaction
+      // reflect prior status/payout writes, as the DB would
       var status =
         current == null
           ? withdrawal.Principal.Status
@@ -607,7 +642,11 @@ public class WithdrawalServiceGuardTests
           };
       var w = withdrawal with
       {
-        Principal = withdrawal.Principal with { Status = status },
+        Principal = withdrawal.Principal with
+        {
+          Status = status,
+          Payout = payoutTouched ? currentPayout : withdrawal.Principal.Payout,
+        },
       };
       return Task.FromResult((Result<Withdrawal?>)w);
     }
@@ -627,7 +666,11 @@ public class WithdrawalServiceGuardTests
         current = status.Status;
       }
       if (payout != null)
+      {
         LastPayoutWritten = payout;
+        currentPayout = payout;
+        payoutTouched = true;
+      }
       if (complete != null)
         LastCompleteWritten = complete;
       var principal = withdrawal!.Principal with
@@ -636,6 +679,11 @@ public class WithdrawalServiceGuardTests
         Payout = payout ?? withdrawal.Principal.Payout,
         Complete = complete ?? withdrawal.Principal.Complete,
       };
+
+      var hook = AfterFirstUpdate;
+      AfterFirstUpdate = null;
+      hook?.Invoke(this);
+
       return Task.FromResult((Result<WithdrawalPrincipal?>)principal);
     }
 

--- a/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
@@ -1,0 +1,514 @@
+using CSharp_Result;
+using Domain;
+using Domain.Exceptions;
+using Domain.Transaction;
+using Domain.User;
+using Domain.Wallet;
+using Domain.Withdrawal;
+using FluentAssertions;
+
+namespace UnitTest.Withdrawals;
+
+// Guards + money movement on WithdrawalService for the automated payout flow.
+// The invariants mirror the booking recovery spec: a withdrawal's reserve is
+// collected at most once, a payout is created at most once per attempt, and
+// the fee ledger always matches the transfer actually created.
+public class WithdrawalServiceGuardTests
+{
+  private const decimal Amount = 100m;
+  private const decimal Fee = 4m;
+
+  private static (
+    WithdrawalService Service,
+    FakeWithdrawalRepository Repo,
+    FakeWalletRepository Wallet,
+    FakeTransactionRepository Txn,
+    FakePayoutGateway Gateway
+  ) Make(Withdrawal? withdrawal, bool gatewayFails = false)
+  {
+    var repo = new FakeWithdrawalRepository(withdrawal);
+    var wallet = new FakeWalletRepository();
+    var txn = new FakeTransactionRepository();
+    var gateway = new FakePayoutGateway(gatewayFails);
+    var service = new WithdrawalService(
+      repo,
+      wallet,
+      txn,
+      new TransactionGenerator(new FixedRefundCalculator()),
+      new FakeWithdrawalStorage(),
+      new PassThroughTransactionManager(),
+      new FourPercentFeeCalculator(),
+      gateway
+    );
+    return (service, repo, wallet, txn, gateway);
+  }
+
+  private static Withdrawal WithdrawalWith(
+    WithdrawStatus status,
+    WithdrawalPayout? payout = null
+  )
+  {
+    var id = Guid.NewGuid();
+    return new Withdrawal
+    {
+      Principal = new WithdrawalPrincipal
+      {
+        Id = id,
+        CreatedAt = DateTime.UtcNow,
+        Status = new WithdrawalStatus { Status = status },
+        Record = new WithdrawalRecord { Amount = Amount, PayNowNumber = "91234567" },
+        Complete = null,
+        Payout = payout,
+      },
+      Wallet = new WalletPrincipal
+      {
+        Id = Guid.NewGuid(),
+        UserId = "user-1",
+        Record = new WalletRecord
+        {
+          Usable = 0m,
+          WithdrawReserve = Amount,
+          BookingReserve = 0m,
+        },
+      },
+      User = new UserPrincipal
+      {
+        Id = "user-1",
+        Record = new UserRecord { Username = "tester" },
+      },
+      Completer = null,
+    };
+  }
+
+  // ---- Approve ----
+
+  [Fact]
+  public async Task Approve_pending_claims_processing_and_pays_out_net_amount()
+  {
+    var w = WithdrawalWith(WithdrawStatus.Pending);
+    var (service, repo, _, _, gateway) = Make(w);
+
+    var result = await service.Approve(w.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    repo.StatusWrites.Should().Contain(s => s.Status == WithdrawStatus.Processing);
+    gateway.Requests.Should().ContainSingle();
+    gateway.Requests[0].Amount.Should().Be(Amount - Fee, "the payout is net of the 4% fee");
+    gateway.Requests[0].RequestId.Should().Be($"{w.Principal.Id}-1");
+    repo.LastPayoutWritten!.ConfirmationNumber.Should().Be("transfer-1");
+    repo.LastPayoutWritten.Fee.Should().Be(Fee);
+  }
+
+  [Theory]
+  [InlineData(WithdrawStatus.Processing)]
+  [InlineData(WithdrawStatus.Completed)]
+  [InlineData(WithdrawStatus.Rejected)]
+  [InlineData(WithdrawStatus.Cancel)]
+  public async Task Approve_from_disallowed_status_is_rejected_and_never_hits_gateway(
+    WithdrawStatus status
+  )
+  {
+    var w = WithdrawalWith(status);
+    var (service, repo, _, _, gateway) = Make(w);
+
+    var result = await service.Approve(w.Principal.Id);
+
+    result.IsSuccess().Should().BeFalse($"a '{status}' withdrawal must not be approved");
+    result.FailureOrDefault().Should().BeOfType<InvalidWithdrawalOperationException>();
+    gateway.Requests.Should().BeEmpty("no payout may be created when the claim guard fails");
+    repo.StatusWrites.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task Approve_releases_claim_when_gateway_fails()
+  {
+    var w = WithdrawalWith(WithdrawStatus.Pending);
+    var (service, repo, wallet, _, gateway) = Make(w, gatewayFails: true);
+
+    var result = await service.Approve(w.Principal.Id);
+
+    result.IsSuccess().Should().BeFalse();
+    gateway.Requests.Should().ContainSingle();
+    repo.StatusWrites.Select(s => s.Status)
+      .Should()
+      .ContainInOrder(WithdrawStatus.Processing, WithdrawStatus.Pending);
+    wallet.WithdrawCalls.Should().Be(0, "no money moves on approve, let alone on failure");
+  }
+
+  [Fact]
+  public async Task Approve_retry_after_failure_uses_a_fresh_request_id()
+  {
+    var w = WithdrawalWith(
+      WithdrawStatus.Pending,
+      new WithdrawalPayout { ConfirmationNumber = null, Fee = Fee, Attempt = 1 }
+    );
+    var (service, _, _, _, gateway) = Make(w);
+
+    var result = await service.Approve(w.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    gateway.Requests[0].RequestId
+      .Should()
+      .Be($"{w.Principal.Id}-2", "each attempt must be unique at the gateway");
+  }
+
+  // ---- CompletePayout (webhook success) ----
+
+  [Fact]
+  public async Task CompletePayout_processing_collects_reserve_and_writes_two_ledger_rows()
+  {
+    var w = WithdrawalWith(
+      WithdrawStatus.Processing,
+      new WithdrawalPayout { ConfirmationNumber = "transfer-9", Fee = Fee, Attempt = 1 }
+    );
+    var (service, repo, wallet, txn, _) = Make(w);
+
+    var result = await service.CompletePayout(w.Principal.Id, "transfer-9");
+
+    result.IsSuccess().Should().BeTrue();
+    wallet.WithdrawCalls.Should().Be(1);
+    wallet.LastWithdrawAmount.Should().Be(Amount, "the full reserved amount is collected");
+    txn.Records.Should().HaveCount(2);
+    txn.Records[0].Type.Should().Be(TransactionType.WithdrawComplete);
+    txn.Records[0].Amount.Should().Be(Amount - Fee);
+    txn.Records[1].Type.Should().Be(TransactionType.WithdrawFee);
+    txn.Records[1].Amount.Should().Be(Fee);
+    txn.Records[1].To.Should().Be(Accounts.WithdrawalFee.DisplayName);
+    repo.StatusWrites.Should().ContainSingle(s => s.Status == WithdrawStatus.Completed);
+    repo.LastCompleteWritten!.CompleterId.Should().BeNull("automation has no human completer");
+  }
+
+  [Theory]
+  [InlineData(WithdrawStatus.Pending)]
+  [InlineData(WithdrawStatus.Completed)]
+  [InlineData(WithdrawStatus.Rejected)]
+  [InlineData(WithdrawStatus.Cancel)]
+  public async Task CompletePayout_from_disallowed_status_moves_no_money(WithdrawStatus status)
+  {
+    var w = WithdrawalWith(
+      status,
+      new WithdrawalPayout { ConfirmationNumber = "transfer-9", Fee = Fee, Attempt = 1 }
+    );
+    var (service, _, wallet, txn, _) = Make(w);
+
+    var result = await service.CompletePayout(w.Principal.Id, "transfer-9");
+
+    result.IsSuccess().Should().BeFalse(
+      $"a '{status}' withdrawal must not be completed by the webhook (double-collect protection)"
+    );
+    wallet.WithdrawCalls.Should().Be(0);
+    txn.Records.Should().BeEmpty();
+  }
+
+  // ---- FailPayout (webhook failure) ----
+
+  [Fact]
+  public async Task FailPayout_processing_returns_to_pending_without_money()
+  {
+    var w = WithdrawalWith(
+      WithdrawStatus.Processing,
+      new WithdrawalPayout { ConfirmationNumber = "transfer-9", Fee = Fee, Attempt = 1 }
+    );
+    var (service, repo, wallet, txn, _) = Make(w);
+
+    var result = await service.FailPayout(w.Principal.Id, "transfer failed");
+
+    result.IsSuccess().Should().BeTrue();
+    repo.StatusWrites.Should().ContainSingle(s => s.Status == WithdrawStatus.Pending);
+    wallet.WithdrawCalls.Should().Be(0);
+    wallet.CancelWithdrawCalls.Should().Be(0, "the reserve was never collected, nothing to refund");
+    txn.Records.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task FailPayout_from_completed_is_rejected()
+  {
+    var w = WithdrawalWith(
+      WithdrawStatus.Completed,
+      new WithdrawalPayout { ConfirmationNumber = "transfer-9", Fee = Fee, Attempt = 1 }
+    );
+    var (service, repo, _, _, _) = Make(w);
+
+    var result = await service.FailPayout(w.Principal.Id, "late failure event");
+
+    result.IsSuccess().Should().BeFalse("a settled withdrawal must never be reopened");
+    repo.StatusWrites.Should().BeEmpty();
+  }
+
+  // ---- Manual flows keep their guards ----
+
+  [Theory]
+  [InlineData(WithdrawStatus.Processing)]
+  [InlineData(WithdrawStatus.Completed)]
+  [InlineData(WithdrawStatus.Rejected)]
+  [InlineData(WithdrawStatus.Cancel)]
+  public async Task Cancel_from_non_pending_is_rejected_and_refunds_nothing(WithdrawStatus status)
+  {
+    var w = WithdrawalWith(status);
+    var (service, _, wallet, txn, _) = Make(w);
+
+    var result = await service.Cancel(w.Principal.Id, "user-1", "changed my mind");
+
+    result.IsSuccess().Should().BeFalse();
+    result.FailureOrDefault().Should().BeOfType<InvalidWithdrawalOperationException>();
+    wallet.CancelWithdrawCalls.Should().Be(0);
+    txn.Records.Should().BeEmpty();
+  }
+
+  [Theory]
+  [InlineData(WithdrawStatus.Processing)]
+  [InlineData(WithdrawStatus.Completed)]
+  public async Task Reject_from_disallowed_status_is_rejected_and_refunds_nothing(
+    WithdrawStatus status
+  )
+  {
+    var w = WithdrawalWith(status);
+    var (service, _, wallet, txn, _) = Make(w);
+
+    var result = await service.Reject(w.Principal.Id, "admin-1", "suspicious");
+
+    result.IsSuccess().Should().BeFalse();
+    wallet.CancelWithdrawCalls.Should().Be(0);
+    txn.Records.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task Manual_complete_charges_the_same_fee_ledger()
+  {
+    var w = WithdrawalWith(WithdrawStatus.Pending);
+    var (service, repo, wallet, txn, _) = Make(w);
+
+    var result = await service.Complete(
+      w.Principal.Id,
+      "admin-1",
+      "manual PayNow transfer",
+      new MemoryStream([1, 2, 3])
+    );
+
+    result.IsSuccess().Should().BeTrue();
+    wallet.LastWithdrawAmount.Should().Be(Amount);
+    txn.Records.Should().HaveCount(2);
+    txn.Records[0].Amount.Should().Be(Amount - Fee);
+    txn.Records[1].Amount.Should().Be(Fee);
+    repo.LastPayoutWritten!.Fee.Should().Be(Fee);
+    repo.LastCompleteWritten!.CompleterId.Should().Be("admin-1");
+  }
+
+  [Fact]
+  public async Task Manual_complete_from_processing_is_rejected()
+  {
+    // A Processing withdrawal has a live transfer at the gateway; a manual
+    // completion on top of it would pay the user twice
+    var w = WithdrawalWith(
+      WithdrawStatus.Processing,
+      new WithdrawalPayout { ConfirmationNumber = "transfer-9", Fee = Fee, Attempt = 1 }
+    );
+    var (service, _, wallet, txn, _) = Make(w);
+
+    var result = await service.Complete(
+      w.Principal.Id,
+      "admin-1",
+      "manual",
+      new MemoryStream([1])
+    );
+
+    result.IsSuccess().Should().BeFalse();
+    wallet.WithdrawCalls.Should().Be(0);
+    txn.Records.Should().BeEmpty();
+  }
+
+  // ---- fakes ----
+
+  private sealed class PassThroughTransactionManager : ITransactionManager
+  {
+    public Task<Result<T>> Start<T>(Func<Task<Result<T>>> func) => func();
+  }
+
+  private sealed class FourPercentFeeCalculator : IFeeCalculator
+  {
+    public decimal WithdrawFeeRate => 0.04m;
+
+    public decimal WithdrawFee(decimal amount) =>
+      Math.Round(amount * this.WithdrawFeeRate, 2, MidpointRounding.ToEven);
+  }
+
+  private sealed class FixedRefundCalculator : IRefundCalculator
+  {
+    public decimal RefundRate => 0.5m;
+    public decimal PenaltyRate => 0.5m;
+  }
+
+  private sealed class FakeWithdrawalStorage : IWithdrawalStorage
+  {
+    public Task<Result<string>> Save(Stream stream) =>
+      Task.FromResult((Result<string>)"receipt-key");
+
+    public Task<Result<string>> Get(string key) => Task.FromResult((Result<string>)"url");
+  }
+
+  private sealed class FakePayoutGateway(bool fails) : IPayoutGateway
+  {
+    public List<PayoutRequest> Requests { get; } = [];
+
+    public Task<Result<PayoutConfirmation>> CreatePayout(PayoutRequest request)
+    {
+      Requests.Add(request);
+      if (fails)
+        return Task.FromResult(
+          (Result<PayoutConfirmation>)new InvalidOperationException("gateway down")
+        );
+      return Task.FromResult(
+        (Result<PayoutConfirmation>)new PayoutConfirmation { Id = "transfer-1" }
+      );
+    }
+  }
+
+  private sealed class FakeWithdrawalRepository(Withdrawal? withdrawal) : IWithdrawalRepository
+  {
+    private WithdrawStatus? current;
+
+    public List<WithdrawalStatus> StatusWrites { get; } = [];
+    public WithdrawalPayout? LastPayoutWritten { get; private set; }
+    public WithdrawalComplete? LastCompleteWritten { get; private set; }
+
+    public Task<Result<Withdrawal?>> Get(Guid id, string? userId)
+    {
+      if (withdrawal == null)
+        return Task.FromResult((Result<Withdrawal?>)(Withdrawal?)null);
+      // reflect prior status writes, as the DB would inside the transaction
+      var status =
+        current == null
+          ? withdrawal.Principal.Status
+          : withdrawal.Principal.Status with
+          {
+            Status = current.Value,
+          };
+      var w = withdrawal with
+      {
+        Principal = withdrawal.Principal with { Status = status },
+      };
+      return Task.FromResult((Result<Withdrawal?>)w);
+    }
+
+    public Task<Result<WithdrawalPrincipal?>> Update(
+      string? userId,
+      Guid id,
+      WithdrawalRecord? record,
+      WithdrawalStatus? status,
+      WithdrawalComplete? complete,
+      WithdrawalPayout? payout = null
+    )
+    {
+      if (status != null)
+      {
+        StatusWrites.Add(status);
+        current = status.Status;
+      }
+      if (payout != null)
+        LastPayoutWritten = payout;
+      if (complete != null)
+        LastCompleteWritten = complete;
+      var principal = withdrawal!.Principal with
+      {
+        Status = status ?? withdrawal.Principal.Status,
+        Payout = payout ?? withdrawal.Principal.Payout,
+        Complete = complete ?? withdrawal.Principal.Complete,
+      };
+      return Task.FromResult((Result<WithdrawalPrincipal?>)principal);
+    }
+
+    public Task<Result<IEnumerable<WithdrawalPrincipal>>> Search(WithdrawalSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WithdrawalPrincipal>> Create(Guid walletId, WithdrawalRecord record) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Unit?>> Delete(Guid id) => throw new NotImplementedException();
+  }
+
+  private sealed class FakeWalletRepository : IWalletRepository
+  {
+    public int WithdrawCalls { get; private set; }
+    public int CancelWithdrawCalls { get; private set; }
+    public decimal? LastWithdrawAmount { get; private set; }
+
+    private static WalletPrincipal Wallet(Guid id) =>
+      new()
+      {
+        Id = id,
+        UserId = "user-1",
+        Record = new WalletRecord
+        {
+          Usable = 0m,
+          WithdrawReserve = 0m,
+          BookingReserve = 0m,
+        },
+      };
+
+    public Task<Result<WalletPrincipal?>> Withdraw(Guid id, decimal amount)
+    {
+      WithdrawCalls++;
+      LastWithdrawAmount = amount;
+      return Task.FromResult((Result<WalletPrincipal?>)Wallet(id));
+    }
+
+    public Task<Result<WalletPrincipal?>> CancelWithdraw(Guid id, decimal amount)
+    {
+      CancelWithdrawCalls++;
+      return Task.FromResult((Result<WalletPrincipal?>)Wallet(id));
+    }
+
+    public Task<Result<IEnumerable<WalletPrincipal>>> Search(WalletSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Wallet?>> Get(Guid id, string? userId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Wallet?>> GetByUserId(string userId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WalletPrincipal?>> PrepareWithdraw(Guid id, decimal amount) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WalletPrincipal?>> Deposit(Guid id, decimal amount) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WalletPrincipal?>> Collect(Guid id, decimal amount) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WalletPrincipal?>> BookStart(Guid id, decimal amount) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WalletPrincipal?>> BookEnd(Guid id, decimal revert, decimal collect) =>
+      throw new NotImplementedException();
+  }
+
+  private sealed class FakeTransactionRepository : ITransactionRepository
+  {
+    public List<TransactionRecord> Records { get; } = [];
+
+    public Task<Result<TransactionPrincipal>> Create(
+      Guid walletId,
+      TransactionRecord record,
+      Guid? paymentId = null
+    )
+    {
+      Records.Add(record);
+      var principal = new TransactionPrincipal
+      {
+        Id = Guid.NewGuid(),
+        CreatedAt = DateTime.UtcNow,
+        Record = record,
+      };
+      return Task.FromResult((Result<TransactionPrincipal>)principal);
+    }
+
+    public Task<Result<IEnumerable<TransactionPrincipal>>> Search(TransactionSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Transaction?>> Get(Guid id, string? userId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Unit?>> Delete(Guid id) => throw new NotImplementedException();
+  }
+}

--- a/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
@@ -370,12 +370,15 @@ public class WithdrawalServiceGuardTests
     );
     var (service, repo, wallet, txn, _) = Make(w);
 
-    var result = await service.ForceCompletePayout(w.Principal.Id);
+    var result = await service.ForceCompletePayout(w.Principal.Id, "admin-1");
 
     result.IsSuccess().Should().BeTrue();
     wallet.LastWithdrawAmount.Should().Be(Amount);
     txn.Records.Should().HaveCount(2);
     repo.StatusWrites.Should().ContainSingle(s => s.Status == WithdrawStatus.Completed);
+    repo.LastCompleteWritten!.CompleterId
+      .Should()
+      .Be("admin-1", "the forcing admin is recorded for the audit trail");
   }
 
   [Fact]
@@ -389,7 +392,7 @@ public class WithdrawalServiceGuardTests
     );
     var (service, _, wallet, txn, _) = Make(w);
 
-    var result = await service.ForceCompletePayout(w.Principal.Id);
+    var result = await service.ForceCompletePayout(w.Principal.Id, "admin-1");
 
     result.IsSuccess().Should().BeFalse();
     result.FailureOrDefault().Should().BeOfType<InvalidWithdrawalOperationException>();
@@ -403,7 +406,7 @@ public class WithdrawalServiceGuardTests
     var w = WithdrawalWith(WithdrawStatus.Pending);
     var (service, _, wallet, _, _) = Make(w);
 
-    var result = await service.ForceCompletePayout(w.Principal.Id);
+    var result = await service.ForceCompletePayout(w.Principal.Id, "admin-1");
 
     result.IsSuccess().Should().BeFalse();
     wallet.WithdrawCalls.Should().Be(0);

--- a/infra/api_chart/app/schema.json
+++ b/infra/api_chart/app/schema.json
@@ -116,6 +116,7 @@
       "additionalProperties": false,
       "required": [
         "RefundPercentage",
+        "WithdrawFeePercentage",
         "BaseUrl",
         "WhatsAppUrl",
         "TelegramUrl",
@@ -125,6 +126,12 @@
         "RefundPercentage": {
           "type": "integer",
           "format": "int32"
+        },
+        "WithdrawFeePercentage": {
+          "type": "number",
+          "format": "decimal",
+          "maximum": 100.0,
+          "minimum": 0.0
         },
         "BaseUrl": {
           "type": "string",

--- a/infra/api_chart/app/settings.yaml
+++ b/infra/api_chart/app/settings.yaml
@@ -7,6 +7,7 @@ Kestrel:
       Url: http://+:9002
 Domain:
   RefundPercentage: 50
+  WithdrawFeePercentage: 4
   BaseUrl: https://bunnybooker.com
   WhatsAppUrl: 'https://wa.me/6588178504'
   TelegramUrl: 'https://t.me/bunnybooker'

--- a/infra/migration_chart/app/schema.json
+++ b/infra/migration_chart/app/schema.json
@@ -116,6 +116,7 @@
       "additionalProperties": false,
       "required": [
         "RefundPercentage",
+        "WithdrawFeePercentage",
         "BaseUrl",
         "WhatsAppUrl",
         "TelegramUrl",
@@ -125,6 +126,12 @@
         "RefundPercentage": {
           "type": "integer",
           "format": "int32"
+        },
+        "WithdrawFeePercentage": {
+          "type": "number",
+          "format": "decimal",
+          "maximum": 100.0,
+          "minimum": 0.0
         },
         "BaseUrl": {
           "type": "string",

--- a/infra/migration_chart/app/settings.yaml
+++ b/infra/migration_chart/app/settings.yaml
@@ -7,6 +7,7 @@ Kestrel:
       Url: http://+:9002
 Domain:
   RefundPercentage: 50
+  WithdrawFeePercentage: 4
   BaseUrl: https://bunnybooker.com
   WhatsAppUrl: 'https://wa.me/6588178504'
   TelegramUrl: 'https://t.me/bunnybooker'


### PR DESCRIPTION
## Summary

- **4% withdrawal fee** (configurable via `Domain:WithdrawFeePercentage`), deducted from the requested amount. Every completion books **two ledger transactions**: net payout (`WithdrawComplete`) + fee into the new **BunnyBooker Withdrawal Fee** account (`WithdrawFee=13`). No deposit fee. `GET Withdrawal/fee` exposes the rate for the UI.
- **Automated payouts**: `POST Withdrawal/{id}/approve` (AdminOrTin) claims Pending→Processing and creates an Airwallex transfer (request id `{id}-{attempt}`, idempotent per attempt); the `transfer.*` webhook completes (collect + fee ledger) or fails it back to Pending. Manual receipt-upload completion stays as fallback and books the identical net+fee ledger.
- **Safety** (reviewed over 4 adversarial rounds): definitive-vs-ambiguous gateway failure classification (no double payout on timeouts/5xx — the claim survives and re-drives with the same request id), idempotent + attempt-fenced webhook transitions, conditional phase-3 confirmation write (never clobbers a concurrent transition), explicit `WithdrawStatus` guards on every transition, new `Processing` status, admin `complete-payout` escape hatch for a permanently lost webhook, and a 400 `invalid_withdrawal_operation` problem type.
- **Bookings**: `LastBuyingAt` stamp (additive column) + `force`/non-force revert (non-force requires stuck-in-Buying > 5 min — the safe path for helium's revived reverter), `StuckForMinutes` + `SortBy` search params with stable pagination tiebreakers, and `UserId` on booking responses.
- **Announcement email**: withdrawal-fee announcement template + OnlyAdmin endpoints to send to one user (test) or broadcast to all users with an email.
- EF migration: `ConfirmationNumber`/`Fee`/`PayoutAttempt` on Withdrawals, `LastBuyingAt` on Bookings.

## Notes for deploy
- Airwallex **PayNow payouts are a Beta feature** — must be enabled by the account manager before approve works against the real gateway; the exact beneficiary schema should be validated in sandbox.
- Companion PRs: tin (nightly withdrawer sweep), helium (reverter revival), argon (UI).

## Test plan
- 90 unit tests pass, including 30+ new money-path tests: claim/re-drive request-id reuse, gateway failure classification, webhook idempotency + attempt fencing, phase-3 no-clobber, two-row fee ledger, revert force/non-force + 5-min guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for withdrawal fees, including fee display and admin access to the current fee rate.
  * Added withdrawal-fee announcement emails for users and admins.
  * Added payout/withdrawal processing updates with clearer status tracking and confirmation details.

* **Bug Fixes**
  * Improved booking search and revert behavior, including better handling of “stuck” bookings and a forced revert option for admins.
  * Added more consistent handling for payout completion, failure, and webhook retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->