### PR TITLE
feat(fees): fee queue with flat+percentage for withdrawal and deposit

### DIFF
--- a/App/Config/schema.json
+++ b/App/Config/schema.json
@@ -116,7 +116,6 @@
       "additionalProperties": false,
       "required": [
         "RefundPercentage",
-        "WithdrawFeePercentage",
         "BaseUrl",
         "WhatsAppUrl",
         "TelegramUrl",
@@ -126,12 +125,6 @@
         "RefundPercentage": {
           "type": "integer",
           "format": "int32"
-        },
-        "WithdrawFeePercentage": {
-          "type": "number",
-          "format": "decimal",
-          "maximum": 100.0,
-          "minimum": 0.0
         },
         "BaseUrl": {
           "type": "string",

--- a/App/Config/settings.yaml
+++ b/App/Config/settings.yaml
@@ -7,7 +7,6 @@ Kestrel:
       Url: http://+:9002
 Domain:
   RefundPercentage: 50
-  WithdrawFeePercentage: 4
   BaseUrl: https://bunnybooker.com
   WhatsAppUrl: 'https://wa.me/6588178504'
   TelegramUrl: 'https://t.me/bunnybooker'

--- a/App/Migrations/20260709063058_GeneralizeFeeQueue.Designer.cs
+++ b/App/Migrations/20260709063058_GeneralizeFeeQueue.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using App.StartUp.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace App.Migrations
 {
     [DbContext(typeof(MainDbContext))]
-    partial class MainDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260709063058_GeneralizeFeeQueue")]
+    partial class GeneralizeFeeQueue
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/App/Migrations/20260709063058_GeneralizeFeeQueue.cs
+++ b/App/Migrations/20260709063058_GeneralizeFeeQueue.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace App.Migrations
+{
+    /// <inheritdoc />
+    public partial class GeneralizeFeeQueue : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Costs",
+                keyColumn: "Id",
+                keyValue: new Guid("07beac74-bfcc-4bbd-b47c-4feb41d59bef"));
+
+            migrationBuilder.RenameColumn(
+                name: "WithdrawFeePercentage",
+                table: "Fees",
+                newName: "Percentage");
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "FlatAmount",
+                table: "Fees",
+                type: "numeric(16,8)",
+                precision: 16,
+                scale: 8,
+                nullable: false,
+                defaultValue: 0m);
+
+            migrationBuilder.AddColumn<byte>(
+                name: "Type",
+                table: "Fees",
+                type: "smallint",
+                nullable: false,
+                defaultValue: (byte)0);
+
+            migrationBuilder.InsertData(
+                table: "Costs",
+                columns: new[] { "Id", "Cost", "CreatedAt" },
+                values: new object[] { new Guid("cdb9da3c-e2b0-4e95-bc42-ce5fa1a2b883"), 14m, new DateTime(2026, 7, 9, 6, 30, 57, 934, DateTimeKind.Utc).AddTicks(2790) });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Costs",
+                keyColumn: "Id",
+                keyValue: new Guid("cdb9da3c-e2b0-4e95-bc42-ce5fa1a2b883"));
+
+            migrationBuilder.DropColumn(
+                name: "FlatAmount",
+                table: "Fees");
+
+            migrationBuilder.DropColumn(
+                name: "Type",
+                table: "Fees");
+
+            migrationBuilder.RenameColumn(
+                name: "Percentage",
+                table: "Fees",
+                newName: "WithdrawFeePercentage");
+
+            migrationBuilder.InsertData(
+                table: "Costs",
+                columns: new[] { "Id", "Cost", "CreatedAt" },
+                values: new object[] { new Guid("07beac74-bfcc-4bbd-b47c-4feb41d59bef"), 14m, new DateTime(2026, 7, 9, 1, 44, 40, 392, DateTimeKind.Utc).AddTicks(4820) });
+        }
+    }
+}

--- a/App/Migrations/20260709065206_GeneralizeFeeQueue.Designer.cs
+++ b/App/Migrations/20260709065206_GeneralizeFeeQueue.Designer.cs
@@ -14,7 +14,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace App.Migrations
 {
     [DbContext(typeof(MainDbContext))]
-    [Migration("20260709063058_GeneralizeFeeQueue")]
+    [Migration("20260709065206_GeneralizeFeeQueue")]
     partial class GeneralizeFeeQueue
     {
         /// <inheritdoc />
@@ -131,9 +131,9 @@ namespace App.Migrations
                     b.HasData(
                         new
                         {
-                            Id = new Guid("cdb9da3c-e2b0-4e95-bc42-ce5fa1a2b883"),
+                            Id = new Guid("6dfd5a2b-37a0-4c65-9d05-1c8dbd5237a2"),
                             Cost = 14m,
-                            CreatedAt = new DateTime(2026, 7, 9, 6, 30, 57, 934, DateTimeKind.Utc).AddTicks(2790)
+                            CreatedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc)
                         });
                 });
 

--- a/App/Migrations/20260709065206_GeneralizeFeeQueue.cs
+++ b/App/Migrations/20260709065206_GeneralizeFeeQueue.cs
@@ -40,7 +40,7 @@ namespace App.Migrations
             migrationBuilder.InsertData(
                 table: "Costs",
                 columns: new[] { "Id", "Cost", "CreatedAt" },
-                values: new object[] { new Guid("cdb9da3c-e2b0-4e95-bc42-ce5fa1a2b883"), 14m, new DateTime(2026, 7, 9, 6, 30, 57, 934, DateTimeKind.Utc).AddTicks(2790) });
+                values: new object[] { new Guid("6dfd5a2b-37a0-4c65-9d05-1c8dbd5237a2"), 14m, new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc) });
         }
 
         /// <inheritdoc />
@@ -49,7 +49,7 @@ namespace App.Migrations
             migrationBuilder.DeleteData(
                 table: "Costs",
                 keyColumn: "Id",
-                keyValue: new Guid("cdb9da3c-e2b0-4e95-bc42-ce5fa1a2b883"));
+                keyValue: new Guid("6dfd5a2b-37a0-4c65-9d05-1c8dbd5237a2"));
 
             migrationBuilder.DropColumn(
                 name: "FlatAmount",

--- a/App/Migrations/MainDbContextModelSnapshot.cs
+++ b/App/Migrations/MainDbContextModelSnapshot.cs
@@ -128,9 +128,9 @@ namespace App.Migrations
                     b.HasData(
                         new
                         {
-                            Id = new Guid("cdb9da3c-e2b0-4e95-bc42-ce5fa1a2b883"),
+                            Id = new Guid("6dfd5a2b-37a0-4c65-9d05-1c8dbd5237a2"),
                             Cost = 14m,
-                            CreatedAt = new DateTime(2026, 7, 9, 6, 30, 57, 934, DateTimeKind.Utc).AddTicks(2790)
+                            CreatedAt = new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc)
                         });
                 });
 

--- a/App/Modules/Announcements/API/V1/AnnouncementController.cs
+++ b/App/Modules/Announcements/API/V1/AnnouncementController.cs
@@ -2,6 +2,7 @@ using System.Net.Mime;
 using App.Modules.Common;
 using App.StartUp.Registry;
 using App.StartUp.Services.Auth;
+using App.Utility;
 using Asp.Versioning;
 using CSharp_Result;
 using Microsoft.AspNetCore.Authorization;
@@ -13,23 +14,34 @@ namespace App.Modules.Announcements.API.V1;
 [ApiController]
 [Consumes(MediaTypeNames.Application.Json)]
 [Route("api/v{version:apiVersion}/[controller]")]
-public class AnnouncementController(IAnnouncementService service, IAuthHelper h)
-  : AtomiControllerBase(h)
+public class AnnouncementController(
+  IAnnouncementService service,
+  SendFeeAnnouncementReqValidator validator,
+  IAuthHelper h
+) : AtomiControllerBase(h)
 {
-  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpPost("withdrawal-fee/{userId}")]
-  public async Task<ActionResult<AnnouncementSentRes>> SendWithdrawalFee(string userId)
+  // send to ONE user — for testing the email before a broadcast
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpPost("fee/{userId}")]
+  public async Task<ActionResult<AnnouncementSentRes>> SendFee(
+    string userId,
+    [FromBody] SendFeeAnnouncementReq req
+  )
   {
-    var x = await service
-      .SendWithdrawalFeeAnnouncement(userId)
+    var x = await validator
+      .ValidateAsyncResult(req, "Invalid SendFeeAnnouncementReq")
+      .ThenAwait(r => service.SendFeeAnnouncement(userId, r.ToSpec()))
       .Then(u => u.ToSentRes(), Errors.MapNone);
     return this.ReturnResult(x);
   }
 
-  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpPost("withdrawal-fee")]
-  public async Task<ActionResult<AnnouncementBroadcastRes>> BroadcastWithdrawalFee()
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpPost("fee")]
+  public async Task<ActionResult<AnnouncementBroadcastRes>> BroadcastFee(
+    [FromBody] SendFeeAnnouncementReq req
+  )
   {
-    var x = await service
-      .BroadcastWithdrawalFeeAnnouncement()
+    var x = await validator
+      .ValidateAsyncResult(req, "Invalid SendFeeAnnouncementReq")
+      .ThenAwait(r => service.BroadcastFeeAnnouncement(r.ToSpec()))
       .Then(r => r.ToRes(), Errors.MapNone);
     return this.ReturnResult(x);
   }

--- a/App/Modules/Announcements/API/V1/AnnouncementMapper.cs
+++ b/App/Modules/Announcements/API/V1/AnnouncementMapper.cs
@@ -1,9 +1,18 @@
+using Domain;
 using Domain.User;
 
 namespace App.Modules.Announcements.API.V1;
 
 public static class AnnouncementMapper
 {
+  public static FeeAnnouncementSpec ToSpec(this SendFeeAnnouncementReq req) =>
+    new()
+    {
+      Type = Enum.Parse<FeeType>(req.Type, true),
+      ChangeId = req.ChangeId,
+      Reasoning = req.Reasoning,
+    };
+
   public static AnnouncementSentRes ToSentRes(this UserPrincipal user) =>
     new(user.Id, user.Record.Email ?? string.Empty);
 

--- a/App/Modules/Announcements/API/V1/AnnouncementModel.cs
+++ b/App/Modules/Announcements/API/V1/AnnouncementModel.cs
@@ -1,5 +1,11 @@
 namespace App.Modules.Announcements.API.V1;
 
+// REQ
+// Type: "Withdrawal" | "Deposit". ChangeId targets a specific queued fee
+// change (defaults to the next upcoming one, else the live fee). Reasoning
+// is the admin's customizable explanation of why the fee is changing.
+public record SendFeeAnnouncementReq(string Type, Guid? ChangeId, string? Reasoning);
+
 // RESP
 public record AnnouncementSentRes(string UserId, string Email);
 

--- a/App/Modules/Announcements/API/V1/AnnouncementValidator.cs
+++ b/App/Modules/Announcements/API/V1/AnnouncementValidator.cs
@@ -1,0 +1,15 @@
+using Domain;
+using FluentValidation;
+
+namespace App.Modules.Announcements.API.V1;
+
+public class SendFeeAnnouncementReqValidator : AbstractValidator<SendFeeAnnouncementReq>
+{
+  public SendFeeAnnouncementReqValidator()
+  {
+    this.RuleFor(x => x.Type)
+      .Must(x => Enum.TryParse<FeeType>(x, true, out _))
+      .WithMessage("Type must be 'Withdrawal' or 'Deposit'");
+    this.RuleFor(x => x.Reasoning).MaximumLength(4096);
+  }
+}

--- a/App/Modules/Announcements/AnnouncementService.cs
+++ b/App/Modules/Announcements/AnnouncementService.cs
@@ -20,14 +20,125 @@ public class AnnouncementService(
   IEmailRenderer emailRenderer,
   IOptionsMonitor<DomainOptions> options,
   IFeeCalculator feeCalculator,
+  IFeeRepository feeRepository,
   ILogger<AnnouncementService> logger
 ) : IAnnouncementService
 {
-  public async Task<Result<UserPrincipal>> SendWithdrawalFeeAnnouncement(string userId)
+  private const string DefaultReasoning =
+    "Recently, we've seen widespread abuse of our wallet system, with large sums being deposited "
+    + "and withdrawn purely to churn funds through the platform. This activity drives up costs "
+    + "for everyone and puts the smooth, reliable service you count on at risk. To protect the "
+    + "platform and the community of genuine travelers who use it, we're adjusting our fees.";
+
+  // The fully-composed email content, resolved ONCE per announcement (not per
+  // recipient) so a broadcast describes the same change to every user.
+  private record AnnouncementContent
+  {
+    public required string FeeKind { get; init; }
+
+    public required string Subject { get; init; }
+
+    public required string Reasoning { get; init; }
+
+    public required string ChangeLine { get; init; }
+
+    public required string DeductLine { get; init; }
+
+    public required string EffectiveLine { get; init; }
+  }
+
+  // What the announcement announces: the specific queued change when ChangeId
+  // is given, else the NEXT scheduled change of the type, else the live fee
+  // as an immediate change. Keeps the email in lockstep with what an admin
+  // just scheduled in the fee editor.
+  private async Task<Result<AnnouncementContent>> Resolve(FeeAnnouncementSpec spec)
+  {
+    decimal percentage,
+      flatAmount;
+    string? effectiveDate;
+
+    var upcomingR = await feeRepository.GetUpcoming(spec.Type);
+    if (upcomingR.IsFailure())
+      return upcomingR.FailureOrDefault();
+    var upcoming = upcomingR.SuccessOrDefault().ToArray();
+
+    if (spec.ChangeId is { } changeId)
+    {
+      var change = upcoming.FirstOrDefault(x => x.Id == changeId);
+      if (change == null)
+        return new EntityNotFound(
+          "Queued Fee Change Not Found",
+          typeof(FeeChange),
+          changeId.ToString()
+        ).ToException();
+      (percentage, flatAmount) = (change.Percentage, change.FlatAmount);
+      effectiveDate = FormatDate(change.EffectiveAt);
+    }
+    else if (upcoming.FirstOrDefault() is { } next)
+    {
+      (percentage, flatAmount) = (next.Percentage, next.FlatAmount);
+      effectiveDate = FormatDate(next.EffectiveAt);
+    }
+    else
+    {
+      var currentR = await feeCalculator.Current(spec.Type);
+      if (currentR.IsFailure())
+        return currentR.FailureOrDefault();
+      var current = currentR.SuccessOrDefault();
+      (percentage, flatAmount) = (current.Percentage, current.FlatAmount);
+      effectiveDate = null;
+    }
+
+    var kind = spec.Type == FeeType.Withdrawal ? "withdrawal" : "deposit";
+    var kindTitle = spec.Type == FeeType.Withdrawal ? "Withdrawal" : "Deposit";
+    var removal = percentage == 0 && flatAmount == 0;
+    var feeText = (Percentage: percentage, Flat: flatAmount) switch
+    {
+      { Percentage: > 0, Flat: > 0 } => $"{percentage:0.##}% + SGD {flatAmount:0.00}",
+      { Percentage: > 0 } => $"{percentage:0.##}%",
+      _ => $"SGD {flatAmount:0.00}",
+    };
+
+    return new AnnouncementContent
+    {
+      FeeKind = kind,
+      Subject = removal
+        ? $"BunnyBooker - Removing the {kindTitle} Fee"
+          + (effectiveDate == null ? "" : $" on {effectiveDate}")
+        : $"BunnyBooker - {kindTitle} Fee Update: {feeText}"
+          + (effectiveDate == null ? "" : $" from {effectiveDate}"),
+      Reasoning = string.IsNullOrWhiteSpace(spec.Reasoning)
+        ? DefaultReasoning
+        : spec.Reasoning.Trim(),
+      ChangeLine = removal
+        ? $"The {kind} fee is being removed — {kind}s will be free"
+        : $"A {feeText} fee will apply to all wallet {kind}s",
+      DeductLine = removal
+        ? $"No fee will be charged on {kind}s"
+        : spec.Type == FeeType.Withdrawal
+          ? "The fee is deducted from the withdrawn amount"
+          : "The fee is collected from the deposited amount",
+      EffectiveLine =
+        effectiveDate == null
+          ? "This change is effective immediately"
+          : $"This change takes effect on {effectiveDate}",
+    };
+  }
+
+  private static string FormatDate(DateTime utc) => utc.ToString("d MMMM yyyy, HH:mm 'UTC'");
+
+  public async Task<Result<UserPrincipal>> SendFeeAnnouncement(
+    string userId,
+    FeeAnnouncementSpec spec
+  )
   {
     try
     {
-      logger.LogInformation("Sending withdrawal fee announcement to user {UserId}", userId);
+      logger.LogInformation(
+        "Sending {Type} fee announcement to user {UserId}",
+        spec.Type,
+        userId
+      );
       var user = await db.Users.Where(x => x.Id == userId).FirstOrDefaultAsync();
       if (user == null)
         return new EntityNotFound("User Not Found", typeof(UserPrincipal), userId).ToException();
@@ -40,23 +151,41 @@ public class AnnouncementService(
           }
         ).ToException();
 
+      var contentR = await this.Resolve(spec);
+      if (contentR.IsFailure())
+        return contentR.FailureOrDefault();
+
       var principal = user.ToPrincipal();
-      return await this.Send(principal).Then(_ => principal, Errors.MapNone);
+      return await this.Send(principal, contentR.SuccessOrDefault())
+        .Then(_ => principal, Errors.MapNone);
     }
     catch (Exception e)
     {
-      logger.LogError(e, "Failed to send withdrawal fee announcement to user {UserId}", userId);
+      logger.LogError(
+        e,
+        "Failed to send {Type} fee announcement to user {UserId}",
+        spec.Type,
+        userId
+      );
       return e;
     }
   }
 
-  public async Task<Result<AnnouncementBroadcastResult>> BroadcastWithdrawalFeeAnnouncement()
+  public async Task<Result<AnnouncementBroadcastResult>> BroadcastFeeAnnouncement(
+    FeeAnnouncementSpec spec
+  )
   {
     try
     {
+      var contentR = await this.Resolve(spec);
+      if (contentR.IsFailure())
+        return contentR.FailureOrDefault();
+      var content = contentR.SuccessOrDefault();
+
       var users = await db.Users.Where(x => x.Email != null && x.Email != "").ToArrayAsync();
       logger.LogInformation(
-        "Broadcasting withdrawal fee announcement to {Count} users",
+        "Broadcasting {Type} fee announcement to {Count} users",
+        spec.Type,
         users.Length
       );
 
@@ -64,7 +193,7 @@ public class AnnouncementService(
       var failed = new List<string>();
       foreach (var user in users)
       {
-        var r = await this.Send(user.ToPrincipal());
+        var r = await this.Send(user.ToPrincipal(), content);
         if (r.IsSuccess())
         {
           sent++;
@@ -73,7 +202,8 @@ public class AnnouncementService(
         {
           logger.LogWarning(
             r.FailureOrDefault(),
-            "Failed to send withdrawal fee announcement to user {UserId}",
+            "Failed to send {Type} fee announcement to user {UserId}",
+            spec.Type,
             user.Id
           );
           failed.Add(user.Id);
@@ -81,7 +211,8 @@ public class AnnouncementService(
       }
 
       logger.LogInformation(
-        "Withdrawal fee announcement broadcast complete: {Sent} sent, {Failed} failed",
+        "{Type} fee announcement broadcast complete: {Sent} sent, {Failed} failed",
+        spec.Type,
         sent,
         failed.Count
       );
@@ -94,22 +225,18 @@ public class AnnouncementService(
     }
     catch (Exception e)
     {
-      logger.LogError(e, "Failed to broadcast withdrawal fee announcement");
+      logger.LogError(e, "Failed to broadcast {Type} fee announcement", spec.Type);
       return e;
     }
   }
 
-  private async Task<Result<Unit>> Send(UserPrincipal user)
+  private async Task<Result<Unit>> Send(UserPrincipal user, AnnouncementContent content)
   {
     var o = options.CurrentValue;
-    var rateR = await feeCalculator.WithdrawFeeRate();
-    if (rateR.IsFailure())
-      return rateR.FailureOrDefault();
-    var feePercent = (rateR.SuccessOrDefault() * 100).ToString("0.##");
     var smtpClient = smtpClientFactory.Get(SmtpProviders.Transactional);
     return await emailRenderer
       .RenderEmail(
-        "withdrawal-fee-announcement",
+        "fee-announcement",
         new
         {
           baseUrl = o.BaseUrl,
@@ -118,7 +245,11 @@ public class AnnouncementService(
           supportEmail = o.SupportEmail,
           userName = user.Record.Username.CapitalizeUsername(),
           userEmail = user.Record.Email,
-          feePercent,
+          feeKind = content.FeeKind,
+          reasoning = content.Reasoning,
+          changeLine = content.ChangeLine,
+          deductLine = content.DeductLine,
+          effectiveLine = content.EffectiveLine,
         }
       )
       .ThenAwait(
@@ -127,15 +258,12 @@ public class AnnouncementService(
           var smtpMessage = new SmtpEmailMessage
           {
             To = user.Record.Email!,
-            Subject = $"BunnyBooker - Introducing a {feePercent}% Withdrawal Fee",
+            Subject = content.Subject,
             Body = html,
             IsHtml = true,
           };
           // user id only: email addresses are PII and do not belong in logs
-          logger.LogInformation(
-            "Sending withdrawal fee announcement email to user {UserId}",
-            user.Id
-          );
+          logger.LogInformation("Sending fee announcement email to user {UserId}", user.Id);
           return await smtpClient.SendAsync(smtpMessage);
         },
         Errors.MapNone

--- a/App/Modules/Announcements/AnnouncementService.cs
+++ b/App/Modules/Announcements/AnnouncementService.cs
@@ -65,14 +65,29 @@ public class AnnouncementService(
     if (spec.ChangeId is { } changeId)
     {
       var change = upcoming.FirstOrDefault(x => x.Id == changeId);
-      if (change == null)
-        return new EntityNotFound(
-          "Queued Fee Change Not Found",
-          typeof(FeeChange),
-          changeId.ToString()
-        ).ToException();
-      (percentage, flatAmount) = (change.Percentage, change.FlatAmount);
-      effectiveDate = FormatDate(change.EffectiveAt);
+      if (change != null)
+      {
+        (percentage, flatAmount) = (change.Percentage, change.FlatAmount);
+        effectiveDate = FormatDate(change.EffectiveAt);
+      }
+      else
+      {
+        // an immediate change (or one that just took effect) is no longer in
+        // the queue — announce it as the live fee instead of 404ing the
+        // add-then-announce flow
+        var liveR = await feeRepository.GetCurrent(spec.Type);
+        if (liveR.IsFailure())
+          return liveR.FailureOrDefault();
+        var live = liveR.SuccessOrDefault();
+        if (live == null || live.Id != changeId)
+          return new EntityNotFound(
+            "Queued Fee Change Not Found",
+            typeof(FeeChange),
+            changeId.ToString()
+          ).ToException();
+        (percentage, flatAmount) = (live.Percentage, live.FlatAmount);
+        effectiveDate = null;
+      }
     }
     else if (upcoming.FirstOrDefault() is { } next)
     {

--- a/App/Modules/Announcements/IAnnouncementService.cs
+++ b/App/Modules/Announcements/IAnnouncementService.cs
@@ -1,4 +1,5 @@
 using CSharp_Result;
+using Domain;
 using Domain.User;
 
 namespace App.Modules.Announcements;
@@ -12,9 +13,22 @@ public record AnnouncementBroadcastResult
   public required string[] FailedUserIds { get; init; }
 }
 
+// What to announce: a specific queued fee change (ChangeId), else the next
+// upcoming change of the type, else the live fee as an immediate change.
+// Reasoning is the admin's own explanation of WHY the fee is changing; when
+// omitted the default anti-abuse copy is used.
+public record FeeAnnouncementSpec
+{
+  public required FeeType Type { get; init; }
+
+  public Guid? ChangeId { get; init; }
+
+  public string? Reasoning { get; init; }
+}
+
 public interface IAnnouncementService
 {
-  Task<Result<UserPrincipal>> SendWithdrawalFeeAnnouncement(string userId);
+  Task<Result<UserPrincipal>> SendFeeAnnouncement(string userId, FeeAnnouncementSpec spec);
 
-  Task<Result<AnnouncementBroadcastResult>> BroadcastWithdrawalFeeAnnouncement();
+  Task<Result<AnnouncementBroadcastResult>> BroadcastFeeAnnouncement(FeeAnnouncementSpec spec);
 }

--- a/App/Modules/Fees/API/V1/FeeController.cs
+++ b/App/Modules/Fees/API/V1/FeeController.cs
@@ -1,4 +1,5 @@
 using System.Net.Mime;
+using App.Error.V1;
 using App.Modules.Common;
 using App.StartUp.Registry;
 using App.StartUp.Services.Auth;
@@ -26,11 +27,23 @@ public class FeeController(
   IAuthHelper h
 ) : AtomiControllerBase(h)
 {
+  // enum route binding happily accepts any numeric ("/Fee/7") — reject
+  // anything that is not a defined fee type before it reaches storage
+  private static Result<FeeType> ValidType(FeeType type) =>
+    Enum.IsDefined(type)
+      ? type
+      : new ValidationError(
+        "Invalid fee type",
+        new Dictionary<string, string[]> { ["Type"] = ["Type must be 'Withdrawal' or 'Deposit'"] }
+      ).ToException();
+
   // the fee in effect right now, for pre-submission display
   [Authorize, HttpGet("{type}")]
   public async Task<ActionResult<FeeSpecRes>> Current(FeeType type)
   {
-    var x = await feeCalculator.Current(type).Then(s => s.ToRes(), Errors.MapNone);
+    var x = await Task.FromResult(ValidType(type))
+      .ThenAwait(t => feeCalculator.Current(t))
+      .Then(s => s.ToRes(), Errors.MapNone);
     return this.ReturnResult(x);
   }
 
@@ -38,8 +51,8 @@ public class FeeController(
   [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("{type}/upcoming")]
   public async Task<ActionResult<IEnumerable<FeeEventRes>>> Upcoming(FeeType type)
   {
-    var x = await feeRepository
-      .GetUpcoming(type)
+    var x = await Task.FromResult(ValidType(type))
+      .ThenAwait(t => feeRepository.GetUpcoming(t))
       .Then(cs => cs.Select(c => c.ToRes()), Errors.MapNone);
     return this.ReturnResult(x);
   }
@@ -48,8 +61,8 @@ public class FeeController(
   [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpPost("{type}")]
   public async Task<ActionResult<FeeEventRes>> Add(FeeType type, [FromBody] AddFeeReq req)
   {
-    var x = await addFeeReqValidator
-      .ValidateAsyncResult(req, "Invalid AddFeeReq")
+    var x = await Task.FromResult(ValidType(type))
+      .ThenAwait(_ => addFeeReqValidator.ValidateAsyncResult(req, "Invalid AddFeeReq"))
       .ThenAwait(r => feeRepository.Add(type, r.Percentage, r.FlatAmount, r.EffectiveAt))
       .Then(c => c.ToRes(), Errors.MapNone);
     return this.ReturnResult(x);

--- a/App/Modules/Fees/API/V1/FeeController.cs
+++ b/App/Modules/Fees/API/V1/FeeController.cs
@@ -1,0 +1,69 @@
+using System.Net.Mime;
+using App.Modules.Common;
+using App.StartUp.Registry;
+using App.StartUp.Services.Auth;
+using App.Utility;
+using Asp.Versioning;
+using CSharp_Result;
+using Domain;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace App.Modules.Fees.API.V1;
+
+// The fee queue: per fee type (Withdrawal | Deposit), an admin can queue
+// "on this date change to X" events (flat + percentage), see the queue, and
+// cancel events that have not yet taken effect. With no effective event the
+// fee is zero-zero.
+[ApiVersion(1.0)]
+[ApiController]
+[Consumes(MediaTypeNames.Application.Json)]
+[Route("api/v{version:apiVersion}/[controller]")]
+public class FeeController(
+  IFeeCalculator feeCalculator,
+  IFeeRepository feeRepository,
+  AddFeeReqValidator addFeeReqValidator,
+  IAuthHelper h
+) : AtomiControllerBase(h)
+{
+  // the fee in effect right now, for pre-submission display
+  [Authorize, HttpGet("{type}")]
+  public async Task<ActionResult<FeeSpecRes>> Current(FeeType type)
+  {
+    var x = await feeCalculator.Current(type).Then(s => s.ToRes(), Errors.MapNone);
+    return this.ReturnResult(x);
+  }
+
+  // the queue: scheduled future fee changes, soonest first
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("{type}/upcoming")]
+  public async Task<ActionResult<IEnumerable<FeeEventRes>>> Upcoming(FeeType type)
+  {
+    var x = await feeRepository
+      .GetUpcoming(type)
+      .Then(cs => cs.Select(c => c.ToRes()), Errors.MapNone);
+    return this.ReturnResult(x);
+  }
+
+  // queue a fee change (immediate when EffectiveAt is null)
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpPost("{type}")]
+  public async Task<ActionResult<FeeEventRes>> Add(FeeType type, [FromBody] AddFeeReq req)
+  {
+    var x = await addFeeReqValidator
+      .ValidateAsyncResult(req, "Invalid AddFeeReq")
+      .ThenAwait(r => feeRepository.Add(type, r.Percentage, r.FlatAmount, r.EffectiveAt))
+      .Then(c => c.ToRes(), Errors.MapNone);
+    return this.ReturnResult(x);
+  }
+
+  // cancel a QUEUED change — only events that have not yet taken effect can
+  // be removed; effective history is immutable
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpDelete("{id:guid}")]
+  public async Task<ActionResult<FeeEventRes>> Cancel(Guid id)
+  {
+    var x = await feeRepository
+      .CancelUpcoming(id)
+      .NullToError(id.ToString())
+      .Then(c => c.ToRes(), Errors.MapNone);
+    return this.ReturnResult(x);
+  }
+}

--- a/App/Modules/Fees/API/V1/FeeMapper.cs
+++ b/App/Modules/Fees/API/V1/FeeMapper.cs
@@ -1,0 +1,17 @@
+using Domain;
+
+namespace App.Modules.Fees.API.V1;
+
+public static class FeeApiMapper
+{
+  public static FeeSpecRes ToRes(this FeeSpec spec) => new(spec.Percentage, spec.FlatAmount);
+
+  public static FeeEventRes ToRes(this FeeChange change) =>
+    new(
+      change.Id,
+      change.Type.ToString(),
+      change.Percentage,
+      change.FlatAmount,
+      change.EffectiveAt
+    );
+}

--- a/App/Modules/Fees/API/V1/FeeModel.cs
+++ b/App/Modules/Fees/API/V1/FeeModel.cs
@@ -1,0 +1,19 @@
+namespace App.Modules.Fees.API.V1;
+
+// REQ
+// Queue a fee change: takes effect at EffectiveAt (immediately when null).
+// Percentage + FlatAmount both zero removes the fee.
+public record AddFeeReq(decimal Percentage, decimal FlatAmount, DateTime? EffectiveAt);
+
+// RESP
+// the fee in effect right now, for pre-submission display
+public record FeeSpecRes(decimal Percentage, decimal FlatAmount);
+
+// a queued (or just-created) fee change event
+public record FeeEventRes(
+  Guid Id,
+  string Type,
+  decimal Percentage,
+  decimal FlatAmount,
+  DateTime EffectiveAt
+);

--- a/App/Modules/Fees/API/V1/FeeValidator.cs
+++ b/App/Modules/Fees/API/V1/FeeValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+
+namespace App.Modules.Fees.API.V1;
+
+public class AddFeeReqValidator : AbstractValidator<AddFeeReq>
+{
+  public AddFeeReqValidator()
+  {
+    this.RuleFor(x => x.Percentage).GreaterThanOrEqualTo(0).LessThanOrEqualTo(100);
+    this.RuleFor(x => x.FlatAmount).GreaterThanOrEqualTo(0).LessThanOrEqualTo(10_000);
+    // a past effective date would insert a row that can never win the
+    // newest-effective ordering — a silently dead change (small tolerance
+    // for clock skew; omit the field for an immediate change)
+    this.RuleFor(x => x.EffectiveAt)
+      .Must(x => x == null || x > DateTime.UtcNow.AddMinutes(-5))
+      .WithMessage("EffectiveAt must be in the future (omit it for an immediate change)");
+  }
+}

--- a/App/Modules/Transactions/API/V1/TransactionMapper.cs
+++ b/App/Modules/Transactions/API/V1/TransactionMapper.cs
@@ -25,6 +25,7 @@ public static class TransactionMapper
       TransactionType.WithdrawRejected => TransactionTypes.WithdrawRejected,
       TransactionType.WithdrawCancelled => TransactionTypes.WithdrawCancelled,
       TransactionType.WithdrawFee => TransactionTypes.WithdrawFee,
+      TransactionType.DepositFee => TransactionTypes.DepositFee,
       _ => throw new ArgumentOutOfRangeException(nameof(type), type, null),
     };
 
@@ -61,6 +62,7 @@ public static class TransactionMapper
       TransactionTypes.WithdrawRejected => TransactionType.WithdrawRejected,
       TransactionTypes.WithdrawCancelled => TransactionType.WithdrawCancelled,
       TransactionTypes.WithdrawFee => TransactionType.WithdrawFee,
+      TransactionTypes.DepositFee => TransactionType.DepositFee,
       _ => throw new ArgumentOutOfRangeException(nameof(type), type, null),
     };
 

--- a/App/Modules/Withdrawals/API/V1/WithdrawalController.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalController.cs
@@ -29,42 +29,15 @@ public class WithdrawalController(
   IAuthHelper h
 ) : AtomiControllerBase(h)
 {
-  // the withdrawal fee rate, e.g. 0.04 = 4%, for pre-submission display
+  // DEPRECATED: kept only so already-deployed frontends keep working during
+  // rollout — use GET Fee/{type} instead, which also carries the flat
+  // component. Returns the percentage as a rate, e.g. 0.04 = 4%.
   [Authorize, HttpGet("fee")]
   public async Task<ActionResult<FeeRes>> Fee()
   {
-    var x = await feeCalculator.WithdrawFeeRate().Then(r => new FeeRes(r), Errors.MapNone);
-    return this.ReturnResult(x);
-  }
-
-  // admin-set the withdrawal fee percentage (insert-only history). Takes
-  // effect at EffectiveAt (immediately when null); 0 disables the fee.
-  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpPost("fee")]
-  public async Task<ActionResult<FeeChangeRes>> SetFee(
-    [FromBody] SetFeeReq req,
-    [FromServices] SetFeeReqValidator setFeeReqValidator,
-    [FromServices] Domain.IFeeRepository feeRepository
-  )
-  {
-    var x = await setFeeReqValidator
-      .ValidateAsyncResult(req, "Invalid SetFeeReq")
-      .ThenAwait(r => feeRepository.SetPercentage(r.WithdrawFeePercentage, r.EffectiveAt))
-      .Then(c => new FeeChangeRes(c.Percentage, c.EffectiveAt), Errors.MapNone);
-    return this.ReturnResult(x);
-  }
-
-  // scheduled future fee changes, soonest first (for the admin editor)
-  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("fee/upcoming")]
-  public async Task<ActionResult<IEnumerable<FeeChangeRes>>> UpcomingFees(
-    [FromServices] Domain.IFeeRepository feeRepository
-  )
-  {
-    var x = await feeRepository
-      .GetUpcoming()
-      .Then(
-        cs => cs.Select(c => new FeeChangeRes(c.Percentage, c.EffectiveAt)),
-        Errors.MapNone
-      );
+    var x = await feeCalculator
+      .Current(FeeType.Withdrawal)
+      .Then(s => new FeeRes(s.Percentage / 100m), Errors.MapNone);
     return this.ReturnResult(x);
   }
 

--- a/App/Modules/Withdrawals/API/V1/WithdrawalModel.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalModel.cs
@@ -40,12 +40,9 @@ public record WithdrawalPrincipalRes(
   WithdrawalPayoutRes? Payout
 );
 
+// DEPRECATED: rollout-compat shape for GET Withdrawal/fee — use the Fee
+// controller's FeeSpecRes instead, which also carries the flat component
 public record FeeRes(decimal WithdrawFeeRate);
-
-// EffectiveAt: ISO-8601 UTC instant; null = immediate
-public record SetFeeReq(decimal WithdrawFeePercentage, DateTime? EffectiveAt);
-
-public record FeeChangeRes(decimal WithdrawFeePercentage, DateTime EffectiveAt);
 
 public record WithdrawalRes(
   WithdrawalPrincipalRes Principal,

--- a/App/Modules/Withdrawals/API/V1/WithdrawalValidator.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalValidator.cs
@@ -29,20 +29,6 @@ public class CreateWithdrawalReqValidator : AbstractValidator<CreateWithdrawalRe
   }
 }
 
-public class SetFeeReqValidator : AbstractValidator<SetFeeReq>
-{
-  public SetFeeReqValidator()
-  {
-    this.RuleFor(x => x.WithdrawFeePercentage).GreaterThanOrEqualTo(0).LessThanOrEqualTo(100);
-    // a past effective date would insert a row that can never win the
-    // newest-effective ordering — a silently dead change (small tolerance
-    // for clock skew; omit the field for an immediate change)
-    this.RuleFor(x => x.EffectiveAt)
-      .Must(x => x == null || x > DateTime.UtcNow.AddMinutes(-5))
-      .WithMessage("EffectiveAt must be in the future (omit it for an immediate change)");
-  }
-}
-
 public class CancelWithdrawalReqValidator : AbstractValidator<CancelWithdrawalReq>
 {
   public CancelWithdrawalReqValidator()

--- a/App/Modules/Withdrawals/Data/FeeData.cs
+++ b/App/Modules/Withdrawals/Data/FeeData.cs
@@ -2,21 +2,27 @@ using Microsoft.EntityFrameworkCore;
 
 namespace App.Modules.Withdrawals.Data;
 
-// Insert-only history of withdrawal fee rates; the newest row is the live
-// rate. When the table is empty the configured Domain:WithdrawFeePercentage
-// acts as the fallback, so deploys behave identically until an admin sets a
-// rate.
+// Insert-only queue of fee change events per fee type; the newest row whose
+// EffectiveAt has passed is the live fee, future rows are the queue. With no
+// effective row the fee is zero-zero — no fee exists until an admin adds one.
 public class FeeData
 {
   public Guid Id { get; set; }
 
   public DateTime CreatedAt { get; set; }
 
-  // the instant this rate starts applying; a future date schedules the
-  // change, CreatedAt (the default) makes it immediate
+  // the instant this change starts applying; a future date queues it,
+  // CreatedAt (the default) makes it immediate
   public DateTime EffectiveAt { get; set; }
 
-  // percent of the withdrawn amount, e.g. 4 = 4%
+  // Domain.FeeType: 0 = Withdrawal, 1 = Deposit
+  public byte Type { get; set; }
+
+  // percent of the amount, e.g. 4 = 4%
   [Precision(16, 8)]
-  public decimal WithdrawFeePercentage { get; set; }
+  public decimal Percentage { get; set; }
+
+  // flat SGD component added on top of the percentage
+  [Precision(16, 8)]
+  public decimal FlatAmount { get; set; }
 }

--- a/App/Modules/Withdrawals/Data/FeeRepository.cs
+++ b/App/Modules/Withdrawals/Data/FeeRepository.cs
@@ -7,78 +7,112 @@ namespace App.Modules.Withdrawals.Data;
 
 public class FeeRepository(MainDbContext db, ILogger<FeeRepository> logger) : IFeeRepository
 {
-  public async Task<Result<decimal?>> GetLatestPercentage()
+  public async Task<Result<FeeChange?>> GetCurrent(FeeType type)
   {
     try
     {
       var now = DateTime.UtcNow;
       var latest = await db
-        .Fees.Where(x => x.EffectiveAt <= now)
+        .Fees.Where(x => x.Type == (byte)type && x.EffectiveAt <= now)
         .OrderByDescending(x => x.EffectiveAt)
         .ThenByDescending(x => x.CreatedAt)
         .ThenByDescending(x => x.Id)
         .FirstOrDefaultAsync();
-      return latest?.WithdrawFeePercentage;
+      return latest?.ToChange();
     }
     catch (Exception e)
     {
-      logger.LogError(e, "Failed to read the latest withdrawal fee percentage");
+      logger.LogError(e, "Failed to read the current {Type} fee", type);
       return e;
     }
   }
 
-  public async Task<Result<IEnumerable<FeeChange>>> GetUpcoming()
+  public async Task<Result<IEnumerable<FeeChange>>> GetUpcoming(FeeType type)
   {
     try
     {
       var now = DateTime.UtcNow;
       var upcoming = await db
-        .Fees.Where(x => x.EffectiveAt > now)
+        .Fees.Where(x => x.Type == (byte)type && x.EffectiveAt > now)
         .OrderBy(x => x.EffectiveAt)
         .ToArrayAsync();
-      return upcoming
-        .Select(x => new FeeChange
-        {
-          Percentage = x.WithdrawFeePercentage,
-          EffectiveAt = x.EffectiveAt,
-        })
-        .ToResult();
+      return upcoming.Select(x => x.ToChange()).ToResult();
     }
     catch (Exception e)
     {
-      logger.LogError(e, "Failed to read upcoming withdrawal fee changes");
+      logger.LogError(e, "Failed to read upcoming {Type} fee changes", type);
       return e;
     }
   }
 
-  public async Task<Result<FeeChange>> SetPercentage(decimal percentage, DateTime? effectiveAt)
+  public async Task<Result<FeeChange>> Add(
+    FeeType type,
+    decimal percentage,
+    decimal flatAmount,
+    DateTime? effectiveAt
+  )
   {
     try
     {
       var now = DateTime.UtcNow;
       logger.LogInformation(
-        "Setting withdrawal fee percentage to {Percentage} effective {EffectiveAt}",
+        "Queueing {Type} fee change: {Percentage}% + {Flat} flat, effective {EffectiveAt}",
+        type,
         percentage,
+        flatAmount,
         effectiveAt ?? now
       );
       var data = new FeeData
       {
         CreatedAt = now,
         EffectiveAt = effectiveAt ?? now,
-        WithdrawFeePercentage = percentage,
+        Type = (byte)type,
+        Percentage = percentage,
+        FlatAmount = flatAmount,
       };
       db.Fees.Add(data);
       await db.SaveChangesAsync();
-      return new FeeChange
-      {
-        Percentage = data.WithdrawFeePercentage,
-        EffectiveAt = data.EffectiveAt,
-      };
+      return data.ToChange();
     }
     catch (Exception e)
     {
-      logger.LogError(e, "Failed to set withdrawal fee percentage to {Percentage}", percentage);
+      logger.LogError(e, "Failed to queue {Type} fee change", type);
       return e;
     }
   }
+
+  public async Task<Result<FeeChange?>> CancelUpcoming(Guid id)
+  {
+    try
+    {
+      var now = DateTime.UtcNow;
+      var row = await db
+        .Fees.Where(x => x.Id == id && x.EffectiveAt > now)
+        .FirstOrDefaultAsync();
+      if (row == null)
+        return (FeeChange?)null;
+      logger.LogInformation("Cancelling queued fee change '{Id}'", id);
+      db.Fees.Remove(row);
+      await db.SaveChangesAsync();
+      return row.ToChange();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to cancel queued fee change '{Id}'", id);
+      return e;
+    }
+  }
+}
+
+public static class FeeMapper
+{
+  public static FeeChange ToChange(this FeeData data) =>
+    new()
+    {
+      Id = data.Id,
+      Type = (FeeType)data.Type,
+      Percentage = data.Percentage,
+      FlatAmount = data.FlatAmount,
+      EffectiveAt = data.EffectiveAt,
+    };
 }

--- a/App/Modules/Withdrawals/Data/FeeRepository.cs
+++ b/App/Modules/Withdrawals/Data/FeeRepository.cs
@@ -62,10 +62,19 @@ public class FeeRepository(MainDbContext db, ILogger<FeeRepository> logger) : IF
         flatAmount,
         effectiveAt ?? now
       );
+      // normalize to UTC: JSON without a Z suffix binds as Unspecified and
+      // an offset binds as Local — Npgsql rejects both for timestamptz
+      var effective = effectiveAt?.Kind switch
+      {
+        null => now,
+        DateTimeKind.Utc => effectiveAt.Value,
+        DateTimeKind.Local => effectiveAt.Value.ToUniversalTime(),
+        _ => DateTime.SpecifyKind(effectiveAt.Value, DateTimeKind.Utc),
+      };
       var data = new FeeData
       {
         CreatedAt = now,
-        EffectiveAt = effectiveAt ?? now,
+        EffectiveAt = effective,
         Type = (byte)type,
         Percentage = percentage,
         FlatAmount = flatAmount,

--- a/App/Modules/Withdrawals/FeeCalculator.cs
+++ b/App/Modules/Withdrawals/FeeCalculator.cs
@@ -1,27 +1,37 @@
-using App.StartUp.Options;
 using CSharp_Result;
 using Domain;
-using Microsoft.Extensions.Options;
 
 namespace App.Modules.Withdrawals;
 
-public class FeeCalculator(IFeeRepository repo, IOptions<DomainOptions> d) : IFeeCalculator
+public class FeeCalculator(IFeeRepository repo) : IFeeCalculator
 {
-  private static decimal Dd => 100;
-
-  // the newest admin-set rate wins; the configured default applies while no
-  // admin has ever set one
-  public Task<Result<decimal>> WithdrawFeeRate()
+  // no effective row = zero-zero: fees only exist once an admin queues one
+  public Task<Result<FeeSpec>> Current(FeeType type)
   {
-    return repo.GetLatestPercentage()
-      .Then(p => (p ?? d.Value.WithdrawFeePercentage) / Dd, Errors.MapNone);
+    return repo.GetCurrent(type)
+      .Then(
+        c =>
+          c == null
+            ? FeeSpec.None
+            : new FeeSpec { Percentage = c.Percentage, FlatAmount = c.FlatAmount },
+        Errors.MapNone
+      );
   }
 
-  // Rounded to cents so the ledger, the payout and the user-visible numbers
-  // always agree
-  public Task<Result<decimal>> WithdrawFee(decimal amount)
+  // Rounded to even cents so the ledger, the payout and the user-visible
+  // numbers always agree; capped at the amount so a fee can never exceed
+  // what is being moved (e.g. a flat fee on a tiny amount)
+  public Task<Result<decimal>> Compute(FeeType type, decimal amount)
   {
-    return this.WithdrawFeeRate()
-      .Then(rate => Math.Round(amount * rate, 2, MidpointRounding.ToEven), Errors.MapNone);
+    return this.Current(type)
+      .Then(
+        spec =>
+        {
+          var raw = spec.FlatAmount + (amount * spec.Percentage / 100m);
+          var fee = Math.Round(raw, 2, MidpointRounding.ToEven);
+          return Math.Clamp(fee, 0m, amount);
+        },
+        Errors.MapNone
+      );
   }
 }

--- a/App/Modules/Withdrawals/FeeCalculator.cs
+++ b/App/Modules/Withdrawals/FeeCalculator.cs
@@ -27,6 +27,10 @@ public class FeeCalculator(IFeeRepository repo) : IFeeCalculator
       .Then(
         spec =>
         {
+          // degenerate amounts (zero/negative) can never carry a fee — and
+          // guarding here keeps Math.Clamp's min<=max contract intact
+          if (amount <= 0)
+            return 0m;
           var raw = spec.FlatAmount + (amount * spec.Percentage / 100m);
           var fee = Math.Round(raw, 2, MidpointRounding.ToEven);
           return Math.Clamp(fee, 0m, amount);

--- a/App/StartUp/Database/MainDbContext.cs
+++ b/App/StartUp/Database/MainDbContext.cs
@@ -125,11 +125,15 @@ public class MainDbContext(
 
     var cost = modelBuilder.Entity<CostData>();
     cost.HasIndex(x => x.CreatedAt).IsUnique();
+    // FIXED id + FIXED early timestamp: dynamic Guid.NewGuid()/UtcNow here
+    // made every migration delete and re-insert this seed row with a fresh
+    // CreatedAt — and since pricing is newest-CreatedAt-wins, each deploy
+    // could silently revert an admin-set cost back to the seed value
     cost.HasData(
       new CostData
       {
-        Id = Guid.NewGuid(),
-        CreatedAt = DateTime.UtcNow,
+        Id = new Guid("6dfd5a2b-37a0-4c65-9d05-1c8dbd5237a2"),
+        CreatedAt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
         Cost = 14,
       }
     );

--- a/App/StartUp/Options/DomainOptions.cs
+++ b/App/StartUp/Options/DomainOptions.cs
@@ -9,11 +9,6 @@ public class DomainOptions
   [Required]
   public int RefundPercentage { get; set; } = 50;
 
-  // Withdrawal fee, in percent of the requested amount (deducted from the
-  // amount before payout), e.g. 4 = 4%
-  [Required, Range(0, 100)]
-  public decimal WithdrawFeePercentage { get; set; } = 4;
-
   [Required, Url]
   public string BaseUrl { get; set; } = string.Empty;
   

--- a/App/Templates/Email/emails/fee-announcement.tsx
+++ b/App/Templates/Email/emails/fee-announcement.tsx
@@ -1,27 +1,44 @@
 import { Heading, Section, Text } from '@react-email/components';
 import { EmailLayout } from './lib/layout';
 
-interface WithdrawalFeeAnnouncementEmailProps {
+// Generalized fee announcement: works for withdrawal AND deposit fees,
+// flat + percentage, scheduled or immediate, introduction or removal.
+// The C# service composes the full sentences (changeLine/deductLine/
+// effectiveLine/reasoning) so this template needs no conditionals.
+interface FeeAnnouncementEmailProps {
   baseUrl: string;
   userName: string;
   userEmail: string;
   whatsappUrl: string;
   telegramUrl: string;
   supportEmail: string;
-  feePercent: string;
+  // "withdrawal" | "deposit"
+  feeKind: string;
+  // why the fee is changing — customizable by the admin sending it
+  reasoning: string;
+  // e.g. "A 4% + SGD 1.00 fee will apply to all wallet withdrawals"
+  changeLine: string;
+  // e.g. "The fee is deducted from the withdrawn amount"
+  deductLine: string;
+  // e.g. "This change is effective immediately" / "takes effect on ..."
+  effectiveLine: string;
 }
 
-export const WithdrawalFeeAnnouncementEmail = ({
+export const FeeAnnouncementEmail = ({
   baseUrl = '{{ baseUrl }}',
   whatsappUrl = '{{ whatsappUrl }}',
   telegramUrl = '{{ telegramUrl }}',
   supportEmail = '{{ supportEmail }}',
   userName = '{{ userName }}',
   userEmail = '{{ userEmail }}',
-  feePercent = '{{ feePercent }}',
-}: WithdrawalFeeAnnouncementEmailProps) => {
-  const subject = `Introducing a ${feePercent}% Withdrawal Fee`;
-  const previewText = `Hi ${userName}, an important update about wallet withdrawals on BunnyBooker.`;
+  feeKind = '{{ feeKind }}',
+  reasoning = '{{ reasoning }}',
+  changeLine = '{{ changeLine }}',
+  deductLine = '{{ deductLine }}',
+  effectiveLine = '{{ effectiveLine }}',
+}: FeeAnnouncementEmailProps) => {
+  const subject = `An Important Update on ${feeKind} fees`;
+  const previewText = `Hi ${userName}, an important update about your BunnyBooker wallet.`;
 
   return (
     <EmailLayout
@@ -43,7 +60,7 @@ export const WithdrawalFeeAnnouncementEmail = ({
           lineHeight: '1.2',
         }}
       >
-        An Important Update on Withdrawals, {userName}
+        An Important Update on your Wallet, {userName}
       </Heading>
 
       <Text
@@ -56,7 +73,7 @@ export const WithdrawalFeeAnnouncementEmail = ({
           fontWeight: '500',
         }}
       >
-        We're writing to let you know about a change to how withdrawals from your BunnyBooker wallet work. We don't make
+        We're writing to let you know about a change to the {feeKind} fees on your BunnyBooker wallet. We don't make
         changes like this lightly, and we want to be upfront about why.
       </Text>
 
@@ -70,10 +87,7 @@ export const WithdrawalFeeAnnouncementEmail = ({
           fontWeight: '500',
         }}
       >
-        Recently, we've seen widespread abuse of our wallet system, with large sums being deposited and withdrawn purely
-        to churn funds through the platform. This activity drives up costs for everyone and puts the smooth, reliable
-        service you count on at risk. To protect the platform and the community of genuine travelers who use it, we're
-        introducing a small fee on withdrawals.
+        {reasoning}
       </Text>
 
       <Section
@@ -105,10 +119,9 @@ export const WithdrawalFeeAnnouncementEmail = ({
             fontWeight: '500',
           }}
         >
-          • A <strong>{feePercent}% fee</strong> now applies to all wallet withdrawals
-          <br />• The fee is <strong>deducted from the withdrawn amount</strong>
-          <br />• <strong>Deposits remain completely free</strong>
-          <br />• This change is <strong>effective immediately</strong>
+          • <strong>{changeLine}</strong>
+          <br />• {deductLine}
+          <br />• {effectiveLine}
         </Text>
       </Section>
 
@@ -136,8 +149,8 @@ export const WithdrawalFeeAnnouncementEmail = ({
           fontWeight: '500',
         }}
       >
-        We're sorry for any inconvenience this causes, especially to those of you who have always used the wallet as
-        intended. This step is necessary to keep BunnyBooker sustainable and fair for everyone.
+        We're sorry for any inconvenience this causes. This step is necessary to keep BunnyBooker sustainable and fair
+        for everyone.
       </Text>
 
       <Text
@@ -158,14 +171,19 @@ export const WithdrawalFeeAnnouncementEmail = ({
 };
 
 // Preview props for development
-WithdrawalFeeAnnouncementEmail.PreviewProps = {
+FeeAnnouncementEmail.PreviewProps = {
   baseUrl: 'https://bunnybooker.com',
   telegramUrl: 'https://t.me/bunnybooker',
   whatsappUrl: 'https://wa.me/60123456789',
   supportEmail: 'support@bunnybooker.com',
   userName: 'John Doe',
   userEmail: 'john@example.com',
-  feePercent: '4',
-} as WithdrawalFeeAnnouncementEmailProps;
+  feeKind: 'withdrawal',
+  reasoning:
+    "Recently, we've seen widespread abuse of our wallet system, with large sums being deposited and withdrawn purely to churn funds through the platform. To protect the platform and the community of genuine travelers who use it, we're introducing a small fee on withdrawals.",
+  changeLine: 'A 4% + SGD 1.00 fee will apply to all wallet withdrawals',
+  deductLine: 'The fee is deducted from the withdrawn amount',
+  effectiveLine: 'This change takes effect on 1 August 2026, 00:00 UTC',
+} as FeeAnnouncementEmailProps;
 
-export default WithdrawalFeeAnnouncementEmail;
+export default FeeAnnouncementEmail;

--- a/App/Templates/Email/emails/index.ts
+++ b/App/Templates/Email/emails/index.ts
@@ -5,7 +5,7 @@ export { default as BookingTerminatedEmail } from './booking-terminated';
 export { default as BookingRefundedEmail } from './booking-refunded';
 export { default as BookingDuplicateEmail } from './booking-duplicate';
 export { default as BookingManualInterventionEmail } from './booking-manual-intervention';
-export { default as WithdrawalFeeAnnouncementEmail } from './withdrawal-fee-announcement';
+export { default as FeeAnnouncementEmail } from './fee-announcement';
 
 // Component library
 export * from './lib/header';

--- a/Domain/IFeeCalculator.cs
+++ b/Domain/IFeeCalculator.cs
@@ -2,34 +2,67 @@ using CSharp_Result;
 
 namespace Domain;
 
-// The live withdrawal fee. Async because the rate is admin-editable at
-// runtime (stored as insert-only rows; the newest wins, with the configured
-// default as fallback while no row exists).
-public interface IFeeCalculator
+public enum FeeType
 {
-  Task<Result<decimal>> WithdrawFeeRate();
-
-  Task<Result<decimal>> WithdrawFee(decimal amount);
+  Withdrawal = 0,
+  Deposit = 1,
 }
 
-// A fee rate change: the percentage and the instant it takes (or took) effect
-public record FeeChange
+// A fee specification: flat component plus a percentage of the amount.
+// Both default to zero — no fee exists until an admin queues one.
+public record FeeSpec
 {
   public required decimal Percentage { get; init; }
+
+  public required decimal FlatAmount { get; init; }
+
+  public static readonly FeeSpec None = new() { Percentage = 0m, FlatAmount = 0m };
+}
+
+// A queued (or past) fee change event
+public record FeeChange
+{
+  public required Guid Id { get; init; }
+
+  public required FeeType Type { get; init; }
+
+  public required decimal Percentage { get; init; }
+
+  public required decimal FlatAmount { get; init; }
 
   public required DateTime EffectiveAt { get; init; }
 }
 
-// Admin mutation surface for the fee rate
+// The live fee. Async because rates are admin-editable at runtime (an
+// insert-only queue of changes; the newest effective row wins, zero-zero
+// while the queue has no effective row).
+public interface IFeeCalculator
+{
+  Task<Result<FeeSpec>> Current(FeeType type);
+
+  // round-to-even cents of flat + percentage x amount, capped at the amount
+  // so a fee can never exceed what is being moved
+  Task<Result<decimal>> Compute(FeeType type, decimal amount);
+}
+
+// Admin mutation surface for the fee queue
 public interface IFeeRepository
 {
-  // the rate currently in effect (newest row whose EffectiveAt has passed),
-  // or null when no admin has ever set one
-  Task<Result<decimal?>> GetLatestPercentage();
+  // the change currently in effect for the type, or null when none ever was
+  Task<Result<FeeChange?>> GetCurrent(FeeType type);
 
-  // rate changes scheduled in the future, soonest first
-  Task<Result<IEnumerable<FeeChange>>> GetUpcoming();
+  // changes scheduled in the future for the type, soonest first
+  Task<Result<IEnumerable<FeeChange>>> GetUpcoming(FeeType type);
 
   // effectiveAt null = immediate
-  Task<Result<FeeChange>> SetPercentage(decimal percentage, DateTime? effectiveAt);
+  Task<Result<FeeChange>> Add(
+    FeeType type,
+    decimal percentage,
+    decimal flatAmount,
+    DateTime? effectiveAt
+  );
+
+  // cancel a QUEUED change (only rows still in the future may be removed —
+  // effective history is immutable); null when no such queued row exists
+  Task<Result<Domain.FeeChange?>> CancelUpcoming(Guid id);
 }

--- a/Domain/Payment/Service.cs
+++ b/Domain/Payment/Service.cs
@@ -29,12 +29,11 @@ public class PaymentService(
         return await walletRepo
           .Collect(x.Wallet.Id, fee)
           .NullToError(x.Wallet.Id.ToString())
+          // no paymentId here: Transactions.PaymentId is UNIQUE and the
+          // Deposit ledger row already claims it — linking the fee row too
+          // would violate the index and roll back every fee-charging deposit
           .ThenAwait(_ =>
-            transactionRepo.Create(
-              x.Wallet.Id,
-              generator.DepositFeeCharge(x.Principal, fee),
-              x.Principal.Reference.Id
-            )
+            transactionRepo.Create(x.Wallet.Id, generator.DepositFeeCharge(x.Principal, fee))
           )
           .Then(_ => x, Errors.MapNone);
       });

--- a/Domain/Payment/Service.cs
+++ b/Domain/Payment/Service.cs
@@ -10,9 +10,36 @@ public class PaymentService(
   IWalletRepository walletRepo,
   ITransactionRepository transactionRepo,
   ITransactionGenerator generator,
-  ITransactionManager transactionManager
+  ITransactionManager transactionManager,
+  IFeeCalculator feeCalculator
 ) : IPaymentService
 {
+  // The full captured amount is deposited first, then the deposit fee (if one
+  // is configured — the default is zero) is collected out of Usable into the
+  // fee account as its own ledger row. The fee is capped at the amount, so
+  // the collect can never overdraw what was just deposited.
+  private Task<Result<Payment>> ChargeDepositFee(Payment x)
+  {
+    return feeCalculator
+      .Compute(FeeType.Deposit, x.Principal.Record.CapturedAmount)
+      .ThenAwait(async fee =>
+      {
+        if (fee <= 0)
+          return (Result<Payment>)x;
+        return await walletRepo
+          .Collect(x.Wallet.Id, fee)
+          .NullToError(x.Wallet.Id.ToString())
+          .ThenAwait(_ =>
+            transactionRepo.Create(
+              x.Wallet.Id,
+              generator.DepositFeeCharge(x.Principal, fee),
+              x.Principal.Reference.Id
+            )
+          )
+          .Then(_ => x, Errors.MapNone);
+      });
+  }
+
   public Task<Result<IEnumerable<PaymentPrincipal>>> Search(PaymentSearch search)
   {
     return repo.Search(search);
@@ -78,6 +105,8 @@ public class PaymentService(
                 x.Principal.Reference.Id
               )
           )
+          // collect the deposit fee, when one is configured
+          .DoAwait(DoType.MapErrors, x => this.ChargeDepositFee(x))
     );
   }
 
@@ -107,6 +136,8 @@ public class PaymentService(
                 x.Principal.Reference.Id
               )
           )
+          // collect the deposit fee, when one is configured
+          .DoAwait(DoType.MapErrors, x => this.ChargeDepositFee(x))
     );
   }
 

--- a/Domain/Transaction/Accounts.cs
+++ b/Domain/Transaction/Accounts.cs
@@ -13,4 +13,5 @@ public static class Accounts
     "BUNNY_BOOKER_WITHDRAWAL_FEE",
     "BunnyBooker Withdrawal Fee"
   );
+  public static Account DepositFee = new("BUNNY_BOOKER_DEPOSIT_FEE", "BunnyBooker Deposit Fee");
 }

--- a/Domain/Transaction/Generator.cs
+++ b/Domain/Transaction/Generator.cs
@@ -37,6 +37,8 @@ public interface ITransactionGenerator
   public TransactionRecord RejectWithdrawalRequest(WithdrawalRecord record);
 
   public TransactionRecord Deposit(PaymentPrincipal principal);
+
+  public TransactionRecord DepositFeeCharge(PaymentPrincipal principal, decimal fee);
 }
 
 public class TransactionGenerator(IRefundCalculator calculator) : ITransactionGenerator
@@ -284,6 +286,22 @@ public class TransactionGenerator(IRefundCalculator calculator) : ITransactionGe
       Type = TransactionType.Deposit,
       From = Accounts.BunnyBooker.DisplayName,
       To = Accounts.Usable.DisplayName,
+    };
+  }
+
+  public TransactionRecord DepositFeeCharge(PaymentPrincipal principal, decimal fee)
+  {
+    var amount = principal.Record.CapturedAmount;
+    return new TransactionRecord
+    {
+      Name = "Deposit Fee",
+      Description =
+        $"A deposit fee of SGD {fee:0.00} has been charged on your deposit of "
+        + $"SGD {amount:0.00}. The fee has been collected from your Usable Account.",
+      Amount = fee,
+      Type = TransactionType.DepositFee,
+      From = Accounts.Usable.DisplayName,
+      To = Accounts.DepositFee.DisplayName,
     };
   }
 }

--- a/Domain/Transaction/Model.cs
+++ b/Domain/Transaction/Model.cs
@@ -19,6 +19,7 @@ public static class TransactionTypes
   public const string WithdrawRejected = "WithdrawRejected";
   public const string WithdrawCancelled = "WithdrawCancelled";
   public const string WithdrawFee = "WithdrawFee";
+  public const string DepositFee = "DepositFee";
 
   // Additional
   public const string Promotional = "Promotional";
@@ -40,6 +41,7 @@ public static class TransactionTypes
     Transfer,
     BookingDuplicate,
     WithdrawFee,
+    DepositFee,
   ];
 }
 
@@ -68,6 +70,7 @@ public enum TransactionType
 
   // Wallet Related (appended to preserve stored smallint values)
   WithdrawFee = 13,
+  DepositFee = 14,
 }
 
 public record TransactionSearch

--- a/Domain/Withdrawal/Service.cs
+++ b/Domain/Withdrawal/Service.cs
@@ -164,7 +164,7 @@ public class WithdrawalService(
             var feeR =
               w.Principal.Payout != null
                 ? (Result<decimal>)w.Principal.Payout.Fee
-                : await feeCalculator.WithdrawFee(w.Principal.Record.Amount);
+                : await feeCalculator.Compute(FeeType.Withdrawal, w.Principal.Record.Amount);
             if (feeR.IsFailure())
               return (Result<WithdrawalPrincipal>)feeR.FailureOrDefault();
             var fee = feeR.SuccessOrDefault();
@@ -228,7 +228,7 @@ public class WithdrawalService(
             var payoutR = redrive
               ? Task.FromResult((Result<WithdrawalPayout>)w.Principal.Payout!)
               : feeCalculator
-                .WithdrawFee(w.Principal.Record.Amount)
+                .Compute(FeeType.Withdrawal, w.Principal.Record.Amount)
                 .Then(
                   fee => new WithdrawalPayout
                   {

--- a/Domain/Withdrawal/Service.cs
+++ b/Domain/Withdrawal/Service.cs
@@ -168,6 +168,16 @@ public class WithdrawalService(
             if (feeR.IsFailure())
               return (Result<WithdrawalPrincipal>)feeR.FailureOrDefault();
             var fee = feeR.SuccessOrDefault();
+            // a flat fee can swallow a small withdrawal whole; paying out
+            // SGD 0 while collecting the full amount as fee is never right —
+            // the admin should reject the withdrawal instead
+            if (w.Principal.Payout == null && fee >= w.Principal.Record.Amount)
+              return (Result<WithdrawalPrincipal>)
+                new InvalidWithdrawalOperationException(
+                  $"The fee (SGD {fee:0.00}) equals or exceeds the withdrawal amount, leaving nothing to pay out — reject the withdrawal instead",
+                  w.Principal.Status.Status,
+                  WithdrawalOperations.Complete
+                );
             return await (CollectReserve(w, fee)
               .ThenAwait(_ => withdrawalStorage.Save(receipt))
               .ThenAwait(link =>
@@ -229,15 +239,28 @@ public class WithdrawalService(
               ? Task.FromResult((Result<WithdrawalPayout>)w.Principal.Payout!)
               : feeCalculator
                 .Compute(FeeType.Withdrawal, w.Principal.Record.Amount)
-                .Then(
-                  fee => new WithdrawalPayout
-                  {
-                    ConfirmationNumber = null,
-                    Fee = fee,
-                    Attempt = (w.Principal.Payout?.Attempt ?? 0) + 1,
-                  },
-                  Errors.MapNone
-                );
+                .ThenAwait(fee =>
+                {
+                  // a flat fee can swallow a small withdrawal whole; never
+                  // send a zero-net transfer to the gateway — the admin
+                  // should reject the withdrawal instead
+                  if (fee >= w.Principal.Record.Amount)
+                    return Task.FromResult<Result<WithdrawalPayout>>(
+                      new InvalidWithdrawalOperationException(
+                        $"The fee (SGD {fee:0.00}) equals or exceeds the withdrawal amount, leaving nothing to pay out — reject the withdrawal instead",
+                        status,
+                        WithdrawalOperations.Approve
+                      )
+                    );
+                  return Task.FromResult<Result<WithdrawalPayout>>(
+                    new WithdrawalPayout
+                    {
+                      ConfirmationNumber = null,
+                      Fee = fee,
+                      Attempt = (w.Principal.Payout?.Attempt ?? 0) + 1,
+                    }
+                  );
+                });
             return payoutR.ThenAwait(payout =>
               repo.Update(
                   null,

--- a/UnitTest/Payments/PaymentServiceDepositFeeTests.cs
+++ b/UnitTest/Payments/PaymentServiceDepositFeeTests.cs
@@ -1,0 +1,273 @@
+using System.Text.Json;
+using CSharp_Result;
+using Domain;
+using Domain.Payment;
+using Domain.Transaction;
+using Domain.Wallet;
+using FluentAssertions;
+
+namespace UnitTest.Payments;
+
+// Deposit completion must credit the FULL captured amount, then collect the
+// deposit fee (default zero — dormant until an admin queues one) out of
+// Usable into the fee account as its own ledger row. A zero fee must produce
+// NO fee ledger row and NO wallet collect.
+public class PaymentServiceDepositFeeTests
+{
+  private const decimal Captured = 100m;
+
+  private static (
+    PaymentService Service,
+    RecordingWalletRepository Wallet,
+    RecordingTransactionRepository Txn
+  ) Make(decimal percentage, decimal flat)
+  {
+    var wallet = new RecordingWalletRepository();
+    var txn = new RecordingTransactionRepository();
+    var service = new PaymentService(
+      new FakePaymentRepository(),
+      new UnusedPaymentGateway(),
+      wallet,
+      txn,
+      new TransactionGenerator(new FixedRefundCalculator()),
+      new PassThroughTransactionManager(),
+      new App.Modules.Withdrawals.FeeCalculator(new FixedFeeRepository(percentage, flat))
+    );
+    return (service, wallet, txn);
+  }
+
+  [Fact]
+  public async Task Zero_fee_deposits_full_amount_with_no_fee_row()
+  {
+    var (service, wallet, txn) = Make(percentage: 0m, flat: 0m);
+    var r = await service.CompleteById(Guid.NewGuid(), Record());
+    r.IsSuccess().Should().BeTrue();
+
+    wallet.Deposited.Should().Be(Captured);
+    wallet.Collected.Should().BeNull("a zero fee must not touch the wallet again");
+    txn.Created.Should().ContainSingle().Which.Type.Should().Be(TransactionType.Deposit);
+  }
+
+  [Fact]
+  public async Task Configured_fee_is_collected_as_its_own_ledger_row()
+  {
+    // 2% of $100 + $0.50 flat = $2.50
+    var (service, wallet, txn) = Make(percentage: 2m, flat: 0.50m);
+    var r = await service.CompleteById(Guid.NewGuid(), Record());
+    r.IsSuccess().Should().BeTrue();
+
+    wallet.Deposited.Should().Be(Captured, "the full captured amount is credited first");
+    wallet.Collected.Should().Be(2.50m);
+    txn.Created.Should().HaveCount(2);
+    txn.Created[0].Type.Should().Be(TransactionType.Deposit);
+    txn.Created[0].Amount.Should().Be(Captured);
+    txn.Created[1].Type.Should().Be(TransactionType.DepositFee);
+    txn.Created[1].Amount.Should().Be(2.50m);
+    txn.Created[1].To.Should().Be(Accounts.DepositFee.DisplayName);
+  }
+
+  // ---- fixtures ----
+
+  private static PaymentRecord Record() =>
+    new()
+    {
+      Amount = Captured,
+      CapturedAmount = Captured,
+      Currency = "SGD",
+      LastUpdated = DateTime.UtcNow,
+      Status = "succeeded",
+      AdditionalData = JsonDocument.Parse("{}"),
+    };
+
+  private static Payment PaymentWith(PaymentRecord record)
+  {
+    var walletId = Guid.NewGuid();
+    return new Payment
+    {
+      Transaction = null,
+      Principal = new PaymentPrincipal
+      {
+        Reference = new PaymentReference
+        {
+          Id = Guid.NewGuid(),
+          ExternalReference = "ext-ref",
+          Gateway = "Airwallex",
+        },
+        Record = record,
+        CreatedAt = DateTime.UtcNow,
+        Statuses = [],
+      },
+      Wallet = new WalletPrincipal
+      {
+        Id = walletId,
+        UserId = "user-1",
+        Record = new WalletRecord
+        {
+          Usable = 0m,
+          WithdrawReserve = 0m,
+          BookingReserve = 0m,
+        },
+      },
+    };
+  }
+
+  // ---- fakes ----
+
+  private sealed class FakePaymentRepository : IPaymentRepository
+  {
+    public Task<Result<IEnumerable<PaymentPrincipal>>> Search(PaymentSearch search) =>
+      throw new NotSupportedException();
+
+    public Task<Result<Payment?>> GetById(Guid id) => throw new NotSupportedException();
+
+    public Task<Result<Payment?>> GetByRef(string id) => throw new NotSupportedException();
+
+    public Task<Result<PaymentPrincipal>> Create(
+      Guid walletId,
+      PaymentReference r,
+      PaymentRecord record
+    ) => throw new NotSupportedException();
+
+    public Task<Result<Payment?>> UpdateById(Guid id, PaymentRecord record) =>
+      Task.FromResult<Result<Payment?>>(PaymentWith(record));
+
+    public Task<Result<Payment?>> UpdateByRef(string reference, PaymentRecord record) =>
+      Task.FromResult<Result<Payment?>>(PaymentWith(record));
+
+    public Task<Result<Unit?>> DeleteById(Guid id) => throw new NotSupportedException();
+
+    public Task<Result<Unit?>> DeleteByRef(string reference) => throw new NotSupportedException();
+  }
+
+  private sealed class UnusedPaymentGateway : IPaymentGateway
+  {
+    public Task<Result<(PaymentReference, PaymentRecord, PaymentSecret)>> Create(
+      Guid id,
+      decimal amount,
+      string currency
+    ) => throw new NotSupportedException();
+  }
+
+  private sealed class RecordingWalletRepository : IWalletRepository
+  {
+    public decimal? Deposited;
+    public decimal? Collected;
+
+    private static WalletPrincipal Principal(Guid id) =>
+      new()
+      {
+        Id = id,
+        UserId = "user-1",
+        Record = new WalletRecord
+        {
+          Usable = 1000m,
+          WithdrawReserve = 0m,
+          BookingReserve = 0m,
+        },
+      };
+
+    public Task<Result<WalletPrincipal?>> Deposit(Guid id, decimal amount)
+    {
+      this.Deposited = amount;
+      return Task.FromResult<Result<WalletPrincipal?>>(Principal(id));
+    }
+
+    public Task<Result<WalletPrincipal?>> Collect(Guid id, decimal amount)
+    {
+      this.Collected = amount;
+      return Task.FromResult<Result<WalletPrincipal?>>(Principal(id));
+    }
+
+    public Task<Result<IEnumerable<WalletPrincipal>>> Search(WalletSearch search) =>
+      throw new NotSupportedException();
+
+    public Task<Result<Wallet?>> Get(Guid id, string? userId) => throw new NotSupportedException();
+
+    public Task<Result<Wallet?>> GetByUserId(string userId) => throw new NotSupportedException();
+
+    public Task<Result<WalletPrincipal?>> PrepareWithdraw(Guid id, decimal amount) =>
+      throw new NotSupportedException();
+
+    public Task<Result<WalletPrincipal?>> Withdraw(Guid id, decimal amount) =>
+      throw new NotSupportedException();
+
+    public Task<Result<WalletPrincipal?>> CancelWithdraw(Guid id, decimal amount) =>
+      throw new NotSupportedException();
+
+    public Task<Result<WalletPrincipal?>> BookStart(Guid id, decimal amount) =>
+      throw new NotSupportedException();
+
+    public Task<Result<WalletPrincipal?>> BookEnd(Guid id, decimal revert, decimal collect) =>
+      throw new NotSupportedException();
+  }
+
+  private sealed class RecordingTransactionRepository : ITransactionRepository
+  {
+    public readonly List<TransactionRecord> Created = [];
+
+    public Task<Result<TransactionPrincipal>> Create(
+      Guid walletId,
+      TransactionRecord record,
+      Guid? paymentId = null
+    )
+    {
+      this.Created.Add(record);
+      return Task.FromResult<Result<TransactionPrincipal>>(
+        new TransactionPrincipal
+        {
+          Id = Guid.NewGuid(),
+          CreatedAt = DateTime.UtcNow,
+          Record = record,
+        }
+      );
+    }
+
+    public Task<Result<IEnumerable<TransactionPrincipal>>> Search(TransactionSearch search) =>
+      throw new NotSupportedException();
+
+    public Task<Result<Domain.Transaction.Transaction?>> Get(Guid id, string? userId) =>
+      throw new NotSupportedException();
+
+    public Task<Result<Unit?>> Delete(Guid id) => throw new NotSupportedException();
+  }
+
+  private sealed class FixedFeeRepository(decimal percentage, decimal flat) : IFeeRepository
+  {
+    public Task<Result<FeeChange?>> GetCurrent(FeeType type) =>
+      Task.FromResult<Result<FeeChange?>>(
+        type == FeeType.Deposit
+          ? new FeeChange
+          {
+            Id = Guid.NewGuid(),
+            Type = type,
+            Percentage = percentage,
+            FlatAmount = flat,
+            EffectiveAt = DateTime.UtcNow.AddDays(-1),
+          }
+          : null
+      );
+
+    public Task<Result<IEnumerable<FeeChange>>> GetUpcoming(FeeType type) =>
+      Task.FromResult<Result<IEnumerable<FeeChange>>>(Array.Empty<FeeChange>());
+
+    public Task<Result<FeeChange>> Add(
+      FeeType type,
+      decimal percentage2,
+      decimal flatAmount,
+      DateTime? effectiveAt
+    ) => throw new NotSupportedException();
+
+    public Task<Result<FeeChange?>> CancelUpcoming(Guid id) => throw new NotSupportedException();
+  }
+
+  private sealed class PassThroughTransactionManager : ITransactionManager
+  {
+    public Task<Result<T>> Start<T>(Func<Task<Result<T>>> func) => func();
+  }
+
+  private sealed class FixedRefundCalculator : IRefundCalculator
+  {
+    public decimal RefundRate => 0.5m;
+    public decimal PenaltyRate => 0.5m;
+  }
+}

--- a/UnitTest/Payments/PaymentServiceDepositFeeTests.cs
+++ b/UnitTest/Payments/PaymentServiceDepositFeeTests.cs
@@ -64,6 +64,10 @@ public class PaymentServiceDepositFeeTests
     txn.Created[1].Type.Should().Be(TransactionType.DepositFee);
     txn.Created[1].Amount.Should().Be(2.50m);
     txn.Created[1].To.Should().Be(Accounts.DepositFee.DisplayName);
+    // Transactions.PaymentId is UNIQUE and the Deposit row claims it — the
+    // fee row must NOT reuse it or every fee-charging deposit rolls back
+    txn.PaymentIds[0].Should().NotBeNull();
+    txn.PaymentIds[1].Should().BeNull();
   }
 
   // ---- fixtures ----
@@ -204,6 +208,7 @@ public class PaymentServiceDepositFeeTests
   private sealed class RecordingTransactionRepository : ITransactionRepository
   {
     public readonly List<TransactionRecord> Created = [];
+    public readonly List<Guid?> PaymentIds = [];
 
     public Task<Result<TransactionPrincipal>> Create(
       Guid walletId,
@@ -212,6 +217,7 @@ public class PaymentServiceDepositFeeTests
     )
     {
       this.Created.Add(record);
+      this.PaymentIds.Add(paymentId);
       return Task.FromResult<Result<TransactionPrincipal>>(
         new TransactionPrincipal
         {

--- a/UnitTest/Withdrawals/FeeCalculatorTests.cs
+++ b/UnitTest/Withdrawals/FeeCalculatorTests.cs
@@ -1,45 +1,72 @@
 using App.Modules.Withdrawals;
-using App.StartUp.Options;
 using CSharp_Result;
 using Domain;
 using FluentAssertions;
-using Microsoft.Extensions.Options;
 
 namespace UnitTest.Withdrawals;
 
-// The withdrawal fee is admin-editable at runtime: the newest stored
-// percentage wins, and the configured default only applies while no admin has
-// ever set one. A stored 0 must genuinely disable the fee (not fall through
-// to the default).
+// Fees are a per-type (Withdrawal | Deposit) queue of flat + percentage
+// change events. The newest effective event wins; with NO event the fee is
+// zero-zero — fees only exist once an admin queues one. The computed fee is
+// flat + pct x amount, rounded to even cents and capped at the amount.
 public class FeeCalculatorTests
 {
-  private static FeeCalculator Make(decimal? stored, decimal configured = 4m) =>
+  private static FeeCalculator Make(
+    FeeType type = FeeType.Withdrawal,
+    decimal? percentage = null,
+    decimal? flat = null
+  ) =>
     new(
-      new FakeFeeRepository(stored),
-      Options.Create(new DomainOptions { WithdrawFeePercentage = configured })
+      new FakeFeeRepository(
+        percentage == null && flat == null
+          ? null
+          : new FeeChange
+          {
+            Id = Guid.NewGuid(),
+            Type = type,
+            Percentage = percentage ?? 0m,
+            FlatAmount = flat ?? 0m,
+            EffectiveAt = DateTime.UtcNow.AddDays(-1),
+          }
+      )
     );
 
   [Fact]
-  public async Task Stored_rate_wins_over_the_configured_default()
+  public async Task No_stored_event_means_zero_zero()
   {
-    var rate = await Make(stored: 10m).WithdrawFeeRate();
-    rate.SuccessOrDefault().Should().Be(0.10m);
+    var spec = await Make().Current(FeeType.Withdrawal);
+    spec.SuccessOrDefault().Should().Be(FeeSpec.None);
+
+    var fee = await Make().Compute(FeeType.Withdrawal, 100m);
+    fee.SuccessOrDefault().Should().Be(0m);
   }
 
   [Fact]
-  public async Task Configured_default_applies_while_no_rate_was_ever_set()
+  public async Task Percentage_only_charges_pct_of_amount()
   {
-    var rate = await Make(stored: null).WithdrawFeeRate();
-    rate.SuccessOrDefault().Should().Be(0.04m);
+    var fee = await Make(percentage: 4m).Compute(FeeType.Withdrawal, 100m);
+    fee.SuccessOrDefault().Should().Be(4.00m);
   }
 
   [Fact]
-  public async Task Stored_zero_disables_the_fee_instead_of_falling_back()
+  public async Task Flat_only_charges_the_flat_amount()
   {
-    var rate = await Make(stored: 0m).WithdrawFeeRate();
-    rate.SuccessOrDefault().Should().Be(0m);
+    var fee = await Make(flat: 1.50m).Compute(FeeType.Withdrawal, 100m);
+    fee.SuccessOrDefault().Should().Be(1.50m);
+  }
 
-    var fee = await Make(stored: 0m).WithdrawFee(123.45m);
+  [Fact]
+  public async Task Flat_and_percentage_combine()
+  {
+    // 4% of $100 = $4.00, plus $1.50 flat = $5.50
+    var fee = await Make(percentage: 4m, flat: 1.50m).Compute(FeeType.Withdrawal, 100m);
+    fee.SuccessOrDefault().Should().Be(5.50m);
+  }
+
+  [Fact]
+  public async Task Stored_zero_zero_disables_the_fee()
+  {
+    var fee = await Make(percentage: 0m, flat: 0m).Compute(FeeType.Withdrawal, 123.45m);
     fee.SuccessOrDefault().Should().Be(0m);
   }
 
@@ -47,21 +74,52 @@ public class FeeCalculatorTests
   public async Task Fee_is_rounded_to_even_cents()
   {
     // 2.5% of $1.00 = $0.025 → banker's rounding gives $0.02
-    var fee = await Make(stored: 2.5m).WithdrawFee(1.00m);
+    var fee = await Make(percentage: 2.5m).Compute(FeeType.Withdrawal, 1.00m);
     fee.SuccessOrDefault().Should().Be(0.02m);
   }
 
-  private sealed class FakeFeeRepository(decimal? stored) : IFeeRepository
+  [Fact]
+  public async Task Fee_is_capped_at_the_amount()
   {
-    public Task<Result<decimal?>> GetLatestPercentage() =>
-      Task.FromResult<Result<decimal?>>(stored);
+    // a $5 flat fee on a $3 withdrawal must never exceed the $3 being moved
+    var fee = await Make(flat: 5m).Compute(FeeType.Withdrawal, 3m);
+    fee.SuccessOrDefault().Should().Be(3m);
+  }
 
-    public Task<Result<IEnumerable<FeeChange>>> GetUpcoming() =>
+  [Fact]
+  public async Task Deposit_fee_uses_the_deposit_type()
+  {
+    var calc = Make(type: FeeType.Deposit, percentage: 2m);
+    var fee = await calc.Compute(FeeType.Deposit, 50m);
+    fee.SuccessOrDefault().Should().Be(1.00m);
+  }
+
+  private sealed class FakeFeeRepository(FeeChange? current) : IFeeRepository
+  {
+    public Task<Result<FeeChange?>> GetCurrent(FeeType type) =>
+      Task.FromResult<Result<FeeChange?>>(current?.Type == type ? current : null);
+
+    public Task<Result<IEnumerable<FeeChange>>> GetUpcoming(FeeType type) =>
       Task.FromResult<Result<IEnumerable<FeeChange>>>(Array.Empty<FeeChange>());
 
-    public Task<Result<FeeChange>> SetPercentage(decimal percentage, DateTime? effectiveAt) =>
+    public Task<Result<FeeChange>> Add(
+      FeeType type,
+      decimal percentage,
+      decimal flatAmount,
+      DateTime? effectiveAt
+    ) =>
       Task.FromResult<Result<FeeChange>>(
-        new FeeChange { Percentage = percentage, EffectiveAt = effectiveAt ?? DateTime.UtcNow }
+        new FeeChange
+        {
+          Id = Guid.NewGuid(),
+          Type = type,
+          Percentage = percentage,
+          FlatAmount = flatAmount,
+          EffectiveAt = effectiveAt ?? DateTime.UtcNow,
+        }
       );
+
+    public Task<Result<FeeChange?>> CancelUpcoming(Guid id) =>
+      Task.FromResult<Result<FeeChange?>>((FeeChange?)null);
   }
 }

--- a/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
@@ -802,10 +802,10 @@ public class WithdrawalServiceGuardTests
 
   private sealed class FourPercentFeeCalculator : IFeeCalculator
   {
-    public Task<Result<decimal>> WithdrawFeeRate() =>
-      Task.FromResult<Result<decimal>>(0.04m);
+    public Task<Result<FeeSpec>> Current(FeeType type) =>
+      Task.FromResult<Result<FeeSpec>>(new FeeSpec { Percentage = 4m, FlatAmount = 0m });
 
-    public Task<Result<decimal>> WithdrawFee(decimal amount) =>
+    public Task<Result<decimal>> Compute(FeeType type, decimal amount) =>
       Task.FromResult<Result<decimal>>(Math.Round(amount * 0.04m, 2, MidpointRounding.ToEven));
   }
 

--- a/infra/api_chart/app/schema.json
+++ b/infra/api_chart/app/schema.json
@@ -116,7 +116,6 @@
       "additionalProperties": false,
       "required": [
         "RefundPercentage",
-        "WithdrawFeePercentage",
         "BaseUrl",
         "WhatsAppUrl",
         "TelegramUrl",
@@ -126,12 +125,6 @@
         "RefundPercentage": {
           "type": "integer",
           "format": "int32"
-        },
-        "WithdrawFeePercentage": {
-          "type": "number",
-          "format": "decimal",
-          "maximum": 100.0,
-          "minimum": 0.0
         },
         "BaseUrl": {
           "type": "string",

--- a/infra/api_chart/app/settings.yaml
+++ b/infra/api_chart/app/settings.yaml
@@ -7,7 +7,6 @@ Kestrel:
       Url: http://+:9002
 Domain:
   RefundPercentage: 50
-  WithdrawFeePercentage: 4
   BaseUrl: https://bunnybooker.com
   WhatsAppUrl: 'https://wa.me/6588178504'
   TelegramUrl: 'https://t.me/bunnybooker'

--- a/infra/migration_chart/app/schema.json
+++ b/infra/migration_chart/app/schema.json
@@ -116,7 +116,6 @@
       "additionalProperties": false,
       "required": [
         "RefundPercentage",
-        "WithdrawFeePercentage",
         "BaseUrl",
         "WhatsAppUrl",
         "TelegramUrl",
@@ -126,12 +125,6 @@
         "RefundPercentage": {
           "type": "integer",
           "format": "int32"
-        },
-        "WithdrawFeePercentage": {
-          "type": "number",
-          "format": "decimal",
-          "maximum": 100.0,
-          "minimum": 0.0
         },
         "BaseUrl": {
           "type": "string",

--- a/infra/migration_chart/app/settings.yaml
+++ b/infra/migration_chart/app/settings.yaml
@@ -7,7 +7,6 @@ Kestrel:
       Url: http://+:9002
 Domain:
   RefundPercentage: 50
-  WithdrawFeePercentage: 4
   BaseUrl: https://bunnybooker.com
   WhatsAppUrl: 'https://wa.me/6588178504'
   TelegramUrl: 'https://t.me/bunnybooker'


### PR DESCRIPTION
## What

Redesigns the fee engine into a managed **queue of scheduled fee-change events**, per fee type, with **flat + percentage** components — and extends fees to **deposits**.

### Fee engine
- `Fees` table generalized: `Type` (Withdrawal | Deposit), `Percentage`, `FlatAmount` (migration renames the old column — no data loss)
- Newest effective event wins; future events are the queue; queued events can be **cancelled** until they take effect
- **Default is 0% + $0**: the `Domain:WithdrawFeePercentage` config fallback is removed. No fee exists until an admin queues one
- Fee = `flat + pct × amount`, banker's-rounded to cents, **capped at the amount**

### New Fee API (`/api/v1/Fee`)
- `GET {type}` current fee (display) · `GET {type}/upcoming` the queue (admin)
- `POST {type}` queue a change (immediate when `effectiveAt` omitted) · `DELETE {id}` cancel a queued event
- `GET Withdrawal/fee` kept as deprecated rollout-compat; old admin fee endpoints removed

### Deposit fees
- Deposit completion credits the full captured amount, then collects the deposit fee out of Usable into a new **BunnyBooker Deposit Fee** account as its own `DepositFee` ledger row (skipped when zero)

### Announcements
- Template generalized to `fee-announcement`: announces a **specific queued event** (`changeId`), the next upcoming one, or the live fee
- Admins can pass **custom reasoning**; server composes subject + change/deduct/effective lines (handles removal announcements too)
- Endpoints moved to `POST Announcement/fee[/{userId}]`

### Tests
116 passing — fee matrix (flat/pct/cap/zero/deposit-type), deposit-fee ledger rows, transaction-type round-trip.

## ⚠️ Deploy note
After this deploys, **prod stops charging the 4% withdrawal fee** (config fallback removed). An admin must queue `4% now` from the new fees UI to keep charging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing both withdrawal and deposit fees, including flat and percentage components.
  * Introduced new fee endpoints to view current fees, list upcoming changes, add queued changes, and cancel future changes.
  * Expanded announcements and email messaging to handle general fee updates.

* **Bug Fixes**
  * Updated withdrawal and payment flows to use the new fee calculation model.
  * Added deposit fee collection during payment completion, with matching transaction records.

* **Deprecation**
  * Legacy withdrawal-fee configuration endpoints and settings were removed or marked as deprecated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->