### PR TITLE
feat(withdrawal): admin-editable fee rate stored in the database

### DIFF
--- a/App/Migrations/20260709013828_AddFeeTable.Designer.cs
+++ b/App/Migrations/20260709013828_AddFeeTable.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using App.StartUp.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace App.Migrations
 {
     [DbContext(typeof(MainDbContext))]
-    partial class MainDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260709013828_AddFeeTable")]
+    partial class AddFeeTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/App/Migrations/20260709013828_AddFeeTable.cs
+++ b/App/Migrations/20260709013828_AddFeeTable.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace App.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFeeTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Costs",
+                keyColumn: "Id",
+                keyValue: new Guid("6b21363e-fff1-493b-8eb3-b73669df4fad"));
+
+            migrationBuilder.CreateTable(
+                name: "Fees",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    WithdrawFeePercentage = table.Column<decimal>(type: "numeric(16,8)", precision: 16, scale: 8, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Fees", x => x.Id);
+                });
+
+            migrationBuilder.InsertData(
+                table: "Costs",
+                columns: ["Id", "Cost", "CreatedAt"],
+                values: [new Guid("849829b6-3815-439f-a0d3-1bd72b9a9eaa"), 14m, new DateTime(2026, 7, 9, 1, 38, 27, 898, DateTimeKind.Utc).AddTicks(4410)]);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Fees");
+
+            migrationBuilder.DeleteData(
+                table: "Costs",
+                keyColumn: "Id",
+                keyValue: new Guid("849829b6-3815-439f-a0d3-1bd72b9a9eaa"));
+
+            migrationBuilder.InsertData(
+                table: "Costs",
+                columns: ["Id", "Cost", "CreatedAt"],
+                values: [new Guid("6b21363e-fff1-493b-8eb3-b73669df4fad"), 14m, new DateTime(2026, 7, 8, 20, 20, 56, 407, DateTimeKind.Utc).AddTicks(8010)]);
+        }
+    }
+}

--- a/App/Migrations/20260709014440_AddFeeEffectiveAt.Designer.cs
+++ b/App/Migrations/20260709014440_AddFeeEffectiveAt.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using App.StartUp.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace App.Migrations
 {
     [DbContext(typeof(MainDbContext))]
-    partial class MainDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260709014440_AddFeeEffectiveAt")]
+    partial class AddFeeEffectiveAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/App/Migrations/20260709014440_AddFeeEffectiveAt.cs
+++ b/App/Migrations/20260709014440_AddFeeEffectiveAt.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace App.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFeeEffectiveAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Costs",
+                keyColumn: "Id",
+                keyValue: new Guid("849829b6-3815-439f-a0d3-1bd72b9a9eaa"));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "EffectiveAt",
+                table: "Fees",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.InsertData(
+                table: "Costs",
+                columns: ["Id", "Cost", "CreatedAt"],
+                values: [new Guid("07beac74-bfcc-4bbd-b47c-4feb41d59bef"), 14m, new DateTime(2026, 7, 9, 1, 44, 40, 392, DateTimeKind.Utc).AddTicks(4820)]);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Costs",
+                keyColumn: "Id",
+                keyValue: new Guid("07beac74-bfcc-4bbd-b47c-4feb41d59bef"));
+
+            migrationBuilder.DropColumn(
+                name: "EffectiveAt",
+                table: "Fees");
+
+            migrationBuilder.InsertData(
+                table: "Costs",
+                columns: ["Id", "Cost", "CreatedAt"],
+                values: [new Guid("849829b6-3815-439f-a0d3-1bd72b9a9eaa"), 14m, new DateTime(2026, 7, 9, 1, 38, 27, 898, DateTimeKind.Utc).AddTicks(4410)]);
+        }
+    }
+}

--- a/App/Modules/Announcements/AnnouncementService.cs
+++ b/App/Modules/Announcements/AnnouncementService.cs
@@ -102,7 +102,10 @@ public class AnnouncementService(
   private async Task<Result<Unit>> Send(UserPrincipal user)
   {
     var o = options.CurrentValue;
-    var feePercent = (feeCalculator.WithdrawFeeRate * 100).ToString("0.##");
+    var rateR = await feeCalculator.WithdrawFeeRate();
+    if (rateR.IsFailure())
+      return rateR.FailureOrDefault();
+    var feePercent = (rateR.SuccessOrDefault() * 100).ToString("0.##");
     var smtpClient = smtpClientFactory.Get(SmtpProviders.Transactional);
     return await emailRenderer
       .RenderEmail(

--- a/App/Modules/DomainServices.cs
+++ b/App/Modules/DomainServices.cs
@@ -103,6 +103,8 @@ public static class DomainServices
 
     s.AddScoped<IFeeCalculator, FeeCalculator>().AutoTrace<IFeeCalculator>();
 
+    s.AddScoped<IFeeRepository, FeeRepository>().AutoTrace<IFeeRepository>();
+
     s.AddScoped<IPayoutGateway, AirwallexPayoutGateway>().AutoTrace<IPayoutGateway>();
 
     // Cost

--- a/App/Modules/Withdrawals/API/V1/WithdrawalController.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalController.cs
@@ -31,9 +31,26 @@ public class WithdrawalController(
 {
   // the withdrawal fee rate, e.g. 0.04 = 4%, for pre-submission display
   [Authorize, HttpGet("fee")]
-  public ActionResult<FeeRes> Fee()
+  public async Task<ActionResult<FeeRes>> Fee()
   {
-    return this.Ok(new FeeRes(feeCalculator.WithdrawFeeRate));
+    var x = await feeCalculator.WithdrawFeeRate().Then(r => new FeeRes(r), Errors.MapNone);
+    return this.ReturnResult(x);
+  }
+
+  // admin-set the live withdrawal fee percentage (insert-only history; the
+  // newest row wins immediately, no redeploy needed). 0 disables the fee.
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpPost("fee")]
+  public async Task<ActionResult<FeeRes>> SetFee(
+    [FromBody] SetFeeReq req,
+    [FromServices] SetFeeReqValidator setFeeReqValidator,
+    [FromServices] Domain.IFeeRepository feeRepository
+  )
+  {
+    var x = await setFeeReqValidator
+      .ValidateAsyncResult(req, "Invalid SetFeeReq")
+      .ThenAwait(r => feeRepository.SetPercentage(r.WithdrawFeePercentage))
+      .Then(p => new FeeRes(p / 100m), Errors.MapNone);
+    return this.ReturnResult(x);
   }
 
   [Authorize, HttpGet]

--- a/App/Modules/Withdrawals/API/V1/WithdrawalController.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalController.cs
@@ -37,10 +37,10 @@ public class WithdrawalController(
     return this.ReturnResult(x);
   }
 
-  // admin-set the live withdrawal fee percentage (insert-only history; the
-  // newest row wins immediately, no redeploy needed). 0 disables the fee.
+  // admin-set the withdrawal fee percentage (insert-only history). Takes
+  // effect at EffectiveAt (immediately when null); 0 disables the fee.
   [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpPost("fee")]
-  public async Task<ActionResult<FeeRes>> SetFee(
+  public async Task<ActionResult<FeeChangeRes>> SetFee(
     [FromBody] SetFeeReq req,
     [FromServices] SetFeeReqValidator setFeeReqValidator,
     [FromServices] Domain.IFeeRepository feeRepository
@@ -48,8 +48,23 @@ public class WithdrawalController(
   {
     var x = await setFeeReqValidator
       .ValidateAsyncResult(req, "Invalid SetFeeReq")
-      .ThenAwait(r => feeRepository.SetPercentage(r.WithdrawFeePercentage))
-      .Then(p => new FeeRes(p / 100m), Errors.MapNone);
+      .ThenAwait(r => feeRepository.SetPercentage(r.WithdrawFeePercentage, r.EffectiveAt))
+      .Then(c => new FeeChangeRes(c.Percentage, c.EffectiveAt), Errors.MapNone);
+    return this.ReturnResult(x);
+  }
+
+  // scheduled future fee changes, soonest first (for the admin editor)
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("fee/upcoming")]
+  public async Task<ActionResult<IEnumerable<FeeChangeRes>>> UpcomingFees(
+    [FromServices] Domain.IFeeRepository feeRepository
+  )
+  {
+    var x = await feeRepository
+      .GetUpcoming()
+      .Then(
+        cs => cs.Select(c => new FeeChangeRes(c.Percentage, c.EffectiveAt)),
+        Errors.MapNone
+      );
     return this.ReturnResult(x);
   }
 

--- a/App/Modules/Withdrawals/API/V1/WithdrawalModel.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalModel.cs
@@ -42,6 +42,8 @@ public record WithdrawalPrincipalRes(
 
 public record FeeRes(decimal WithdrawFeeRate);
 
+public record SetFeeReq(decimal WithdrawFeePercentage);
+
 public record WithdrawalRes(
   WithdrawalPrincipalRes Principal,
   UserPrincipalRes User,

--- a/App/Modules/Withdrawals/API/V1/WithdrawalModel.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalModel.cs
@@ -42,7 +42,10 @@ public record WithdrawalPrincipalRes(
 
 public record FeeRes(decimal WithdrawFeeRate);
 
-public record SetFeeReq(decimal WithdrawFeePercentage);
+// EffectiveAt: ISO-8601 UTC instant; null = immediate
+public record SetFeeReq(decimal WithdrawFeePercentage, DateTime? EffectiveAt);
+
+public record FeeChangeRes(decimal WithdrawFeePercentage, DateTime EffectiveAt);
 
 public record WithdrawalRes(
   WithdrawalPrincipalRes Principal,

--- a/App/Modules/Withdrawals/API/V1/WithdrawalValidator.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalValidator.cs
@@ -34,6 +34,12 @@ public class SetFeeReqValidator : AbstractValidator<SetFeeReq>
   public SetFeeReqValidator()
   {
     this.RuleFor(x => x.WithdrawFeePercentage).GreaterThanOrEqualTo(0).LessThanOrEqualTo(100);
+    // a past effective date would insert a row that can never win the
+    // newest-effective ordering — a silently dead change (small tolerance
+    // for clock skew; omit the field for an immediate change)
+    this.RuleFor(x => x.EffectiveAt)
+      .Must(x => x == null || x > DateTime.UtcNow.AddMinutes(-5))
+      .WithMessage("EffectiveAt must be in the future (omit it for an immediate change)");
   }
 }
 

--- a/App/Modules/Withdrawals/API/V1/WithdrawalValidator.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalValidator.cs
@@ -29,6 +29,14 @@ public class CreateWithdrawalReqValidator : AbstractValidator<CreateWithdrawalRe
   }
 }
 
+public class SetFeeReqValidator : AbstractValidator<SetFeeReq>
+{
+  public SetFeeReqValidator()
+  {
+    this.RuleFor(x => x.WithdrawFeePercentage).GreaterThanOrEqualTo(0).LessThanOrEqualTo(100);
+  }
+}
+
 public class CancelWithdrawalReqValidator : AbstractValidator<CancelWithdrawalReq>
 {
   public CancelWithdrawalReqValidator()

--- a/App/Modules/Withdrawals/Data/FeeData.cs
+++ b/App/Modules/Withdrawals/Data/FeeData.cs
@@ -12,6 +12,10 @@ public class FeeData
 
   public DateTime CreatedAt { get; set; }
 
+  // the instant this rate starts applying; a future date schedules the
+  // change, CreatedAt (the default) makes it immediate
+  public DateTime EffectiveAt { get; set; }
+
   // percent of the withdrawn amount, e.g. 4 = 4%
   [Precision(16, 8)]
   public decimal WithdrawFeePercentage { get; set; }

--- a/App/Modules/Withdrawals/Data/FeeData.cs
+++ b/App/Modules/Withdrawals/Data/FeeData.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace App.Modules.Withdrawals.Data;
+
+// Insert-only history of withdrawal fee rates; the newest row is the live
+// rate. When the table is empty the configured Domain:WithdrawFeePercentage
+// acts as the fallback, so deploys behave identically until an admin sets a
+// rate.
+public class FeeData
+{
+  public Guid Id { get; set; }
+
+  public DateTime CreatedAt { get; set; }
+
+  // percent of the withdrawn amount, e.g. 4 = 4%
+  [Precision(16, 8)]
+  public decimal WithdrawFeePercentage { get; set; }
+}

--- a/App/Modules/Withdrawals/Data/FeeRepository.cs
+++ b/App/Modules/Withdrawals/Data/FeeRepository.cs
@@ -11,8 +11,11 @@ public class FeeRepository(MainDbContext db, ILogger<FeeRepository> logger) : IF
   {
     try
     {
+      var now = DateTime.UtcNow;
       var latest = await db
-        .Fees.OrderByDescending(x => x.CreatedAt)
+        .Fees.Where(x => x.EffectiveAt <= now)
+        .OrderByDescending(x => x.EffectiveAt)
+        .ThenByDescending(x => x.CreatedAt)
         .ThenByDescending(x => x.Id)
         .FirstOrDefaultAsync();
       return latest?.WithdrawFeePercentage;
@@ -24,22 +27,53 @@ public class FeeRepository(MainDbContext db, ILogger<FeeRepository> logger) : IF
     }
   }
 
-  public async Task<Result<decimal>> SetPercentage(decimal percentage)
+  public async Task<Result<IEnumerable<FeeChange>>> GetUpcoming()
   {
     try
     {
+      var now = DateTime.UtcNow;
+      var upcoming = await db
+        .Fees.Where(x => x.EffectiveAt > now)
+        .OrderBy(x => x.EffectiveAt)
+        .ToArrayAsync();
+      return upcoming
+        .Select(x => new FeeChange
+        {
+          Percentage = x.WithdrawFeePercentage,
+          EffectiveAt = x.EffectiveAt,
+        })
+        .ToResult();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to read upcoming withdrawal fee changes");
+      return e;
+    }
+  }
+
+  public async Task<Result<FeeChange>> SetPercentage(decimal percentage, DateTime? effectiveAt)
+  {
+    try
+    {
+      var now = DateTime.UtcNow;
       logger.LogInformation(
-        "Setting withdrawal fee percentage to {Percentage}",
-        percentage
+        "Setting withdrawal fee percentage to {Percentage} effective {EffectiveAt}",
+        percentage,
+        effectiveAt ?? now
       );
       var data = new FeeData
       {
-        CreatedAt = DateTime.UtcNow,
+        CreatedAt = now,
+        EffectiveAt = effectiveAt ?? now,
         WithdrawFeePercentage = percentage,
       };
       db.Fees.Add(data);
       await db.SaveChangesAsync();
-      return data.WithdrawFeePercentage;
+      return new FeeChange
+      {
+        Percentage = data.WithdrawFeePercentage,
+        EffectiveAt = data.EffectiveAt,
+      };
     }
     catch (Exception e)
     {

--- a/App/Modules/Withdrawals/Data/FeeRepository.cs
+++ b/App/Modules/Withdrawals/Data/FeeRepository.cs
@@ -1,0 +1,50 @@
+using App.StartUp.Database;
+using CSharp_Result;
+using Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace App.Modules.Withdrawals.Data;
+
+public class FeeRepository(MainDbContext db, ILogger<FeeRepository> logger) : IFeeRepository
+{
+  public async Task<Result<decimal?>> GetLatestPercentage()
+  {
+    try
+    {
+      var latest = await db
+        .Fees.OrderByDescending(x => x.CreatedAt)
+        .ThenByDescending(x => x.Id)
+        .FirstOrDefaultAsync();
+      return latest?.WithdrawFeePercentage;
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to read the latest withdrawal fee percentage");
+      return e;
+    }
+  }
+
+  public async Task<Result<decimal>> SetPercentage(decimal percentage)
+  {
+    try
+    {
+      logger.LogInformation(
+        "Setting withdrawal fee percentage to {Percentage}",
+        percentage
+      );
+      var data = new FeeData
+      {
+        CreatedAt = DateTime.UtcNow,
+        WithdrawFeePercentage = percentage,
+      };
+      db.Fees.Add(data);
+      await db.SaveChangesAsync();
+      return data.WithdrawFeePercentage;
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to set withdrawal fee percentage to {Percentage}", percentage);
+      return e;
+    }
+  }
+}

--- a/App/Modules/Withdrawals/FeeCalculator.cs
+++ b/App/Modules/Withdrawals/FeeCalculator.cs
@@ -1,18 +1,27 @@
 using App.StartUp.Options;
+using CSharp_Result;
 using Domain;
 using Microsoft.Extensions.Options;
 
 namespace App.Modules.Withdrawals;
 
-public class FeeCalculator(IOptions<DomainOptions> d) : IFeeCalculator
+public class FeeCalculator(IFeeRepository repo, IOptions<DomainOptions> d) : IFeeCalculator
 {
-  private decimal Nn => d.Value.WithdrawFeePercentage;
   private static decimal Dd => 100;
 
-  public decimal WithdrawFeeRate => this.Nn / Dd;
+  // the newest admin-set rate wins; the configured default applies while no
+  // admin has ever set one
+  public Task<Result<decimal>> WithdrawFeeRate()
+  {
+    return repo.GetLatestPercentage()
+      .Then(p => (p ?? d.Value.WithdrawFeePercentage) / Dd, Errors.MapNone);
+  }
 
   // Rounded to cents so the ledger, the payout and the user-visible numbers
   // always agree
-  public decimal WithdrawFee(decimal amount) =>
-    Math.Round(amount * this.WithdrawFeeRate, 2, MidpointRounding.ToEven);
+  public Task<Result<decimal>> WithdrawFee(decimal amount)
+  {
+    return this.WithdrawFeeRate()
+      .Then(rate => Math.Round(amount * rate, 2, MidpointRounding.ToEven), Errors.MapNone);
+  }
 }

--- a/App/StartUp/Database/MainDbContext.cs
+++ b/App/StartUp/Database/MainDbContext.cs
@@ -35,6 +35,8 @@ public class MainDbContext(
 
   public DbSet<WithdrawalData> Withdrawals { get; set; }
 
+  public DbSet<FeeData> Fees { get; set; }
+
   public DbSet<TransactionData> Transactions { get; set; }
 
   public DbSet<UserData> Users { get; set; }

--- a/Domain/IFeeCalculator.cs
+++ b/Domain/IFeeCalculator.cs
@@ -12,11 +12,24 @@ public interface IFeeCalculator
   Task<Result<decimal>> WithdrawFee(decimal amount);
 }
 
+// A fee rate change: the percentage and the instant it takes (or took) effect
+public record FeeChange
+{
+  public required decimal Percentage { get; init; }
+
+  public required DateTime EffectiveAt { get; init; }
+}
+
 // Admin mutation surface for the fee rate
 public interface IFeeRepository
 {
-  // newest rate, or null when no admin has ever set one
+  // the rate currently in effect (newest row whose EffectiveAt has passed),
+  // or null when no admin has ever set one
   Task<Result<decimal?>> GetLatestPercentage();
 
-  Task<Result<decimal>> SetPercentage(decimal percentage);
+  // rate changes scheduled in the future, soonest first
+  Task<Result<IEnumerable<FeeChange>>> GetUpcoming();
+
+  // effectiveAt null = immediate
+  Task<Result<FeeChange>> SetPercentage(decimal percentage, DateTime? effectiveAt);
 }

--- a/Domain/IFeeCalculator.cs
+++ b/Domain/IFeeCalculator.cs
@@ -1,8 +1,22 @@
+using CSharp_Result;
+
 namespace Domain;
 
+// The live withdrawal fee. Async because the rate is admin-editable at
+// runtime (stored as insert-only rows; the newest wins, with the configured
+// default as fallback while no row exists).
 public interface IFeeCalculator
 {
-  decimal WithdrawFeeRate { get; }
+  Task<Result<decimal>> WithdrawFeeRate();
 
-  decimal WithdrawFee(decimal amount);
+  Task<Result<decimal>> WithdrawFee(decimal amount);
+}
+
+// Admin mutation surface for the fee rate
+public interface IFeeRepository
+{
+  // newest rate, or null when no admin has ever set one
+  Task<Result<decimal?>> GetLatestPercentage();
+
+  Task<Result<decimal>> SetPercentage(decimal percentage);
 }

--- a/Domain/Withdrawal/Service.cs
+++ b/Domain/Withdrawal/Service.cs
@@ -156,14 +156,19 @@ public class WithdrawalService(
         repo.Get(id, null)
           .NullToError(id.ToString())
           .DoAwait(DoType.MapErrors, w => GuardStatus(w, WithdrawalOperations.Complete))
-          .ThenAwait(w =>
+          .ThenAwait(async w =>
           {
             // manual completion charges the same fee as the automated payout:
             // the admin pays out the net amount and the fee is collected into
             // the fee account, so both paths produce an identical ledger
-            var fee =
-              w.Principal.Payout?.Fee ?? feeCalculator.WithdrawFee(w.Principal.Record.Amount);
-            return CollectReserve(w, fee)
+            var feeR =
+              w.Principal.Payout != null
+                ? (Result<decimal>)w.Principal.Payout.Fee
+                : await feeCalculator.WithdrawFee(w.Principal.Record.Amount);
+            if (feeR.IsFailure())
+              return (Result<WithdrawalPrincipal>)feeR.FailureOrDefault();
+            var fee = feeR.SuccessOrDefault();
+            return await (CollectReserve(w, fee)
               .ThenAwait(_ => withdrawalStorage.Save(receipt))
               .ThenAwait(link =>
                 repo.Update(
@@ -186,7 +191,7 @@ public class WithdrawalService(
                     }
                   )
                   .NullToError(id.ToString())
-              );
+              ));
           })
     );
   }
@@ -220,24 +225,31 @@ public class WithdrawalService(
               );
               return Task.FromResult((Result<(Withdrawal, WithdrawalPayout, bool)>)r);
             }
-            var payout = redrive
-              ? w.Principal.Payout!
-              : new WithdrawalPayout
-              {
-                ConfirmationNumber = null,
-                Fee = feeCalculator.WithdrawFee(w.Principal.Record.Amount),
-                Attempt = (w.Principal.Payout?.Attempt ?? 0) + 1,
-              };
-            return repo.Update(
-                null,
-                id,
-                null,
-                new WithdrawalStatus { Status = WithdrawStatus.Processing },
-                null,
-                payout
-              )
-              .NullToError(id.ToString())
-              .Then(_ => (w, payout, redrive), Errors.MapNone);
+            var payoutR = redrive
+              ? Task.FromResult((Result<WithdrawalPayout>)w.Principal.Payout!)
+              : feeCalculator
+                .WithdrawFee(w.Principal.Record.Amount)
+                .Then(
+                  fee => new WithdrawalPayout
+                  {
+                    ConfirmationNumber = null,
+                    Fee = fee,
+                    Attempt = (w.Principal.Payout?.Attempt ?? 0) + 1,
+                  },
+                  Errors.MapNone
+                );
+            return payoutR.ThenAwait(payout =>
+              repo.Update(
+                  null,
+                  id,
+                  null,
+                  new WithdrawalStatus { Status = WithdrawStatus.Processing },
+                  null,
+                  payout
+                )
+                .NullToError(id.ToString())
+                .Then(_ => (w, payout, redrive), Errors.MapNone)
+            );
           })
     );
     if (claim.IsFailure())

--- a/Domain/Withdrawal/Service.cs
+++ b/Domain/Withdrawal/Service.cs
@@ -619,7 +619,9 @@ public class WithdrawalService(
   }
 
   // Collects the full reserved amount: net to BunnyBooker (paid out to the
-  // user) and fee to the withdrawal-fee account, as two ledger transactions
+  // user) and fee to the withdrawal-fee account, as two ledger transactions.
+  // A disabled fee (0) books only the payout: a "SGD 0.00 fee charged" row
+  // would contradict the fee being hidden everywhere else.
   private Task<Result<Withdrawal>> CollectReserve(Withdrawal w, decimal fee)
   {
     return walletRepo
@@ -631,11 +633,13 @@ public class WithdrawalService(
           generator.CompleteWithdrawalRequest(w.Principal.Record, fee)
         )
       )
-      .ThenAwait(_ =>
-        transactionRepository.Create(
-          w.Wallet.Id,
-          generator.WithdrawalFeeCharge(w.Principal.Record, fee)
-        )
+      .ThenAwait(t =>
+        fee > 0
+          ? transactionRepository.Create(
+            w.Wallet.Id,
+            generator.WithdrawalFeeCharge(w.Principal.Record, fee)
+          )
+          : Task.FromResult((Result<TransactionPrincipal>)t)
       )
       .Then(_ => w, Errors.MapNone);
   }

--- a/UnitTest/Withdrawals/FeeCalculatorTests.cs
+++ b/UnitTest/Withdrawals/FeeCalculatorTests.cs
@@ -56,7 +56,12 @@ public class FeeCalculatorTests
     public Task<Result<decimal?>> GetLatestPercentage() =>
       Task.FromResult<Result<decimal?>>(stored);
 
-    public Task<Result<decimal>> SetPercentage(decimal percentage) =>
-      Task.FromResult<Result<decimal>>(percentage);
+    public Task<Result<IEnumerable<FeeChange>>> GetUpcoming() =>
+      Task.FromResult<Result<IEnumerable<FeeChange>>>(Array.Empty<FeeChange>());
+
+    public Task<Result<FeeChange>> SetPercentage(decimal percentage, DateTime? effectiveAt) =>
+      Task.FromResult<Result<FeeChange>>(
+        new FeeChange { Percentage = percentage, EffectiveAt = effectiveAt ?? DateTime.UtcNow }
+      );
   }
 }

--- a/UnitTest/Withdrawals/FeeCalculatorTests.cs
+++ b/UnitTest/Withdrawals/FeeCalculatorTests.cs
@@ -1,0 +1,62 @@
+using App.Modules.Withdrawals;
+using App.StartUp.Options;
+using CSharp_Result;
+using Domain;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+
+namespace UnitTest.Withdrawals;
+
+// The withdrawal fee is admin-editable at runtime: the newest stored
+// percentage wins, and the configured default only applies while no admin has
+// ever set one. A stored 0 must genuinely disable the fee (not fall through
+// to the default).
+public class FeeCalculatorTests
+{
+  private static FeeCalculator Make(decimal? stored, decimal configured = 4m) =>
+    new(
+      new FakeFeeRepository(stored),
+      Options.Create(new DomainOptions { WithdrawFeePercentage = configured })
+    );
+
+  [Fact]
+  public async Task Stored_rate_wins_over_the_configured_default()
+  {
+    var rate = await Make(stored: 10m).WithdrawFeeRate();
+    rate.SuccessOrDefault().Should().Be(0.10m);
+  }
+
+  [Fact]
+  public async Task Configured_default_applies_while_no_rate_was_ever_set()
+  {
+    var rate = await Make(stored: null).WithdrawFeeRate();
+    rate.SuccessOrDefault().Should().Be(0.04m);
+  }
+
+  [Fact]
+  public async Task Stored_zero_disables_the_fee_instead_of_falling_back()
+  {
+    var rate = await Make(stored: 0m).WithdrawFeeRate();
+    rate.SuccessOrDefault().Should().Be(0m);
+
+    var fee = await Make(stored: 0m).WithdrawFee(123.45m);
+    fee.SuccessOrDefault().Should().Be(0m);
+  }
+
+  [Fact]
+  public async Task Fee_is_rounded_to_even_cents()
+  {
+    // 2.5% of $1.00 = $0.025 → banker's rounding gives $0.02
+    var fee = await Make(stored: 2.5m).WithdrawFee(1.00m);
+    fee.SuccessOrDefault().Should().Be(0.02m);
+  }
+
+  private sealed class FakeFeeRepository(decimal? stored) : IFeeRepository
+  {
+    public Task<Result<decimal?>> GetLatestPercentage() =>
+      Task.FromResult<Result<decimal?>>(stored);
+
+    public Task<Result<decimal>> SetPercentage(decimal percentage) =>
+      Task.FromResult<Result<decimal>>(percentage);
+  }
+}

--- a/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
@@ -412,6 +412,25 @@ public class WithdrawalServiceGuardTests
     wallet.WithdrawCalls.Should().Be(0);
   }
 
+  [Fact]
+  public async Task CompletePayout_with_disabled_fee_books_no_fee_transaction()
+  {
+    // fee 0 = disabled: the ledger must not carry a "SGD 0.00 fee charged"
+    // row that contradicts the fee being hidden everywhere else
+    var w = WithdrawalWith(
+      WithdrawStatus.Processing,
+      new WithdrawalPayout { ConfirmationNumber = "transfer-9", Fee = 0m, Attempt = 1 }
+    );
+    var (service, _, wallet, txn, _) = Make(w);
+
+    var result = await service.CompletePayout(w.Principal.Id, "transfer-9", 1);
+
+    result.IsSuccess().Should().BeTrue();
+    wallet.LastWithdrawAmount.Should().Be(Amount);
+    txn.Records.Should().ContainSingle(r => r.Type == TransactionType.WithdrawComplete);
+    txn.Records.Should().NotContain(r => r.Type == TransactionType.WithdrawFee);
+  }
+
   // ---- Webhook idempotency and attempt fencing ----
 
   [Fact]

--- a/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
@@ -783,10 +783,11 @@ public class WithdrawalServiceGuardTests
 
   private sealed class FourPercentFeeCalculator : IFeeCalculator
   {
-    public decimal WithdrawFeeRate => 0.04m;
+    public Task<Result<decimal>> WithdrawFeeRate() =>
+      Task.FromResult<Result<decimal>>(0.04m);
 
-    public decimal WithdrawFee(decimal amount) =>
-      Math.Round(amount * this.WithdrawFeeRate, 2, MidpointRounding.ToEven);
+    public Task<Result<decimal>> WithdrawFee(decimal amount) =>
+      Task.FromResult<Result<decimal>>(Math.Round(amount * 0.04m, 2, MidpointRounding.ToEven));
   }
 
   private sealed class FixedRefundCalculator : IRefundCalculator


### PR DESCRIPTION
The fee percentage moves from static config to an insert-only `Fees` table (newest row wins, config value as fallback while empty, stored 0 disables the fee). `POST Withdrawal/fee` (OnlyAdmin, 0-100) changes it at runtime — managed from argon's discounts admin segment (companion PR). `GET Withdrawal/fee` unchanged. IFeeCalculator is now async; fee snapshotting at approve/complete unchanged, so in-flight withdrawals keep the rate they were approved with.

Test plan: 109/109 unit tests incl. new calculator tests (stored wins / fallback / zero disables / banker's rounding).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable withdrawal fees with support for viewing the current fee and updating it through an admin-only action.
  * Withdrawal fee calculations now use the latest saved fee rate when available, with a fallback default.
* **Bug Fixes**
  * Improved fee handling so failures are reported cleanly instead of continuing with incomplete data.
  * Added validation to keep fee percentages within a valid 0–100 range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->