### PR TITLE
feat(bookings): queue position, search totals, stats, fuzzy name, SGT emails

### DIFF
--- a/App/Modules/Announcements/AnnouncementService.cs
+++ b/App/Modules/Announcements/AnnouncementService.cs
@@ -140,7 +140,9 @@ public class AnnouncementService(
     };
   }
 
-  private static string FormatDate(DateTime utc) => utc.ToString("d MMMM yyyy, HH:mm 'UTC'");
+  // user-facing emails always speak SGT (GMT+8), never UTC
+  private static string FormatDate(DateTime utc) =>
+    utc.AddHours(8).ToString("d MMMM yyyy, h:mm tt 'SGT'");
 
   public async Task<Result<UserPrincipal>> SendFeeAnnouncement(
     string userId,

--- a/App/Modules/Bookings/API/V1/BookingController.cs
+++ b/App/Modules/Bookings/API/V1/BookingController.cs
@@ -55,6 +55,55 @@ public class BookingController(
     return this.ReturnResult(x);
   }
 
+  // total matches for the same filters — lets the UI show real page numbers
+  // and jump to any page
+  [Authorize, HttpGet("search/count")]
+  public async Task<ActionResult<SearchCountRes>> SearchCount([FromQuery] SearchBookingQuery query)
+  {
+    var x = await this.GuardOrAnyAsync(
+        query.UserId,
+        AuthRoles.Field,
+        AuthRoles.Admin,
+        AuthRoles.Tin
+      )
+      .ThenAwait(_ =>
+        bookingSearchQueryValidator.ValidateAsyncResult(query, "Invalid SearchBookingQuery")
+      )
+      .ThenAwait(q => service.SearchCount(q.ToDomain()))
+      .Then(total => new SearchCountRes(total), Errors.MapNone);
+
+    return this.ReturnResult(x);
+  }
+
+  // where this booking sits in its timeslot's purchase queue (1 = next to be
+  // bought); users may only see their own bookings
+  [Authorize, HttpGet("{id:guid}/queue")]
+  public async Task<ActionResult<BookingQueuePositionRes>> QueuePosition(Guid id, string? userId)
+  {
+    var x = await this.GuardOrAnyAsync(userId, AuthRoles.Field, AuthRoles.Admin, AuthRoles.Tin)
+      .ThenAwait(_ => service.QueuePosition(userId, id))
+      .Then(p => p?.ToRes(), Errors.MapAll);
+    return this.ReturnNullableResult(
+      x,
+      new EntityNotFound("Booking not found", typeof(Booking), id.ToString())
+    );
+  }
+
+  // booking outcomes grouped by travel day-of-week, departure time, direction
+  // and purchase-to-departure lead time — the success-rate dashboard source
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("stats")]
+  public async Task<ActionResult<IEnumerable<BookingStatRes>>> Stats(
+    [FromQuery] BookingStatsQueryReq query,
+    [FromServices] BookingStatsQueryReqValidator statsValidator
+  )
+  {
+    var x = await statsValidator
+      .ValidateAsyncResult(query, "Invalid BookingStatsQueryReq")
+      .ThenAwait(q => service.Stats(q.ToDomain()))
+      .Then(rows => rows.Select(r => r.ToRes()), Errors.MapAll);
+    return this.ReturnResult(x);
+  }
+
   [Authorize(Policy = AuthPolicies.AdminOrTin)]
   [HttpGet("refund")]
   public async Task<ActionResult<IEnumerable<BookingPrincipalRes>>> ListRefunds()

--- a/App/Modules/Bookings/API/V1/BookingMapper.cs
+++ b/App/Modules/Bookings/API/V1/BookingMapper.cs
@@ -57,6 +57,26 @@ public static class BookingMapper
       p.TicketsNeeded
     );
 
+  public static BookingQueuePositionRes ToRes(this BookingQueuePosition p) =>
+    new(p.Status.ToRes(), p.Position, p.Total);
+
+  public static BookingStatRes ToRes(this BookingStatRow r) =>
+    new(
+      r.DayOfWeek.ToString(),
+      r.Time.ToStandardTimeFormat(),
+      r.Direction.ToRes(),
+      r.Bucket,
+      r.Total,
+      r.Completed,
+      r.Refunded,
+      r.Cancelled,
+      r.Terminated,
+      r.Other
+    );
+
+  public static BookingStatsQuery ToDomain(this BookingStatsQueryReq req) =>
+    new() { After = req.After?.ToDate(), Before = req.Before?.ToDate() };
+
   // REQ -> DOMAIN
   public static BookingCountSearch ToDomain(this BookingCountQuery q) =>
     new() { Date = q.Date.ToDate(), Direction = q.Direction.DirectionToDomain() };
@@ -112,6 +132,7 @@ public static class BookingMapper
       Direction = query.Direction?.DirectionToDomain(),
       UserId = query.UserId,
       PassportNumber = query.PassportNumber,
+      PassengerName = query.PassengerName,
       // resolved to an absolute cutoff server-side so callers (e.g. the
       // reverter cron) need no clock agreement with zinc
       BuyingBefore =

--- a/App/Modules/Bookings/API/V1/BookingModel.cs
+++ b/App/Modules/Bookings/API/V1/BookingModel.cs
@@ -9,11 +9,14 @@ public record SearchBookingQuery(
   string? Time,
   string? UserId,
   string? PassportNumber,
+  string? PassengerName,
   int? StuckForMinutes,
   string? SortBy,
   int? Limit,
   int? Skip
 );
+
+public record BookingStatsQueryReq(string? After, string? Before);
 
 public record ReserveBookingQuery(string Date, string Direction, string Time);
 
@@ -67,3 +70,23 @@ public record BookingPrincipalRes(
 public record BookingRes(BookingPrincipalRes Principal, UserPrincipalRes User);
 
 public record BookingCountRes(string Date, string Time, string Direction, int TicketsNeeded);
+
+// total rows matching a search, ignoring Limit/Skip — for real page numbers
+public record SearchCountRes(int Total);
+
+// Position/Total null when the booking is no longer queued; Position is
+// 1-based (1 = next to be bought)
+public record BookingQueuePositionRes(string Status, int? Position, int? Total);
+
+public record BookingStatRes(
+  string DayOfWeek,
+  string Time,
+  string Direction,
+  string Bucket,
+  int Total,
+  int Completed,
+  int Refunded,
+  int Cancelled,
+  int Terminated,
+  int Other
+);

--- a/App/Modules/Bookings/API/V1/BookingValidator.cs
+++ b/App/Modules/Bookings/API/V1/BookingValidator.cs
@@ -48,6 +48,12 @@ public class BookingSearchQueryValidator : AbstractValidator<SearchBookingQuery>
       .MaximumLength(20)
       .Matches("^([a-zA-Z0-9]+)$")
       .When(x => x.PassportNumber != null);
+    // fuzzy name filter: same alphabet passenger names are stored in, plus
+    // nothing that could not appear in one
+    this.RuleFor(x => x.PassengerName)
+      .MaximumLength(512)
+      .Matches("^[a-zA-Z @./',\\-`*]+$")
+      .When(x => x.PassengerName != null);
     // upper bound keeps DateTime.UtcNow.AddMinutes(-x) in range (a 500 otherwise)
     this.RuleFor(x => x.StuckForMinutes)
       .GreaterThanOrEqualTo(1)
@@ -61,6 +67,15 @@ public class BookingSearchQueryValidator : AbstractValidator<SearchBookingQuery>
       .When(x => x.SortBy != null);
     this.RuleFor(x => x.Limit).Limit();
     this.RuleFor(x => x.Skip).Skip();
+  }
+}
+
+public class BookingStatsQueryReqValidator : AbstractValidator<BookingStatsQueryReq>
+{
+  public BookingStatsQueryReqValidator()
+  {
+    this.RuleFor(x => x.After).NullableDateValid();
+    this.RuleFor(x => x.Before).NullableDateValid();
   }
 }
 

--- a/App/Modules/Bookings/Data/BookingEmailNotifierAdapter.cs
+++ b/App/Modules/Bookings/Data/BookingEmailNotifierAdapter.cs
@@ -17,6 +17,11 @@ public class BookingEmailNotifierAdapter(
   ILogger<BookingEmailNotifierAdapter> logger
 ) : IBookingEmailNotifier
 {
+  // CompletedAt is stored UTC but user-facing emails always speak SGT
+  // (GMT+8); rendering the raw UTC value shows the wrong DAY near midnight
+  private static string ToSgtDate(DateTime? utc) =>
+    utc?.AddHours(8).ToString("ddd, MMM dd yyyy") ?? "Not Applicable";
+
   public async Task<Result<(string, string)>> Rendering(BookingEmailNotificationRequest request)
   {
     logger.LogDebug("Rendering email to send {Request}", request);
@@ -35,7 +40,7 @@ public class BookingEmailNotifierAdapter(
         direction = request.Booking.Record.Direction == TrainDirection.JToW ? "Johor Bahru → Singapore" : "Singapore → Johor Bahru",
         bookingDate = request.Booking.Record.Date.ToString("ddd, MMM dd yyyy"),
         bookingTime = request.Booking.Record.Time.ToString("HH:mm"),
-        cancellationDate = request.Booking.Status.CompletedAt?.ToString("ddd, MMM dd yyyy") ?? "Not Applicable", 
+        cancellationDate = ToSgtDate(request.Booking.Status.CompletedAt),
       }),
       BookingEmailNotificationType.Completed => emailRenderer.RenderEmail("booking-completed", new { 
         baseUrl = o.BaseUrl,
@@ -63,7 +68,7 @@ public class BookingEmailNotifierAdapter(
         direction = request.Booking.Record.Direction == TrainDirection.JToW ? "Johor Bahru → Singapore" : "Singapore → Johor Bahru",
         bookingDate = request.Booking.Record.Date.ToString("ddd, MMM dd yyyy"),
         bookingTime = request.Booking.Record.Time.ToString("HH:mm"),
-        refundDate = request.Booking.Status.CompletedAt?.ToString("ddd, MMM dd yyyy") ?? "Not Applicable", 
+        refundDate = ToSgtDate(request.Booking.Status.CompletedAt),
       }),
       BookingEmailNotificationType.Terminated => emailRenderer.RenderEmail("booking-terminated", new
       {
@@ -77,7 +82,7 @@ public class BookingEmailNotifierAdapter(
         direction = request.Booking.Record.Direction == TrainDirection.JToW ? "Johor Bahru → Singapore" : "Singapore → Johor Bahru",
         bookingDate = request.Booking.Record.Date.ToString("ddd, MMM dd yyyy"),
         bookingTime = request.Booking.Record.Time.ToString("HH:mm"),
-        terminationDate = request.Booking.Status.CompletedAt?.ToString("ddd, MMM dd yyyy") ?? "Not Applicable",
+        terminationDate = ToSgtDate(request.Booking.Status.CompletedAt),
       }),
       BookingEmailNotificationType.Duplicate => emailRenderer.RenderEmail("booking-duplicate", new
       {
@@ -91,7 +96,7 @@ public class BookingEmailNotifierAdapter(
         direction = request.Booking.Record.Direction == TrainDirection.JToW ? "Johor Bahru → Singapore" : "Singapore → Johor Bahru",
         bookingDate = request.Booking.Record.Date.ToString("ddd, MMM dd yyyy"),
         bookingTime = request.Booking.Record.Time.ToString("HH:mm"),
-        duplicateDate = request.Booking.Status.CompletedAt?.ToString("ddd, MMM dd yyyy") ?? "Not Applicable",
+        duplicateDate = ToSgtDate(request.Booking.Status.CompletedAt),
       }),
       BookingEmailNotificationType.RequireManualIntervention => emailRenderer.RenderEmail("booking-manual-intervention", new
       {

--- a/App/Modules/Bookings/Data/BookingRepository.cs
+++ b/App/Modules/Bookings/Data/BookingRepository.cs
@@ -16,37 +16,59 @@ public class BookingRepository(
   IBookingCdcRepository cdc
 ) : IBookingRepository
 {
+  // shared by Search and SearchCount so the count always agrees with the page
+  private static IQueryable<BookingData> ApplyFilters(
+    IQueryable<BookingData> query,
+    BookingSearch search
+  )
+  {
+    if (!string.IsNullOrWhiteSpace(search.UserId))
+      query = query.Where(x => x.UserId == search.UserId);
+
+    if (search.Date != null)
+      query = query.Where(x => x.Date == search.Date);
+
+    if (search.Time != null)
+      query = query.Where(x => x.Time == search.Time);
+
+    if (search.Status != null)
+      query = query.Where(x => x.Status == (byte)search.Status);
+
+    if (search.Direction != null)
+    {
+      var d = search.Direction?.ToData();
+      query = query.Where(x => x.Direction == d);
+    }
+
+    if (!string.IsNullOrWhiteSpace(search.PassportNumber))
+      query = query.Where(x => x.Passenger.PassportNumber == search.PassportNumber);
+
+    if (!string.IsNullOrWhiteSpace(search.PassengerName))
+    {
+      // fuzzy = case-insensitive contains; escape ILIKE wildcards so a
+      // literal % or _ in the input cannot widen the match
+      var pattern =
+        "%"
+        + search
+          .PassengerName.Replace(@"\", @"\\")
+          .Replace("%", @"\%")
+          .Replace("_", @"\_")
+        + "%";
+      query = query.Where(x => EF.Functions.ILike(x.Passenger.FullName, pattern, @"\"));
+    }
+
+    if (search.BuyingBefore != null)
+      query = query.Where(x => x.LastBuyingAt != null && x.LastBuyingAt < search.BuyingBefore);
+
+    return query;
+  }
+
   public async Task<Result<IEnumerable<BookingPrincipal>>> Search(BookingSearch search)
   {
     try
     {
       logger.LogInformation("Searching for Booking with '{@Search}'", search.ToJson());
-      var query = db.Bookings.AsQueryable();
-      if (!string.IsNullOrWhiteSpace(search.UserId))
-        query = query.Where(x => x.UserId == search.UserId);
-
-      if (search.Date != null)
-        query = query.Where(x => x.Date == search.Date);
-
-      if (search.Time != null)
-        query = query.Where(x => x.Time == search.Time);
-
-      if (search.Status != null)
-        query = query.Where(x => x.Status == (byte)search.Status);
-
-      if (search.Direction != null)
-      {
-        var d = search.Direction?.ToData();
-        query = query.Where(x => x.Direction == d);
-      }
-
-      if (!string.IsNullOrWhiteSpace(search.PassportNumber))
-        query = query.Where(x => x.Passenger.PassportNumber == search.PassportNumber);
-
-      if (search.BuyingBefore != null)
-        query = query.Where(x =>
-          x.LastBuyingAt != null && x.LastBuyingAt < search.BuyingBefore
-        );
+      var query = ApplyFilters(db.Bookings.AsQueryable(), search);
 
       // Id tiebreaker everywhere: Skip/Take pagination needs a stable total
       // order, and none of the sort keys are unique
@@ -79,6 +101,137 @@ public class BookingRepository(
       return e;
     }
   }
+
+  public async Task<Result<int>> SearchCount(BookingSearch search)
+  {
+    try
+    {
+      return await ApplyFilters(db.Bookings.AsQueryable(), search).CountAsync();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed counting Bookings with {@Search}", search.ToJson());
+      return e;
+    }
+  }
+
+  // statuses still waiting for the buyer form the timeslot's queue,
+  // processed oldest-first
+  private static bool IsQueued(byte status) =>
+    status
+      is (byte)BookStatus.Pending
+        or (byte)BookStatus.Buying
+        or (byte)BookStatus.Recovering;
+
+  public async Task<Result<BookingQueuePosition?>> QueuePosition(string? userId, Guid id)
+  {
+    try
+    {
+      var b = await db
+        .Bookings.Where(x => x.Id == id && (userId == null || x.UserId == userId))
+        .FirstOrDefaultAsync();
+      if (b == null)
+        return (BookingQueuePosition?)null;
+
+      if (!IsQueued(b.Status))
+        return new BookingQueuePosition
+        {
+          Status = (BookStatus)b.Status,
+          Position = null,
+          Total = null,
+        };
+
+      var slot = db.Bookings.Where(x =>
+        x.Date == b.Date
+        && x.Time == b.Time
+        && x.Direction == b.Direction
+        && (
+          x.Status == (byte)BookStatus.Pending
+          || x.Status == (byte)BookStatus.Buying
+          || x.Status == (byte)BookStatus.Recovering
+        )
+      );
+      // the buyer works oldest-first, so everyone who booked earlier (Id as
+      // the deterministic tiebreak) is ahead of this booking
+      var ahead = await slot
+        .Where(x => x.CreatedAt < b.CreatedAt || (x.CreatedAt == b.CreatedAt && x.Id < b.Id))
+        .CountAsync();
+      var total = await slot.CountAsync();
+
+      return new BookingQueuePosition
+      {
+        Status = (BookStatus)b.Status,
+        Position = ahead + 1,
+        Total = total,
+      };
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to compute queue position for Booking '{Id}'", id);
+      return e;
+    }
+  }
+
+  public async Task<Result<IEnumerable<BookingStatRow>>> Stats(BookingStatsQuery statsQuery)
+  {
+    try
+    {
+      var query = db.Bookings.AsQueryable();
+      if (statsQuery.After != null)
+        query = query.Where(x => x.Date >= statsQuery.After);
+      if (statsQuery.Before != null)
+        query = query.Where(x => x.Date <= statsQuery.Before);
+
+      // minimal projection; grouping happens in memory because the lead-time
+      // bucket is computed from two columns and SQL GROUP BY can't help
+      var slices = await query
+        .Select(x => new
+        {
+          x.Date,
+          x.Time,
+          x.Direction,
+          x.Status,
+          x.CreatedAt,
+        })
+        .ToArrayAsync();
+
+      var rows = slices
+        .GroupBy(x => new
+        {
+          x.Date.DayOfWeek,
+          x.Time,
+          x.Direction,
+          Bucket = BookingStats.LeadTimeBucket(x.Date, x.Time, x.CreatedAt),
+        })
+        .Select(g => new BookingStatRow
+        {
+          DayOfWeek = g.Key.DayOfWeek,
+          Time = g.Key.Time,
+          Direction = g.Key.Direction.ToTrainDirection(),
+          Bucket = g.Key.Bucket,
+          Total = g.Count(),
+          Completed = g.Count(x => x.Status == (byte)BookStatus.Completed),
+          Refunded = g.Count(x => x.Status == (byte)BookStatus.Refunded),
+          Cancelled = g.Count(x => x.Status == (byte)BookStatus.Cancelled),
+          Terminated = g.Count(x => x.Status == (byte)BookStatus.Terminated),
+          Other = g.Count(x =>
+            x.Status != (byte)BookStatus.Completed
+            && x.Status != (byte)BookStatus.Refunded
+            && x.Status != (byte)BookStatus.Cancelled
+            && x.Status != (byte)BookStatus.Terminated
+          ),
+        })
+        .ToArray();
+
+      return rows.AsEnumerable().ToResult();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to compute booking stats");
+      return e;
+    }
+  }
+
 
   public async Task<Result<IEnumerable<BookingPrincipal>>> RefundList(DateOnly date, TimeOnly time)
   {

--- a/App/Modules/Bookings/Data/BookingStats.cs
+++ b/App/Modules/Bookings/Data/BookingStats.cs
@@ -1,0 +1,52 @@
+namespace App.Modules.Bookings.Data;
+
+public static class BookingStats
+{
+  // how long before departure the booking was made, in the buckets the
+  // success-rate dashboard slices on. Travel date+time are SGT (UTC+8)
+  // wall-clock; CreatedAt is UTC. Bookings made after departure (should not
+  // happen) land in the tightest bucket.
+  public static string LeadTimeBucket(DateOnly date, TimeOnly time, DateTime createdAtUtc)
+  {
+    var departureUtc = date.ToDateTime(time, DateTimeKind.Unspecified).AddHours(-8);
+    var lead = departureUtc - createdAtUtc;
+    return lead.TotalHours switch
+    {
+      <= 6 => "6h",
+      <= 12 => "12h",
+      <= 24 => "24h",
+      <= 48 => "2d",
+      <= 72 => "3d",
+      <= 96 => "4d",
+      <= 24 * 7 => "1w",
+      <= 24 * 14 => "2w",
+      <= 24 * 21 => "3w",
+      <= 24 * 28 => "4w",
+      <= 24 * 31 => "1m",
+      <= 24 * 61 => "2m",
+      <= 24 * 92 => "3m",
+      <= 24 * 183 => "6m",
+      _ => "6m+",
+    };
+  }
+
+  // bucket display/sort order for consumers
+  public static readonly string[] BucketOrder =
+  [
+    "6h",
+    "12h",
+    "24h",
+    "2d",
+    "3d",
+    "4d",
+    "1w",
+    "2w",
+    "3w",
+    "4w",
+    "1m",
+    "2m",
+    "3m",
+    "6m",
+    "6m+",
+  ];
+}

--- a/App/Templates/Email/emails/fee-announcement.tsx
+++ b/App/Templates/Email/emails/fee-announcement.tsx
@@ -183,7 +183,7 @@ FeeAnnouncementEmail.PreviewProps = {
     "Recently, we've seen widespread abuse of our wallet system, with large sums being deposited and withdrawn purely to churn funds through the platform. To protect the platform and the community of genuine travelers who use it, we're introducing a small fee on withdrawals.",
   changeLine: 'A 4% + SGD 1.00 fee will apply to all wallet withdrawals',
   deductLine: 'The fee is deducted from the withdrawn amount',
-  effectiveLine: 'This change takes effect on 1 August 2026, 00:00 UTC',
+  effectiveLine: 'This change takes effect on 1 August 2026, 8:00 AM SGT',
 } as FeeAnnouncementEmailProps;
 
 export default FeeAnnouncementEmail;

--- a/Domain/Booking/IService.cs
+++ b/Domain/Booking/IService.cs
@@ -7,6 +7,12 @@ public interface IBookingService
 {
   Task<Result<IEnumerable<BookingPrincipal>>> Search(BookingSearch search);
 
+  Task<Result<int>> SearchCount(BookingSearch search);
+
+  Task<Result<BookingQueuePosition?>> QueuePosition(string? userId, Guid id);
+
+  Task<Result<IEnumerable<BookingStatRow>>> Stats(BookingStatsQuery query);
+
   Task<Result<IEnumerable<BookingPrincipal>>> ListRefunds(DateTime referenceTime);
 
   Task<Result<Booking?>> Get(string? userId, Guid id);

--- a/Domain/Booking/Model.cs
+++ b/Domain/Booking/Model.cs
@@ -65,6 +65,9 @@ public record BookingSearch
 
   public string? PassportNumber { get; init; }
 
+  // fuzzy (case-insensitive contains) match on the passenger's full name
+  public string? PassengerName { get; init; }
+
   // only bookings whose last entry into Buying is older than this; lets the
   // reverter cron list stuck-Buying bookings without racing live purchases
   public DateTime? BuyingBefore { get; init; }
@@ -140,4 +143,54 @@ public record BookingCount
 
   public required TrainDirection Direction { get; init; }
   public required int TicketsNeeded { get; init; }
+}
+
+// A booking's place in its timeslot's purchase queue. Position/Total are null
+// when the booking is no longer queued (completed, refunded, cancelled, ...).
+// Position is 1-based: 1 = next to be bought.
+public record BookingQueuePosition
+{
+  public required BookStatus Status { get; init; }
+
+  public required int? Position { get; init; }
+
+  public required int? Total { get; init; }
+}
+
+public record BookingStatsQuery
+{
+  // travel-date range (inclusive); null = unbounded
+  public DateOnly? After { get; init; }
+
+  public DateOnly? Before { get; init; }
+}
+
+// Booking outcomes bucketed by everything the success-rate dashboards slice
+// on: day of week (of travel), departure time, direction, and how long before
+// departure the booking was made. The UI aggregates across any of these.
+public record BookingStatRow
+{
+  public required DayOfWeek DayOfWeek { get; init; }
+
+  public required TimeOnly Time { get; init; }
+
+  public required TrainDirection Direction { get; init; }
+
+  // lead time from purchase to departure:
+  // 6h, 12h, 24h, 2d, 3d, 4d, 1w, 2w, 3w, 4w, 1m, 2m, 3m, 6m, 6m+
+  public required string Bucket { get; init; }
+
+  public required int Total { get; init; }
+
+  public required int Completed { get; init; }
+
+  public required int Refunded { get; init; }
+
+  public required int Cancelled { get; init; }
+
+  public required int Terminated { get; init; }
+
+  // everything else: still in flight (Pending/Buying/Recovering), Duplicate,
+  // RequireManualIntervention
+  public required int Other { get; init; }
 }

--- a/Domain/Booking/Repository.cs
+++ b/Domain/Booking/Repository.cs
@@ -7,6 +7,15 @@ public interface IBookingRepository
 {
   Task<Result<IEnumerable<BookingPrincipal>>> Search(BookingSearch search);
 
+  // total matches for the same filters, ignoring Limit/Skip — lets the UI
+  // paginate with real page numbers
+  Task<Result<int>> SearchCount(BookingSearch search);
+
+  // null when the booking does not exist (or is not visible to userId)
+  Task<Result<BookingQueuePosition?>> QueuePosition(string? userId, Guid id);
+
+  Task<Result<IEnumerable<BookingStatRow>>> Stats(BookingStatsQuery query);
+
   Task<Result<IEnumerable<BookingPrincipal>>> RefundList(DateOnly date, TimeOnly time);
 
   Task<Result<Booking?>> Get(string? userId, Guid id);

--- a/Domain/Booking/Service.cs
+++ b/Domain/Booking/Service.cs
@@ -26,6 +26,21 @@ public class BookingService(
     return repo.Search(search);
   }
 
+  public Task<Result<int>> SearchCount(BookingSearch search)
+  {
+    return repo.SearchCount(search);
+  }
+
+  public Task<Result<BookingQueuePosition?>> QueuePosition(string? userId, Guid id)
+  {
+    return repo.QueuePosition(userId, id);
+  }
+
+  public Task<Result<IEnumerable<BookingStatRow>>> Stats(BookingStatsQuery query)
+  {
+    return repo.Stats(query);
+  }
+
   public Task<Result<IEnumerable<BookingPrincipal>>> ListRefunds(DateTime referenceTime)
   {
     var singapore = TimeZoneInfo.FindSystemTimeZoneById("Singapore");

--- a/UnitTest/Bookings/BookingServiceBuyingGuardTests.cs
+++ b/UnitTest/Bookings/BookingServiceBuyingGuardTests.cs
@@ -193,6 +193,15 @@ public class BookingServiceBuyingGuardTests
     public Task<Result<IEnumerable<BookingPrincipal>>> Search(BookingSearch search) =>
       throw new NotImplementedException();
 
+    public Task<Result<int>> SearchCount(BookingSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<BookingQueuePosition?>> QueuePosition(string? userId, Guid id) =>
+      throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingStatRow>>> Stats(BookingStatsQuery query) =>
+      throw new NotImplementedException();
+
     public Task<Result<IEnumerable<BookingPrincipal>>> RefundList(DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 

--- a/UnitTest/Bookings/BookingServiceCompleteNoCollectTests.cs
+++ b/UnitTest/Bookings/BookingServiceCompleteNoCollectTests.cs
@@ -187,6 +187,15 @@ public class BookingServiceCompleteNoCollectTests
     public Task<Result<IEnumerable<BookingPrincipal>>> Search(BookingSearch search) =>
       throw new NotImplementedException();
 
+    public Task<Result<int>> SearchCount(BookingSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<BookingQueuePosition?>> QueuePosition(string? userId, Guid id) =>
+      throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingStatRow>>> Stats(BookingStatsQuery query) =>
+      throw new NotImplementedException();
+
     public Task<Result<IEnumerable<BookingPrincipal>>> RefundList(DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 

--- a/UnitTest/Bookings/BookingServiceRevertGuardTests.cs
+++ b/UnitTest/Bookings/BookingServiceRevertGuardTests.cs
@@ -326,6 +326,15 @@ public class BookingServiceRevertGuardTests
     public Task<Result<IEnumerable<BookingPrincipal>>> Search(BookingSearch search) =>
       throw new NotImplementedException();
 
+    public Task<Result<int>> SearchCount(BookingSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<BookingQueuePosition?>> QueuePosition(string? userId, Guid id) =>
+      throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingStatRow>>> Stats(BookingStatsQuery query) =>
+      throw new NotImplementedException();
+
     public Task<Result<IEnumerable<BookingPrincipal>>> RefundList(DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 

--- a/UnitTest/Bookings/BookingStatsTests.cs
+++ b/UnitTest/Bookings/BookingStatsTests.cs
@@ -1,0 +1,60 @@
+using App.Modules.Bookings.Data;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// Lead-time buckets: how long before departure (SGT wall-clock) a booking
+// was made (CreatedAt, UTC). Boundaries are inclusive on the tight side —
+// exactly 6h before departure is "6h".
+public class BookingStatsTests
+{
+  // departure 2026-07-10 08:00 SGT = 2026-07-10 00:00 UTC
+  private static readonly DateOnly Date = new(2026, 7, 10);
+  private static readonly TimeOnly Time = new(8, 0);
+  private static readonly DateTime DepartureUtc = new(2026, 7, 10, 0, 0, 0, DateTimeKind.Utc);
+
+  [Theory]
+  [InlineData(1, "6h")]
+  [InlineData(6, "6h")]
+  [InlineData(7, "12h")]
+  [InlineData(12, "12h")]
+  [InlineData(13, "24h")]
+  [InlineData(24, "24h")]
+  [InlineData(25, "2d")]
+  [InlineData(48, "2d")]
+  [InlineData(49, "3d")]
+  [InlineData(72, "3d")]
+  [InlineData(73, "4d")]
+  [InlineData(96, "4d")]
+  [InlineData(97, "1w")]
+  [InlineData(24 * 7, "1w")]
+  [InlineData(24 * 7 + 1, "2w")]
+  [InlineData(24 * 14, "2w")]
+  [InlineData(24 * 21, "3w")]
+  [InlineData(24 * 28, "4w")]
+  [InlineData(24 * 31, "1m")]
+  [InlineData(24 * 61, "2m")]
+  [InlineData(24 * 92, "3m")]
+  [InlineData(24 * 183, "6m")]
+  [InlineData(24 * 200, "6m+")]
+  public void Buckets_by_hours_before_departure(int hoursBefore, string expected)
+  {
+    var createdAt = DepartureUtc.AddHours(-hoursBefore);
+    BookingStats.LeadTimeBucket(Date, Time, createdAt).Should().Be(expected);
+  }
+
+  [Fact]
+  public void Booking_made_after_departure_lands_in_the_tightest_bucket()
+  {
+    BookingStats.LeadTimeBucket(Date, Time, DepartureUtc.AddHours(2)).Should().Be("6h");
+  }
+
+  [Fact]
+  public void Departure_is_interpreted_as_SGT_not_UTC()
+  {
+    // 7h before the SGT departure instant; if the code wrongly treated the
+    // travel time as UTC the lead would be 15h and the bucket "24h"
+    var createdAt = DepartureUtc.AddHours(-7);
+    BookingStats.LeadTimeBucket(Date, Time, createdAt).Should().Be("12h");
+  }
+}


### PR DESCRIPTION
## What

Admin/UX round for bookings:

- **`GET Booking/search/count`** — total matches for the same search filters → the UI can show real page numbers and jump straight to page N
- **`GET Booking/{id}/queue`** — a booking's 1-based position + queue size within its timeslot (Pending/Buying/Recovering, oldest-first). Users see their own bookings' position; admins see any
- **`GET Booking/stats`** (admin) — outcomes grouped by travel **day-of-week × departure time × direction × lead-time bucket** (6h, 12h, 24h, 2d, 3d, 4d, 1w, 2w, 3w, 4w, 1m, 2m, 3m, 6m, 6m+), with completed/refunded/cancelled/terminated/other counts. The UI can aggregate across any dimension and compute success rates under either definition (refund-only or refund+cancel)
- **Fuzzy passenger-name filter** (case-insensitive contains, ILIKE with escaped wildcards) alongside the existing exact passport filter — timeslot filtering (date+time+direction) already existed and pairs with buy-time sort for queue triage
- **SGT everywhere in emails**: fee-announcement effective dates and booking cancellation/refund/termination/duplicate dates now render in SGT (GMT+8) instead of UTC (UTC dates show the wrong day near midnight SGT)

## Tests
141 passing — includes full lead-time bucket boundary matrix and SGT-interpretation guard.