### PR TITLE
feat(booking): sort by purchase and fulfilment instants

### DIFF
--- a/App/Modules/Bookings/API/V1/BookingMapper.cs
+++ b/App/Modules/Bookings/API/V1/BookingMapper.cs
@@ -129,6 +129,8 @@ public static class BookingMapper
       "Timing" => BookingSort.Timing,
       "PassengerName" => BookingSort.PassengerName,
       "PassportNumber" => BookingSort.PassportNumber,
+      "BuyTime" => BookingSort.BuyTime,
+      "FulfilTime" => BookingSort.FulfilTime,
       _ => throw new ArgumentOutOfRangeException(nameof(sort), sort, null),
     };
 }

--- a/App/Modules/Bookings/API/V1/BookingValidator.cs
+++ b/App/Modules/Bookings/API/V1/BookingValidator.cs
@@ -54,8 +54,10 @@ public class BookingSearchQueryValidator : AbstractValidator<SearchBookingQuery>
       .LessThanOrEqualTo(525600)
       .When(x => x.StuckForMinutes != null);
     this.RuleFor(x => x.SortBy)
-      .Must(x => x is "Timing" or "PassengerName" or "PassportNumber")
-      .WithMessage("SortBy must be one of: Timing, PassengerName, PassportNumber")
+      .Must(x => x is "Timing" or "PassengerName" or "PassportNumber" or "BuyTime" or "FulfilTime")
+      .WithMessage(
+        "SortBy must be one of: Timing, PassengerName, PassportNumber, BuyTime, FulfilTime"
+      )
       .When(x => x.SortBy != null);
     this.RuleFor(x => x.Limit).Limit();
     this.RuleFor(x => x.Skip).Skip();

--- a/App/Modules/Bookings/Data/BookingRepository.cs
+++ b/App/Modules/Bookings/Data/BookingRepository.cs
@@ -59,6 +59,13 @@ public class BookingRepository(
         BookingSort.PassportNumber => query
           .OrderBy(x => x.Passenger.PassportNumber)
           .ThenBy(x => x.Id),
+        // purchase instant, newest first
+        BookingSort.BuyTime => query.OrderByDescending(x => x.CreatedAt).ThenBy(x => x.Id),
+        // fulfilment instant, newest first; unfulfilled (null) bookings last
+        BookingSort.FulfilTime => query
+          .OrderBy(x => x.CompletedAt == null)
+          .ThenByDescending(x => x.CompletedAt)
+          .ThenBy(x => x.Id),
         _ => query.OrderByDescending(x => x.Date).ThenBy(x => x.Id),
       };
 

--- a/App/Modules/Passengers/API/V1/PassengerMapper.cs
+++ b/App/Modules/Passengers/API/V1/PassengerMapper.cs
@@ -11,6 +11,7 @@ public static class PassengerMapper
   public static PassengerPrincipalRes ToRes(this PassengerPrincipal p) =>
     new(
       p.Id,
+      p.UserId,
       p.Record.FullName,
       p.Record.Gender.ToRes(),
       p.Record.PassportExpiry.ToStandardDateFormat(),

--- a/App/Modules/Passengers/API/V1/PassengerModel.cs
+++ b/App/Modules/Passengers/API/V1/PassengerModel.cs
@@ -22,6 +22,7 @@ public record UpdatePassengerReq(
 // RESP
 public record PassengerPrincipalRes(
   Guid Id,
+  string UserId,
   string FullName,
   string Gender,
   string PassportExpiry,

--- a/Domain/Booking/Model.cs
+++ b/Domain/Booking/Model.cs
@@ -43,6 +43,12 @@ public enum BookingSort
   Timing = 0,
   PassengerName = 1,
   PassportNumber = 2,
+
+  // purchase instant (CreatedAt), newest first
+  BuyTime = 3,
+
+  // fulfilment instant (CompletedAt), newest first; unfulfilled bookings last
+  FulfilTime = 4,
 }
 
 public record BookingSearch


### PR DESCRIPTION
Adds `SortBy=BuyTime` (CreatedAt instant, newest first) and `SortBy=FulfilTime` (CompletedAt instant, newest first, unfulfilled last) to the booking search, with stable pagination tiebreakers. Companion argon PR adds the sort options to the bookings UI.

Test plan: 105/105 unit tests; validator whitelist extended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two new booking sort options for search results: purchase time (newest first) and fulfilment time.
* **Bug Fixes**
  * Expanded booking sort validation to accept the new options.
  * Improved fulfilment-time sorting so unfulfilled bookings appear last and results use stable tie-breaking.
* **API Changes**
  * Updated passenger principal responses to include `UserId` alongside existing passenger details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->