### PR TITLE
fix(storage): verify ticket upload persisted; don't serve/commit dangling R2 refs

### DIFF
--- a/App/Modules/Bookings/API/V1/BookingImageEnricher.cs
+++ b/App/Modules/Bookings/API/V1/BookingImageEnricher.cs
@@ -10,14 +10,30 @@ public interface IBookingImageEnricher
   Task<Result<BookingRes>> Enrich(BookingRes booking);
 }
 
-public class BookingImageEnricher(IBookingStorage storage) : IBookingImageEnricher
+public class BookingImageEnricher(
+  IBookingStorage storage,
+  ILogger<BookingImageEnricher> logger
+) : IBookingImageEnricher
 {
   public async Task<Result<BookingPrincipalRes>> Enrich(BookingPrincipalRes booking)
   {
     if (booking.TicketLink == null)
       return booking;
 
-    return await storage.Get(booking.TicketLink).Select(link => booking with { TicketLink = link });
+    // Producing a link must never fail the whole request: one unresolvable ticket
+    // (e.g. a dangling reference or a transient storage error) would otherwise
+    // sink an entire booking list via ToResultOfSeq. Degrade to no link rather
+    // than a broken one, and log the key so the bad reference is discoverable.
+    var key = booking.TicketLink;
+    var link = await storage.Get(key);
+    return link.Match(
+      l => booking with { TicketLink = l },
+      e =>
+      {
+        logger.LogWarning(e, "Failed to resolve ticket link for key {Key}", key);
+        return booking with { TicketLink = null };
+      }
+    );
   }
 
   public async Task<Result<IEnumerable<BookingPrincipalRes>>> Enrich(

--- a/App/Modules/Common/FileRepository.cs
+++ b/App/Modules/Common/FileRepository.cs
@@ -79,6 +79,30 @@ public class FileRepository(IBlockStorageFactory factory, ContentInspector inspe
 
     var a = await s.WriteClient.PutObjectAsync(put).ConfigureAwait(false);
 
+    // Verify the object is actually readable before returning its key. A PutObject
+    // can report success without the object durably landing (transient storage or
+    // proxy anomaly), and if we returned the key regardless the caller would commit
+    // a DB reference (e.g. a booking's Ticket) to an object that does not exist —
+    // a permanently dangling link that only 404s when fetched. HEAD-ing the exact
+    // key we are about to hand back also guards against the returned name diverging
+    // from the key we wrote. On failure we fail the Save so the caller aborts and
+    // can retry instead of persisting a phantom reference.
+    try
+    {
+      await s
+        .WriteClient.StatObjectAsync(
+          new StatObjectArgs().WithBucket(s.Bucket).WithObject(a.ObjectName)
+        )
+        .ConfigureAwait(false);
+    }
+    catch (Exception e)
+    {
+      return new ApplicationException(
+        $"Object '{a.ObjectName}' in bucket '{s.Bucket}' was uploaded but could not be verified as stored",
+        e
+      );
+    }
+
     return a.ObjectName;
   }
 


### PR DESCRIPTION
## What & why

Booking `3a8a31bc-bf55-436e-a9a6-9075439a123c` (Completed 2026-07-08 13:57) references R2 object `bookings/c21d5b97-990a-40cc-874f-a1125fe712df.pdf`, which **does not exist** in the bucket.

Investigation (raichu prod):
- The completion went through the **normal `Complete`** path — a matching "Ticket Booking Successful" wallet transaction exists at 13:57:03, so **money is correct**.
- `Complete` uploads the file *before* committing the DB row, yet the object is absent → the upload **reported success without durably persisting**, and the key was committed anyway.
- Diffed **all 8040** DB ticket keys against **all 8065** R2 objects: **exactly one** dangling reference. R2 is otherwise fully intact (files 2024→today). Not a backend/config loss — a one-off phantom write.

## Changes

1. **`FileRepository.Save`** — after `PutObjectAsync`, `StatObjectAsync` (HEAD) the exact key before returning it. If it can't be verified, `Save` fails so callers (`Complete` / `CompleteNoCollect`) abort instead of committing a phantom reference. Also guards against the returned object name diverging from the written key.
2. **`BookingImageEnricher`** — one unresolvable ticket no longer sinks an entire booking list (`Task.WhenAll` + `ToResultOfSeq`). It degrades to *no* link (rather than a broken one) and logs the offending key so bad references are discoverable.

## Scope / notes
- Prevents recurrence + makes existing bad refs visible. Does **not** repair the existing file — the PDF is gone and must be re-supplied by the external `tin`/KTMB service (BookingNo `KST260726170760` / TicketNo `TST260768810430`) and re-uploaded to the same key.
- Build passes (`dotnet build App`), 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Booking images now handle resolution issues more gracefully, avoiding failed booking responses when a ticket link cannot be resolved.
  * File uploads are now verified after saving, reducing the chance of returning an unusable file reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->