### PR TITLE
feat(withdrawal): gateway reconciliation and RequireManualIntervention

### DIFF
--- a/App/Migrations/20260708202056_AddWithdrawalReconciliation.Designer.cs
+++ b/App/Migrations/20260708202056_AddWithdrawalReconciliation.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using App.StartUp.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace App.Migrations
 {
     [DbContext(typeof(MainDbContext))]
-    partial class MainDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260708202056_AddWithdrawalReconciliation")]
+    partial class AddWithdrawalReconciliation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/App/Migrations/20260708202056_AddWithdrawalReconciliation.cs
+++ b/App/Migrations/20260708202056_AddWithdrawalReconciliation.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace App.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWithdrawalReconciliation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Costs",
+                keyColumn: "Id",
+                keyValue: new Guid("5aa07550-fc00-48bd-bb0c-35eeaf8a1362"));
+
+            migrationBuilder.AddColumn<int>(
+                name: "ReconcileAttempts",
+                table: "Withdrawals",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.InsertData(
+                table: "Costs",
+                columns: ["Id", "Cost", "CreatedAt"],
+                values: [new Guid("6b21363e-fff1-493b-8eb3-b73669df4fad"), 14m, new DateTime(2026, 7, 8, 20, 20, 56, 407, DateTimeKind.Utc).AddTicks(8010)]);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Costs",
+                keyColumn: "Id",
+                keyValue: new Guid("6b21363e-fff1-493b-8eb3-b73669df4fad"));
+
+            migrationBuilder.DropColumn(
+                name: "ReconcileAttempts",
+                table: "Withdrawals");
+
+            migrationBuilder.InsertData(
+                table: "Costs",
+                columns: ["Id", "Cost", "CreatedAt"],
+                values: [new Guid("5aa07550-fc00-48bd-bb0c-35eeaf8a1362"), 14m, new DateTime(2026, 7, 8, 6, 8, 2, 518, DateTimeKind.Utc).AddTicks(7650)]);
+        }
+    }
+}

--- a/App/Modules/Payments/Airwallex/AirwallexEventAdapter.cs
+++ b/App/Modules/Payments/Airwallex/AirwallexEventAdapter.cs
@@ -13,15 +13,9 @@ public enum TransferOutcome
 
 public class AirwallexEventAdapter
 {
-  private static readonly string[] SettledStatuses = ["PAID", "SETTLED"];
+  private static readonly string[] SettledStatuses = AirwallexTransferStatuses.Settled;
 
-  private static readonly string[] FailedStatuses =
-  [
-    "FAILED",
-    "CANCELLED",
-    "REJECTED",
-    "RETURNED",
-  ];
+  private static readonly string[] FailedStatuses = AirwallexTransferStatuses.Failed;
 
   public (Guid, PaymentRecord, bool) ProcessEvent(AirwallexEvent evt)
   {

--- a/App/Modules/Payments/Airwallex/Client.cs
+++ b/App/Modules/Payments/Airwallex/Client.cs
@@ -97,4 +97,67 @@ public class AirWallexClient(
         }
       });
   }
+
+  // Point-in-time lookup for reconciliation. Returns null (not an error) when
+  // the gateway definitively has no such transfer.
+  public Task<Result<AirwallexTransferRes?>> GetTransfer(string transferId)
+  {
+    return this.LookupTransfer($"api/v1/transfers/{transferId}", isList: false);
+  }
+
+  public Task<Result<AirwallexTransferRes?>> GetTransferByRequestId(string requestId)
+  {
+    return this.LookupTransfer(
+      $"api/v1/transfers?request_id={Uri.EscapeDataString(requestId)}",
+      isList: true
+    );
+  }
+
+  private Task<Result<AirwallexTransferRes?>> LookupTransfer(string path, bool isList)
+  {
+    return authenticator
+      .GetToken()
+      .ThenAwait(async token =>
+      {
+        var request = new HttpRequestMessage
+        {
+          Method = HttpMethod.Get,
+          RequestUri = new Uri(path, UriKind.Relative),
+          Headers = { Authorization = new AuthenticationHeaderValue("Bearer", token) },
+        };
+        try
+        {
+          using var response = await this.HttpClient.SendAsync(request);
+          var body = await response.Content.ReadAsStringAsync();
+          if ((int)response.StatusCode == 404)
+            return (Result<AirwallexTransferRes?>)(AirwallexTransferRes?)null;
+          if (!response.IsSuccessStatusCode)
+          {
+            logger.LogError(
+              "Failed to look up Airwallex transfer, Status: {Status}, Response: {Body}",
+              (int)response.StatusCode,
+              body
+            );
+            return (Result<AirwallexTransferRes?>)
+              new HttpRequestException(
+                $"Airwallex transfer lookup failed ({(int)response.StatusCode}): {body}"
+              );
+          }
+          if (!isList)
+            return body.ToObj<AirwallexTransferRes>().ToResult().Then(
+              t => (AirwallexTransferRes?)t,
+              Errors.MapNone
+            );
+          var list = body.ToObj<AirwallexTransferListRes>();
+          return (Result<AirwallexTransferRes?>)(
+            list.Items is { Length: > 0 } ? list.Items[0] : null
+          );
+        }
+        catch (Exception e)
+        {
+          logger.LogError(e, "Failed to look up Airwallex transfer (transport error)");
+          return (Result<AirwallexTransferRes?>)e;
+        }
+      });
+  }
 }

--- a/App/Modules/Payments/Airwallex/ResModel.cs
+++ b/App/Modules/Payments/Airwallex/ResModel.cs
@@ -70,3 +70,18 @@ public record AirwallexTransferRes
   [JsonPropertyName("short_reference_id")]
   public string? ShortReferenceId { get; set; }
 }
+
+public record AirwallexTransferListRes
+{
+  [JsonPropertyName("items")]
+  public AirwallexTransferRes[]? Items { get; set; }
+}
+
+// Shared status classification for transfer objects, used by both the webhook
+// adapter and the reconciliation lookup so the two paths can never disagree
+public static class AirwallexTransferStatuses
+{
+  public static readonly string[] Settled = ["PAID", "SETTLED"];
+
+  public static readonly string[] Failed = ["FAILED", "CANCELLED", "REJECTED", "RETURNED"];
+}

--- a/App/Modules/Withdrawals/API/V1/WithdrawalController.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalController.cs
@@ -142,6 +142,30 @@ public class WithdrawalController(
     return this.ReturnResult(x);
   }
 
+  // Reconciliation sweep entry (tin every 6h, or an admin): looks the
+  // transfer up at the gateway and settles/fails/parks accordingly
+  [Authorize(Policy = AuthPolicies.AdminOrTin), HttpPost("{id:guid}/reconcile")]
+  public async Task<ActionResult<WithdrawalPrincipalRes>> Reconcile(Guid id)
+  {
+    var x = await service
+      .Reconcile(id)
+      .Then(w => w.ToRes(), Errors.MapNone)
+      .ThenAwait(enrich.Enrich);
+    return this.ReturnResult(x);
+  }
+
+  // Admin resolution for a parked withdrawal: back to Pending for another
+  // automated attempt (only after verifying no live transfer at the gateway)
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpPost("{id:guid}/requeue")]
+  public async Task<ActionResult<WithdrawalPrincipalRes>> Requeue(Guid id)
+  {
+    var x = await service
+      .Requeue(id)
+      .Then(w => w.ToRes(), Errors.MapNone)
+      .ThenAwait(enrich.Enrich);
+    return this.ReturnResult(x);
+  }
+
   [Authorize(Policy = AuthPolicies.OnlyAdmin)]
   [HttpPost("{id:guid}/complete")]
   [Consumes(MediaTypeNames.Multipart.FormData)]

--- a/App/Modules/Withdrawals/API/V1/WithdrawalMapper.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalMapper.cs
@@ -16,6 +16,7 @@ public static class WithdrawalMapper
       WithdrawStatus.Rejected => "Rejected",
       WithdrawStatus.Cancel => "Cancel",
       WithdrawStatus.Processing => "Processing",
+      WithdrawStatus.RequireManualIntervention => "RequireManualIntervention",
       _ => throw new ArgumentOutOfRangeException(nameof(status), status, null),
     };
 
@@ -29,7 +30,7 @@ public static class WithdrawalMapper
     new(record.Amount, record.PayNowNumber);
 
   public static WithdrawalPayoutRes ToRes(this WithdrawalPayout payout) =>
-    new(payout.ConfirmationNumber, payout.Fee);
+    new(payout.ConfirmationNumber, payout.Fee, payout.ReconcileAttempts);
 
   public static WithdrawalPrincipalRes ToRes(this WithdrawalPrincipal w) =>
     new(
@@ -53,6 +54,7 @@ public static class WithdrawalMapper
       "Rejected" => WithdrawStatus.Rejected,
       "Cancel" => WithdrawStatus.Cancel,
       "Processing" => WithdrawStatus.Processing,
+      "RequireManualIntervention" => WithdrawStatus.RequireManualIntervention,
       _ => throw new ArgumentOutOfRangeException(nameof(status), status, null),
     };
 

--- a/App/Modules/Withdrawals/API/V1/WithdrawalModel.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalModel.cs
@@ -29,7 +29,7 @@ public record WithdrawalCompleteRes(DateTime CompletedAt, string Note, string? R
 
 public record WithdrawalRecordRes(decimal Amount, string PayNowNumber);
 
-public record WithdrawalPayoutRes(string? ConfirmationNumber, decimal Fee);
+public record WithdrawalPayoutRes(string? ConfirmationNumber, decimal Fee, int ReconcileAttempts);
 
 public record WithdrawalPrincipalRes(
   Guid Id,

--- a/App/Modules/Withdrawals/Data/AirwallexPayoutGateway.cs
+++ b/App/Modules/Withdrawals/Data/AirwallexPayoutGateway.cs
@@ -36,6 +36,27 @@ public class AirwallexPayoutGateway(AirWallexClient client) : IPayoutGateway
       .Then(res => new PayoutConfirmation { Id = res.Id }, Errors.MapNone);
   }
 
+  public Task<Result<PayoutStatus>> GetPayoutStatus(string requestId, string? confirmationNumber)
+  {
+    var lookup =
+      confirmationNumber != null
+        ? client.GetTransfer(confirmationNumber)
+        : client.GetTransferByRequestId(requestId);
+    return lookup.Then(
+      transfer =>
+      {
+        if (transfer == null)
+          return new PayoutStatus { Outcome = PayoutOutcome.NotFound, ConfirmationNumber = null };
+        var status = transfer.Status.ToUpperInvariant();
+        var outcome = AirwallexTransferStatuses.Settled.Contains(status) ? PayoutOutcome.Settled
+          : AirwallexTransferStatuses.Failed.Contains(status) ? PayoutOutcome.Failed
+          : PayoutOutcome.InFlight;
+        return new PayoutStatus { Outcome = outcome, ConfirmationNumber = transfer.Id };
+      },
+      Errors.MapNone
+    );
+  }
+
   // PayNow mobile IDs are addressed in E.164 form; local 8-digit numbers get
   // the Singapore country prefix
   private static string ToPayNowId(string payNowNumber) =>

--- a/App/Modules/Withdrawals/Data/WithdrawalData.cs
+++ b/App/Modules/Withdrawals/Data/WithdrawalData.cs
@@ -39,6 +39,8 @@ public class WithdrawalData
 
   public int PayoutAttempt { get; set; }
 
+  public int ReconcileAttempts { get; set; }
+
   // References
   public string? CompleterId { get; set; }
   public UserData? Completer { get; set; }

--- a/App/Modules/Withdrawals/Data/WithdrawalMapper.cs
+++ b/App/Modules/Withdrawals/Data/WithdrawalMapper.cs
@@ -35,6 +35,7 @@ public static class WithdrawalMapper
       ConfirmationNumber = data.ConfirmationNumber,
       Fee = data.Fee.Value,
       Attempt = data.PayoutAttempt,
+      ReconcileAttempts = data.ReconcileAttempts,
     };
   }
 
@@ -86,6 +87,7 @@ public static class WithdrawalMapper
     data.ConfirmationNumber = record.ConfirmationNumber;
     data.Fee = record.Fee;
     data.PayoutAttempt = record.Attempt;
+    data.ReconcileAttempts = record.ReconcileAttempts;
     return data;
   }
 }

--- a/Domain/Withdrawal/IPayoutGateway.cs
+++ b/Domain/Withdrawal/IPayoutGateway.cs
@@ -21,7 +21,32 @@ public record PayoutConfirmation
   public required string Id { get; init; }
 }
 
+public enum PayoutOutcome
+{
+  // the gateway has the transfer but it is neither settled nor dead yet
+  InFlight = 0,
+  Settled = 1,
+  Failed = 2,
+
+  // the gateway has no transfer for this request id: the create call never
+  // landed (safe to retry via re-drive)
+  NotFound = 3,
+}
+
+// Point-in-time gateway view of a payout, used by the reconciliation sweep
+public record PayoutStatus
+{
+  public required PayoutOutcome Outcome { get; init; }
+
+  // present whenever the gateway knows the transfer
+  public required string? ConfirmationNumber { get; init; }
+}
+
 public interface IPayoutGateway
 {
   Task<Result<PayoutConfirmation>> CreatePayout(PayoutRequest request);
+
+  // Looks the payout up at the gateway — by transfer id when confirmed,
+  // else by the deterministic request id
+  Task<Result<PayoutStatus>> GetPayoutStatus(string requestId, string? confirmationNumber);
 }

--- a/Domain/Withdrawal/IService.cs
+++ b/Domain/Withdrawal/IService.cs
@@ -43,9 +43,17 @@ public interface IWithdrawalService
   // Gateway webhook: payout failed, return the withdrawal to Pending for retry
   Task<Result<WithdrawalPrincipal>> FailPayout(Guid id, string reason, int? attempt);
 
-  // Admin only: finalize a confirmed Processing withdrawal whose settled
-  // webhook was permanently lost (verified against the gateway dashboard)
+  // Admin only: finalize a confirmed Processing/parked withdrawal whose
+  // settled webhook was permanently lost (verified against the gateway)
   Task<Result<WithdrawalPrincipal>> ForceCompletePayout(Guid id, string completerId);
+
+  // Reconciliation sweep (admin or tin): look the transfer up at the gateway;
+  // settle/fail accordingly, else count the sweep and park at the cap
+  Task<Result<WithdrawalPrincipal>> Reconcile(Guid id);
+
+  // Admin only: RequireManualIntervention -> Pending, after verifying at the
+  // gateway that no live transfer exists
+  Task<Result<WithdrawalPrincipal>> Requeue(Guid id);
 
   Task<Result<Unit?>> Delete(Guid id);
 }

--- a/Domain/Withdrawal/Model.cs
+++ b/Domain/Withdrawal/Model.cs
@@ -35,6 +35,12 @@ public enum WithdrawStatus
   // payout initiated at the gateway, awaiting settlement confirmation via
   // webhook (appended to preserve stored byte values)
   Processing = 4,
+
+  // parking state: the payout sat in Processing through the maximum number
+  // of reconciliation attempts without the gateway ever confirming or
+  // denying it — a human must check the Airwallex dashboard and resolve via
+  // force-complete (money left), reject (refund) or requeue (retry)
+  RequireManualIntervention = 5,
 }
 
 public record Withdrawal
@@ -92,6 +98,10 @@ public record WithdrawalPayout
   // genuinely failed payout can be retried without colliding with the
   // gateway's idempotency window
   public required int Attempt { get; init; }
+
+  // Number of inconclusive reconciliation sweeps while stuck in Processing;
+  // at MaxReconcileAttempts the withdrawal is parked for a human
+  public int ReconcileAttempts { get; init; }
 }
 
 public record WithdrawalRecord

--- a/Domain/Withdrawal/Service.cs
+++ b/Domain/Withdrawal/Service.cs
@@ -89,14 +89,24 @@ public class WithdrawalService(
     );
   }
 
-  // only admin
+  // only admin. Also allowed from RequireManualIntervention: the admin has
+  // verified at the gateway that no money left, so refunding is safe.
   public Task<Result<WithdrawalPrincipal>> Reject(Guid id, string completerId, string note)
   {
     return transactionManager.Start(
       () =>
         repo.Get(id, null)
           .NullToError(id.ToString())
-          .DoAwait(DoType.MapErrors, w => GuardStatus(w, WithdrawalOperations.Reject))
+          .DoAwait(
+            DoType.MapErrors,
+            w =>
+              GuardStatus(
+                w,
+                WithdrawalOperations.Reject,
+                WithdrawStatus.Pending,
+                WithdrawStatus.RequireManualIntervention
+              )
+          )
           // update wallet
           .DoAwait(
             DoType.MapErrors,
@@ -340,7 +350,12 @@ public class WithdrawalService(
             )
               return Task.FromResult((Result<WithdrawalPrincipal>)w.Principal);
 
-            if (status != WithdrawStatus.Processing)
+            // the webhook may only settle Processing; an admin force-complete
+            // (completerId set) may also settle a parked withdrawal
+            var allowed =
+              status == WithdrawStatus.Processing
+              || (completerId != null && status == WithdrawStatus.RequireManualIntervention);
+            if (!allowed)
               return Stale(
                 $"settled event for transfer '{confirmationNumber}' but withdrawal '{id}' is '{status}'"
               );
@@ -390,10 +405,10 @@ public class WithdrawalService(
     );
   }
 
-  // Admin escape hatch for a confirmed Processing withdrawal whose settled
-  // webhook was permanently lost: after verifying the transfer on the
-  // Airwallex dashboard, an admin finalizes it through the same idempotent
-  // path the webhook would have taken (the transactional Processing guard
+  // Admin escape hatch for a confirmed Processing (or parked) withdrawal
+  // whose settled webhook was permanently lost: after verifying the transfer
+  // on the Airwallex dashboard, an admin finalizes it through the same
+  // idempotent path the webhook would have taken (the transactional guard
   // still prevents any race with a late webhook).
   public Task<Result<WithdrawalPrincipal>> ForceCompletePayout(Guid id, string completerId)
   {
@@ -401,21 +416,139 @@ public class WithdrawalService(
       .NullToError(id.ToString())
       .ThenAwait(w =>
       {
+        var status = w.Principal.Status.Status;
         var payout = w.Principal.Payout;
-        if (
-          w.Principal.Status.Status != WithdrawStatus.Processing
-          || payout?.ConfirmationNumber == null
-        )
+        var allowed =
+          status is WithdrawStatus.Processing or WithdrawStatus.RequireManualIntervention;
+        if (!allowed || payout?.ConfirmationNumber == null)
           return Task.FromResult(
             (Result<WithdrawalPrincipal>)
               new InvalidWithdrawalOperationException(
-                "Force-completion requires a 'Processing' withdrawal with a confirmed transfer",
-                w.Principal.Status.Status,
+                "Force-completion requires a 'Processing' or 'RequireManualIntervention' withdrawal with a confirmed transfer",
+                status,
                 WithdrawalOperations.CompletePayout
               )
           );
         return this.CompletePayout(id, payout.ConfirmationNumber, payout.Attempt, completerId);
       });
+  }
+
+  // The number of inconclusive reconciliation sweeps tolerated before a
+  // Processing withdrawal is parked for a human (8 sweeps at 6h ≈ 2 days)
+  public const int MaxReconcileAttempts = 8;
+
+  // Reconciliation: asks the gateway what actually happened to a Processing
+  // withdrawal's transfer. Settled/failed outcomes are delegated to the same
+  // guarded transitions the webhook uses; anything inconclusive (still in
+  // flight, not found, or the lookup itself failing) increments the attempt
+  // counter and parks the withdrawal at the cap. Never moves money itself.
+  public async Task<Result<WithdrawalPrincipal>> Reconcile(Guid id)
+  {
+    var read = await repo.Get(id, null).NullToError(id.ToString());
+    if (read.IsFailure())
+      return read.FailureOrDefault();
+    var w = read.SuccessOrDefault();
+    var payout = w.Principal.Payout;
+    if (w.Principal.Status.Status != WithdrawStatus.Processing || payout == null)
+      return new InvalidWithdrawalOperationException(
+        "Reconcile requires a 'Processing' withdrawal with payout bookkeeping",
+        w.Principal.Status.Status,
+        WithdrawalOperations.Reconcile
+      );
+
+    var lookup = await payoutGateway.GetPayoutStatus(
+      $"{id}-{payout.Attempt}",
+      payout.ConfirmationNumber
+    );
+
+    if (lookup.IsSuccess())
+    {
+      var gateway = lookup.SuccessOrDefault();
+      switch (gateway.Outcome)
+      {
+        case PayoutOutcome.Settled:
+          return await this.CompletePayout(id, gateway.ConfirmationNumber!, payout.Attempt);
+        case PayoutOutcome.Failed:
+          return await this.FailPayout(
+            id,
+            "reconciliation: gateway reports the transfer terminally failed",
+            payout.Attempt
+          );
+      }
+    }
+
+    // Inconclusive: count the sweep; at the cap, park for a human. The write
+    // is conditional on the state being unchanged so a concurrent webhook or
+    // admin action is never clobbered.
+    return await transactionManager.Start(
+      () =>
+        repo.Get(id, null)
+          .NullToError(id.ToString())
+          .ThenAwait(w2 =>
+          {
+            var p2 = w2.Principal.Payout;
+            if (
+              w2.Principal.Status.Status != WithdrawStatus.Processing
+              || p2 == null
+              || p2.Attempt != payout.Attempt
+            )
+              return Task.FromResult((Result<WithdrawalPrincipal>)w2.Principal);
+            var attempts = p2.ReconcileAttempts + 1;
+            return repo.Update(
+                null,
+                id,
+                null,
+                attempts >= MaxReconcileAttempts
+                  ? new WithdrawalStatus { Status = WithdrawStatus.RequireManualIntervention }
+                  : null,
+                null,
+                p2 with
+                {
+                  ReconcileAttempts = attempts,
+                }
+              )
+              .NullToError(id.ToString());
+          })
+    );
+  }
+
+  // Admin only: return a parked withdrawal to Pending for another automated
+  // attempt. The admin must have verified at the gateway that no live
+  // transfer exists — the next approve mints a fresh request id, so
+  // requeueing a withdrawal whose transfer is actually alive would double-pay.
+  public Task<Result<WithdrawalPrincipal>> Requeue(Guid id)
+  {
+    return transactionManager.Start(
+      () =>
+        repo.Get(id, null)
+          .NullToError(id.ToString())
+          .DoAwait(
+            DoType.MapErrors,
+            w =>
+              GuardStatus(
+                w,
+                WithdrawalOperations.Requeue,
+                WithdrawStatus.RequireManualIntervention
+              )
+          )
+          .ThenAwait(w =>
+            repo.Update(
+                null,
+                id,
+                null,
+                new WithdrawalStatus { Status = WithdrawStatus.Pending },
+                null,
+                w.Principal.Payout == null
+                  ? null
+                  : w.Principal.Payout with
+                  {
+                    ConfirmationNumber = null,
+                    ReconcileAttempts = 0,
+                  }
+              )
+              .NullToError(id.ToString())
+          )
+    );
   }
 
   public Task<Result<WithdrawalPrincipal>> FailPayout(Guid id, string reason, int? attempt)

--- a/Domain/Withdrawal/WithdrawalOperations.cs
+++ b/Domain/Withdrawal/WithdrawalOperations.cs
@@ -11,4 +11,8 @@ public static class WithdrawalOperations
   public const string Approve = "Approve";
 
   public const string CompletePayout = "CompletePayout";
+
+  public const string Reconcile = "Reconcile";
+
+  public const string Requeue = "Requeue";
 }

--- a/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
@@ -481,6 +481,217 @@ public class WithdrawalServiceGuardTests
     repo.StatusWrites.Should().BeEmpty();
   }
 
+  // ---- Reconciliation (6h sweep) ----
+
+  [Fact]
+  public async Task Reconcile_settled_transfer_completes_and_collects_once()
+  {
+    var w = WithdrawalWith(
+      WithdrawStatus.Processing,
+      new WithdrawalPayout { ConfirmationNumber = "transfer-9", Fee = Fee, Attempt = 1 }
+    );
+    var (service, repo, wallet, txn, gateway) = Make(w);
+    gateway.LookupResult = new PayoutStatus
+    {
+      Outcome = PayoutOutcome.Settled,
+      ConfirmationNumber = "transfer-9",
+    };
+
+    var result = await service.Reconcile(w.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    gateway.LastLookup!.Value.ConfirmationNumber.Should().Be("transfer-9");
+    wallet.WithdrawCalls.Should().Be(1);
+    txn.Records.Should().HaveCount(2, "settling via reconciliation books the same fee ledger");
+    repo.StatusWrites.Should().ContainSingle(s => s.Status == WithdrawStatus.Completed);
+  }
+
+  [Fact]
+  public async Task Reconcile_failed_transfer_returns_to_pending_without_money()
+  {
+    var w = WithdrawalWith(
+      WithdrawStatus.Processing,
+      new WithdrawalPayout { ConfirmationNumber = "transfer-9", Fee = Fee, Attempt = 1 }
+    );
+    var (service, repo, wallet, txn, gateway) = Make(w);
+    gateway.LookupResult = new PayoutStatus
+    {
+      Outcome = PayoutOutcome.Failed,
+      ConfirmationNumber = "transfer-9",
+    };
+
+    var result = await service.Reconcile(w.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    repo.StatusWrites.Should().ContainSingle(s => s.Status == WithdrawStatus.Pending);
+    repo.LastPayoutWritten!.ConfirmationNumber.Should().BeNull("the dead transfer is cleared");
+    wallet.WithdrawCalls.Should().Be(0);
+    txn.Records.Should().BeEmpty();
+  }
+
+  [Theory]
+  [InlineData(PayoutOutcome.InFlight)]
+  [InlineData(PayoutOutcome.NotFound)]
+  public async Task Reconcile_inconclusive_counts_the_sweep_and_stays_processing(
+    PayoutOutcome outcome
+  )
+  {
+    var w = WithdrawalWith(
+      WithdrawStatus.Processing,
+      new WithdrawalPayout { ConfirmationNumber = "transfer-9", Fee = Fee, Attempt = 1 }
+    );
+    var (service, repo, wallet, _, gateway) = Make(w);
+    gateway.LookupResult = new PayoutStatus { Outcome = outcome, ConfirmationNumber = null };
+
+    var result = await service.Reconcile(w.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    repo.LastPayoutWritten!.ReconcileAttempts.Should().Be(1);
+    repo.StatusWrites.Should().BeEmpty("below the cap the status is untouched");
+    wallet.WithdrawCalls.Should().Be(0);
+  }
+
+  [Fact]
+  public async Task Reconcile_lookup_failure_also_counts_as_inconclusive()
+  {
+    var w = WithdrawalWith(
+      WithdrawStatus.Processing,
+      new WithdrawalPayout { ConfirmationNumber = "transfer-9", Fee = Fee, Attempt = 1 }
+    );
+    var (service, repo, _, _, gateway) = Make(w);
+    gateway.LookupResult = null;
+
+    var result = await service.Reconcile(w.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    repo.LastPayoutWritten!.ReconcileAttempts.Should().Be(1);
+  }
+
+  [Fact]
+  public async Task Reconcile_parks_for_a_human_at_the_attempt_cap()
+  {
+    var w = WithdrawalWith(
+      WithdrawStatus.Processing,
+      new WithdrawalPayout
+      {
+        ConfirmationNumber = "transfer-9",
+        Fee = Fee,
+        Attempt = 1,
+        ReconcileAttempts = WithdrawalService.MaxReconcileAttempts - 1,
+      }
+    );
+    var (service, repo, wallet, _, gateway) = Make(w);
+    gateway.LookupResult = new PayoutStatus
+    {
+      Outcome = PayoutOutcome.InFlight,
+      ConfirmationNumber = null,
+    };
+
+    var result = await service.Reconcile(w.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    repo.LastPayoutWritten!.ReconcileAttempts.Should().Be(WithdrawalService.MaxReconcileAttempts);
+    repo.StatusWrites
+      .Should()
+      .ContainSingle(s => s.Status == WithdrawStatus.RequireManualIntervention);
+    wallet.WithdrawCalls.Should().Be(0, "parking moves no money");
+  }
+
+  [Theory]
+  [InlineData(WithdrawStatus.Pending)]
+  [InlineData(WithdrawStatus.Completed)]
+  [InlineData(WithdrawStatus.RequireManualIntervention)]
+  public async Task Reconcile_from_disallowed_status_is_rejected(WithdrawStatus status)
+  {
+    var w = WithdrawalWith(
+      status,
+      new WithdrawalPayout { ConfirmationNumber = "transfer-9", Fee = Fee, Attempt = 1 }
+    );
+    var (service, _, _, _, gateway) = Make(w);
+
+    var result = await service.Reconcile(w.Principal.Id);
+
+    result.IsSuccess().Should().BeFalse();
+    result.FailureOrDefault().Should().BeOfType<InvalidWithdrawalOperationException>();
+    gateway.LastLookup.Should().BeNull("no gateway call for a non-Processing withdrawal");
+  }
+
+  // ---- RequireManualIntervention resolutions ----
+
+  [Fact]
+  public async Task Requeue_returns_a_parked_withdrawal_to_pending()
+  {
+    var w = WithdrawalWith(
+      WithdrawStatus.RequireManualIntervention,
+      new WithdrawalPayout
+      {
+        ConfirmationNumber = "transfer-9",
+        Fee = Fee,
+        Attempt = 2,
+        ReconcileAttempts = 8,
+      }
+    );
+    var (service, repo, wallet, _, _) = Make(w);
+
+    var result = await service.Requeue(w.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    repo.StatusWrites.Should().ContainSingle(s => s.Status == WithdrawStatus.Pending);
+    repo.LastPayoutWritten!.ConfirmationNumber.Should().BeNull();
+    repo.LastPayoutWritten.ReconcileAttempts.Should().Be(0, "a fresh cycle starts clean");
+    repo.LastPayoutWritten.Attempt.Should().Be(2, "the attempt counter survives for uniqueness");
+    wallet.WithdrawCalls.Should().Be(0);
+  }
+
+  [Theory]
+  [InlineData(WithdrawStatus.Pending)]
+  [InlineData(WithdrawStatus.Processing)]
+  [InlineData(WithdrawStatus.Completed)]
+  public async Task Requeue_from_disallowed_status_is_rejected(WithdrawStatus status)
+  {
+    var w = WithdrawalWith(status);
+    var (service, repo, _, _, _) = Make(w);
+
+    var result = await service.Requeue(w.Principal.Id);
+
+    result.IsSuccess().Should().BeFalse();
+    repo.StatusWrites.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task Reject_from_manual_intervention_refunds_once()
+  {
+    var w = WithdrawalWith(
+      WithdrawStatus.RequireManualIntervention,
+      new WithdrawalPayout { ConfirmationNumber = null, Fee = Fee, Attempt = 1 }
+    );
+    var (service, repo, wallet, txn, _) = Make(w);
+
+    var result = await service.Reject(w.Principal.Id, "admin-1", "gateway shows no transfer");
+
+    result.IsSuccess().Should().BeTrue();
+    wallet.CancelWithdrawCalls.Should().Be(1, "rejecting a parked withdrawal refunds the reserve");
+    txn.Records.Should().ContainSingle(r => r.Type == TransactionType.WithdrawRejected);
+    repo.StatusWrites.Should().ContainSingle(s => s.Status == WithdrawStatus.Rejected);
+  }
+
+  [Fact]
+  public async Task ForceComplete_from_manual_intervention_with_confirmation_completes()
+  {
+    var w = WithdrawalWith(
+      WithdrawStatus.RequireManualIntervention,
+      new WithdrawalPayout { ConfirmationNumber = "transfer-9", Fee = Fee, Attempt = 1 }
+    );
+    var (service, repo, wallet, txn, _) = Make(w);
+
+    var result = await service.ForceCompletePayout(w.Principal.Id, "admin-1");
+
+    result.IsSuccess().Should().BeTrue();
+    wallet.LastWithdrawAmount.Should().Be(Amount);
+    txn.Records.Should().HaveCount(2);
+    repo.StatusWrites.Should().ContainSingle(s => s.Status == WithdrawStatus.Completed);
+  }
+
   // ---- Manual flows keep their guards ----
 
   [Theory]
@@ -596,6 +807,10 @@ public class WithdrawalServiceGuardTests
   {
     public List<PayoutRequest> Requests { get; } = [];
 
+    // null = the lookup itself fails (transport error); otherwise returned
+    public PayoutStatus? LookupResult { get; set; }
+    public (string RequestId, string? ConfirmationNumber)? LastLookup { get; private set; }
+
     public Task<Result<PayoutConfirmation>> CreatePayout(PayoutRequest request)
     {
       Requests.Add(request);
@@ -607,6 +822,19 @@ public class WithdrawalServiceGuardTests
           _ => new PayoutConfirmation { Id = "transfer-1" },
         }
       );
+    }
+
+    public Task<Result<PayoutStatus>> GetPayoutStatus(
+      string requestId,
+      string? confirmationNumber
+    )
+    {
+      LastLookup = (requestId, confirmationNumber);
+      if (LookupResult == null)
+        return Task.FromResult<Result<PayoutStatus>>(
+          new HttpRequestException("lookup transport error")
+        );
+      return Task.FromResult<Result<PayoutStatus>>(LookupResult);
     }
   }
 


### PR DESCRIPTION
## Summary
Closes the last unattended failure mode of the automated payout pipeline: a Processing withdrawal that never hears back from Airwallex.

- **Reconcile** (`POST Withdrawal/{id}/reconcile`, AdminOrTin): looks the transfer up at Airwallex (by confirmation number, or request id when unconfirmed). Settled → completes via the same guarded path as the webhook; failed → back to Pending; inconclusive (in flight / not found / lookup error) → increments `ReconcileAttempts`.
- After **8 inconclusive sweeps** (~2 days at tin's 6-hourly cadence) the withdrawal parks in the new **RequireManualIntervention** status.
- **Admin resolutions**: force-complete (money left, verified at the gateway), reject (refund — no transfer exists), requeue (`POST {id}/requeue`, back to Pending; next approve mints a fresh request id).
- All transitions reuse the existing transactional guards — reconciliation itself never moves money, and racing webhooks/admins are never clobbered (conditional counter write).
- Migration: `ReconcileAttempts` column. 15 new tests (105 total).

Companion PRs: tin (6-hourly sweep), argon (RMI UI + deposit keypad).

## Test plan
105/105 unit tests; reviewed by adversarial money/concurrency + completion passes (both PASS).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added withdrawal reconciliation and requeue actions for admins.
  * Withdrawals can now enter a manual-intervention state after repeated reconciliation attempts.
  * Withdrawal payout details now show how many reconciliation attempts have been made.

* **Bug Fixes**
  * Improved payout status matching to better recognize settled and failed transfers.
  * Reconciliation can now look up transfer status more reliably, including by request reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->