### PR TITLE
feat(cost): policy engine and priority queue

### DIFF
--- a/App/Migrations/20260709191210_AddCostPolicies.Designer.cs
+++ b/App/Migrations/20260709191210_AddCostPolicies.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using App.StartUp.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace App.Migrations
 {
     [DbContext(typeof(MainDbContext))]
-    partial class MainDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260709191210_AddCostPolicies")]
+    partial class AddCostPolicies
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/App/Migrations/20260709191210_AddCostPolicies.cs
+++ b/App/Migrations/20260709191210_AddCostPolicies.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace App.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCostPolicies : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "Priority",
+                table: "Bookings",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "PriorityFee",
+                table: "Bookings",
+                type: "numeric(16,8)",
+                precision: 16,
+                scale: 8,
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "CostPolicies",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Name = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Enabled = table.Column<bool>(type: "boolean", nullable: false),
+                    MatchDate = table.Column<DateOnly>(type: "date", nullable: true),
+                    MatchTime = table.Column<TimeOnly>(type: "time without time zone", nullable: true),
+                    MatchDayOfWeek = table.Column<byte>(type: "smallint", nullable: true),
+                    MatchDirection = table.Column<int>(type: "integer", nullable: true),
+                    LeadTimeUnderHours = table.Column<int>(type: "integer", nullable: true),
+                    Amount = table.Column<decimal>(type: "numeric(16,8)", precision: 16, scale: 8, nullable: false),
+                    IsPercentage = table.Column<bool>(type: "boolean", nullable: false),
+                    EffectiveAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    ExpiresAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CostPolicies", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PriorityAccesses",
+                columns: table => new
+                {
+                    UserId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PriorityAccesses", x => x.UserId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PrioritySettings",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Fee = table.Column<decimal>(type: "numeric(16,8)", precision: 16, scale: 8, nullable: false),
+                    AllowAll = table.Column<bool>(type: "boolean", nullable: false),
+                    WindowStartSgt = table.Column<TimeOnly>(type: "time without time zone", nullable: true),
+                    WindowEndSgt = table.Column<TimeOnly>(type: "time without time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PrioritySettings", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CostPolicies");
+
+            migrationBuilder.DropTable(
+                name: "PriorityAccesses");
+
+            migrationBuilder.DropTable(
+                name: "PrioritySettings");
+
+            migrationBuilder.DropColumn(
+                name: "Priority",
+                table: "Bookings");
+
+            migrationBuilder.DropColumn(
+                name: "PriorityFee",
+                table: "Bookings");
+        }
+    }
+}

--- a/App/Modules/Bookings/API/V1/BookingController.cs
+++ b/App/Modules/Bookings/API/V1/BookingController.cs
@@ -28,6 +28,9 @@ public class BookingController(
   BookingSearchQueryValidator bookingSearchQueryValidator,
   ReserveBookingQueryValidator reserveBookingQueryValidator,
   BookingCountQueryValidator countQueryValidator,
+  SetPrioritySettingsReqValidator setPrioritySettingsReqValidator,
+  IPrioritySettingsRepository prioritySettingsRepo,
+  IPriorityAccessRepository priorityAccessRepo,
   IOptions<TerminatorOption> terminatorOptions,
   ILogger<BookingController> logger,
   IBookingImageEnricher enrich,
@@ -360,6 +363,84 @@ public class BookingController(
       p,
       new EntityNotFound(
         "Cannot find booking to be terminated",
+        typeof(BookingPrincipal),
+        id.ToString()
+      )
+    );
+  }
+
+  // may the CALLING user prioritize a booking right now, and at what fee —
+  // powers the prioritize button on the booking page
+  [Authorize, HttpGet("priority/eligibility")]
+  public async Task<ActionResult<PriorityEligibilityRes>> PriorityEligibility()
+  {
+    var sub = this.Sub()!;
+    var x = await service.PriorityEligibility(sub).Then(e => e.ToRes(), Errors.MapNone);
+    return this.ReturnResult(x);
+  }
+
+  // the priority settings in effect right now (defaults when never configured)
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("priority/settings")]
+  public async Task<ActionResult<PrioritySettingsRes>> GetPrioritySettings()
+  {
+    var x = await prioritySettingsRepo
+      .GetCurrent()
+      .Then(s => (s?.Record ?? PrioritySettingsRecord.Default).ToRes(), Errors.MapNone);
+    return this.ReturnResult(x);
+  }
+
+  // replace the priority settings (insert-only latest, like Cost)
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpPost("priority/settings")]
+  public async Task<ActionResult<PrioritySettingsRes>> SetPrioritySettings(
+    [FromBody] SetPrioritySettingsReq req
+  )
+  {
+    var x = await setPrioritySettingsReqValidator
+      .ValidateAsyncResult(req, "Invalid SetPrioritySettingsReq")
+      .ThenAwait(r => prioritySettingsRepo.Create(r.ToDomain()))
+      .Then(s => s.Record.ToRes(), Errors.MapNone);
+    return this.ReturnResult(x);
+  }
+
+  // the per-user priority allowlist
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("priority/access")]
+  public async Task<ActionResult<IEnumerable<PriorityAccessRes>>> ListPriorityAccess()
+  {
+    var x = await priorityAccessRepo.List().Then(a => a.Select(u => u.ToRes()), Errors.MapNone);
+    return this.ReturnResult(x);
+  }
+
+  // allowlist a user (idempotent)
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpPost("priority/access/{userId}")]
+  public async Task<ActionResult<PriorityAccessRes>> AddPriorityAccess(string userId)
+  {
+    var x = await priorityAccessRepo.Add(userId).Then(a => a.ToRes(), Errors.MapNone);
+    return this.ReturnResult(x);
+  }
+
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpDelete("priority/access/{userId}")]
+  public async Task<ActionResult> RemovePriorityAccess(string userId)
+  {
+    var x = await priorityAccessRepo.Remove(userId);
+    return this.ReturnUnitNullableResult(
+      x,
+      new EntityNotFound("Priority access not found", typeof(PriorityAccess), userId)
+    );
+  }
+
+  // prioritize: charge the priority fee and jump this booking to the front of
+  // its timeslot's purchase queue (owner or admin, like cancel/terminate)
+  [Authorize, HttpPost("{id:guid}/prioritize")]
+  public async Task<ActionResult<BookingPrincipalRes>> Prioritize(Guid id, string? userId)
+  {
+    var p = await this.GuardOrAnyAsync(userId, AuthRoles.Field, AuthRoles.Admin)
+      .ThenAwait(_ => service.Prioritize(userId, id))
+      .Then(b => b?.ToRes(), Errors.MapNone);
+
+    return this.ReturnNullableResult(
+      p,
+      new EntityNotFound(
+        "Cannot find booking to be prioritized",
         typeof(BookingPrincipal),
         id.ToString()
       )

--- a/App/Modules/Bookings/API/V1/BookingMapper.cs
+++ b/App/Modules/Bookings/API/V1/BookingMapper.cs
@@ -43,7 +43,8 @@ public static class BookingMapper
       p.Complete.Ticket,
       p.Complete.TicketNumber,
       p.Complete.BookingNumber,
-      p.Status.Status.ToRes()
+      p.Status.Status.ToRes(),
+      p.Priority
     );
   }
 
@@ -153,5 +154,28 @@ public static class BookingMapper
       "BuyTime" => BookingSort.BuyTime,
       "FulfilTime" => BookingSort.FulfilTime,
       _ => throw new ArgumentOutOfRangeException(nameof(sort), sort, null),
+    };
+
+  // Priority queue
+  public static PrioritySettingsRes ToRes(this PrioritySettingsRecord r) =>
+    new(
+      r.Fee,
+      r.AllowAll,
+      r.WindowStartSgt?.ToStandardTimeFormat(),
+      r.WindowEndSgt?.ToStandardTimeFormat()
+    );
+
+  public static PriorityAccessRes ToRes(this PriorityAccess a) => new(a.UserId, a.CreatedAt);
+
+  public static PriorityEligibilityRes ToRes(this PriorityEligibility e) =>
+    new(e.Eligible, e.Fee);
+
+  public static PrioritySettingsRecord ToDomain(this SetPrioritySettingsReq req) =>
+    new()
+    {
+      Fee = req.Fee,
+      AllowAll = req.AllowAll,
+      WindowStartSgt = req.WindowStartSgt?.ToTime(),
+      WindowEndSgt = req.WindowEndSgt?.ToTime(),
     };
 }

--- a/App/Modules/Bookings/API/V1/BookingModel.cs
+++ b/App/Modules/Bookings/API/V1/BookingModel.cs
@@ -64,7 +64,8 @@ public record BookingPrincipalRes(
   string? TicketLink,
   string? TicketNo,
   string? BookingNo,
-  string Status
+  string Status,
+  bool Priority
 );
 
 public record BookingRes(BookingPrincipalRes Principal, UserPrincipalRes User);
@@ -90,3 +91,28 @@ public record BookingStatRes(
   int Terminated,
   int Other
 );
+
+// Priority queue
+
+// REQ: replace the priority settings (insert-only latest, like Cost).
+// Window times are SGT HH:mm:ss; both null = always available; start > end
+// wraps midnight. Fee 0 disables charging (prioritizing stays free).
+public record SetPrioritySettingsReq(
+  decimal Fee,
+  bool AllowAll,
+  string? WindowStartSgt,
+  string? WindowEndSgt
+);
+
+// RESP
+public record PrioritySettingsRes(
+  decimal Fee,
+  bool AllowAll,
+  string? WindowStartSgt,
+  string? WindowEndSgt
+);
+
+public record PriorityAccessRes(string UserId, DateTime CreatedAt);
+
+// may the calling user prioritize right now, and at what fee
+public record PriorityEligibilityRes(bool Eligible, decimal Fee);

--- a/App/Modules/Bookings/API/V1/BookingValidator.cs
+++ b/App/Modules/Bookings/API/V1/BookingValidator.cs
@@ -97,3 +97,20 @@ public class ReserveBookingQueryValidator : AbstractValidator<ReserveBookingQuer
     this.RuleFor(x => x.Direction).NotNull().TrainDirectionValid();
   }
 }
+
+public class SetPrioritySettingsReqValidator : AbstractValidator<SetPrioritySettingsReq>
+{
+  public SetPrioritySettingsReqValidator()
+  {
+    this.RuleFor(x => x.Fee)
+      .GreaterThanOrEqualTo(0)
+      .LessThanOrEqualTo(10_000)
+      .WithMessage("Fee must be between 0 and 10000");
+    this.RuleFor(x => x.WindowStartSgt).NullableTimeValid();
+    this.RuleFor(x => x.WindowEndSgt).NullableTimeValid();
+    // a half-open window needs both bounds; a lone bound is ambiguous
+    this.RuleFor(x => x.WindowEndSgt)
+      .Must((req, x) => (x == null) == (req.WindowStartSgt == null))
+      .WithMessage("WindowStartSgt and WindowEndSgt must be set together (or both omitted)");
+  }
+}

--- a/App/Modules/Bookings/Data/BookingData.cs
+++ b/App/Modules/Bookings/Data/BookingData.cs
@@ -2,6 +2,7 @@ using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using App.Modules.Transactions.Data;
 using App.Modules.Users.Data;
+using Microsoft.EntityFrameworkCore;
 
 namespace App.Modules.Bookings.Data;
 
@@ -32,6 +33,14 @@ public class BookingData
 
   // when the booking last entered Buying (null for rows predating the column)
   public DateTime? LastBuyingAt { get; set; }
+
+  // priority bookings jump to the front of their timeslot's purchase queue
+  public bool Priority { get; set; }
+
+  // snapshot of the fee charged when the booking was prioritized; refunded
+  // when the booking ends Refunded or Cancelled
+  [Precision(16, 8)]
+  public decimal? PriorityFee { get; set; }
 
   // record
   public DateOnly Date { get; set; }

--- a/App/Modules/Bookings/Data/BookingMapper.cs
+++ b/App/Modules/Bookings/Data/BookingMapper.cs
@@ -53,6 +53,8 @@ public static class BookingMapper
       Record = data.ToRecord(),
       Status = data.ToStatus(),
       Complete = data.ToComplete(),
+      Priority = data.Priority,
+      PriorityFee = data.PriorityFee,
     };
 
   public static Booking ToDomain(this BookingData data) =>

--- a/App/Modules/Bookings/Data/BookingQueue.cs
+++ b/App/Modules/Bookings/Data/BookingQueue.cs
@@ -1,0 +1,19 @@
+using System.Linq.Expressions;
+
+namespace App.Modules.Bookings.Data;
+
+// The purchase-queue ordering in one place: priority first, then oldest
+// CreatedAt, Id as the deterministic tiebreak. Reserve() sorts by these keys
+// and QueuePosition() counts with AheadOf — they must always agree.
+public static class BookingQueue
+{
+  // EF-translatable (b's fields are captured constants): x is ahead of b iff
+  // x outranks b on priority, or ties on priority and booked earlier
+  public static Expression<Func<BookingData, bool>> AheadOf(BookingData b) =>
+    x =>
+      (x.Priority && !b.Priority)
+      || (
+        x.Priority == b.Priority
+        && (x.CreatedAt < b.CreatedAt || (x.CreatedAt == b.CreatedAt && x.Id < b.Id))
+      );
+}

--- a/App/Modules/Bookings/Data/BookingRepository.cs
+++ b/App/Modules/Bookings/Data/BookingRepository.cs
@@ -116,7 +116,7 @@ public class BookingRepository(
   }
 
   // statuses still waiting for the buyer form the timeslot's queue,
-  // processed oldest-first
+  // processed priority-first, then oldest-first
   private static bool IsQueued(byte status) =>
     status
       is (byte)BookStatus.Pending
@@ -151,11 +151,10 @@ public class BookingRepository(
           || x.Status == (byte)BookStatus.Recovering
         )
       );
-      // the buyer works oldest-first, so everyone who booked earlier (Id as
-      // the deterministic tiebreak) is ahead of this booking
-      var ahead = await slot
-        .Where(x => x.CreatedAt < b.CreatedAt || (x.CreatedAt == b.CreatedAt && x.Id < b.Id))
-        .CountAsync();
+      // the buyer works priority-first, then oldest-first (Id as the
+      // deterministic tiebreak) — the predicate must mirror Reserve()'s
+      // ordering exactly or the shown position lies
+      var ahead = await slot.Where(BookingQueue.AheadOf(b)).CountAsync();
       var total = await slot.CountAsync();
 
       return new BookingQueuePosition
@@ -418,6 +417,8 @@ public class BookingRepository(
         time
       );
 
+      // priority first, then oldest-first (Id tiebreak) — must mirror
+      // BookingQueue.AheadOf, which QueuePosition uses to count "ahead"
       var v1 = await db
         .Bookings.Where(x =>
           x.Direction == direction.ToData()
@@ -425,7 +426,9 @@ public class BookingRepository(
           && x.Time == time
           && x.Status == (int)BookStatus.Pending
         )
-        .OrderBy(x => x.CreatedAt)
+        .OrderByDescending(x => x.Priority)
+        .ThenBy(x => x.CreatedAt)
+        .ThenBy(x => x.Id)
         .FirstOrDefaultAsync();
       return v1?.ToPrincipal();
     }
@@ -438,6 +441,34 @@ public class BookingRepository(
         date,
         time
       );
+      return e;
+    }
+  }
+
+  public async Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal fee)
+  {
+    try
+    {
+      logger.LogInformation(
+        "Prioritizing Booking '{Id}' under User '{UserId}' with fee {Fee}",
+        id,
+        userId,
+        fee
+      );
+      var v1 = await db
+        .Bookings.Where(x => x.Id == id && (userId == null || x.UserId == userId))
+        .FirstOrDefaultAsync();
+      if (v1 == null)
+        return (BookingPrincipal?)null;
+
+      v1.Priority = true;
+      v1.PriorityFee = fee;
+      await db.SaveChangesAsync();
+      return v1.ToPrincipal();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to prioritize Booking '{Id}' under User '{UserId}'", id, userId);
       return e;
     }
   }

--- a/App/Modules/Bookings/Data/PriorityData.cs
+++ b/App/Modules/Bookings/Data/PriorityData.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace App.Modules.Bookings.Data;
+
+// Insert-only priority-queue settings (newest CreatedAt wins, like Costs);
+// with no row the domain defaults apply (fee 10, allowlist-only, no window)
+public class PrioritySettingsData
+{
+  public Guid Id { get; set; }
+
+  public DateTime CreatedAt { get; set; }
+
+  // Record
+  [Precision(16, 8)]
+  public decimal Fee { get; set; }
+
+  // true = every user may prioritize; false = allowlisted users only
+  public bool AllowAll { get; set; }
+
+  // SGT wall-clock availability window [start, end); both null = always
+  public TimeOnly? WindowStartSgt { get; set; }
+
+  public TimeOnly? WindowEndSgt { get; set; }
+}
+
+// A user allowed to prioritize bookings (when AllowAll is off)
+public class PriorityAccessData
+{
+  [Key]
+  [MaxLength(128)]
+  public string UserId { get; set; } = string.Empty;
+
+  public DateTime CreatedAt { get; set; }
+}

--- a/App/Modules/Bookings/Data/PriorityRepository.cs
+++ b/App/Modules/Bookings/Data/PriorityRepository.cs
@@ -1,0 +1,162 @@
+using App.StartUp.Database;
+using App.Utility;
+using CSharp_Result;
+using Domain.Booking;
+using Microsoft.EntityFrameworkCore;
+
+namespace App.Modules.Bookings.Data;
+
+public class PrioritySettingsRepository(
+  MainDbContext db,
+  ILogger<PrioritySettingsRepository> logger
+) : IPrioritySettingsRepository
+{
+  public async Task<Result<PrioritySettingsPrincipal?>> GetCurrent()
+  {
+    try
+    {
+      var r = await db
+        .PrioritySettings.OrderByDescending(x => x.CreatedAt)
+        .ThenByDescending(x => x.Id)
+        .FirstOrDefaultAsync();
+      return r?.ToPrincipal();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to read the current priority settings");
+      return e;
+    }
+  }
+
+  public async Task<Result<PrioritySettingsPrincipal>> Create(PrioritySettingsRecord record)
+  {
+    try
+    {
+      logger.LogInformation("Creating PrioritySettings: {@Record}", record.ToJson());
+      var data = new PrioritySettingsData { CreatedAt = DateTime.UtcNow };
+      data.UpdateData(record);
+      var r = db.PrioritySettings.Add(data);
+      await db.SaveChangesAsync();
+      return r.Entity.ToPrincipal();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to create PrioritySettings {@Record}", record.ToJson());
+      return e;
+    }
+  }
+}
+
+public class PriorityAccessRepository(MainDbContext db, ILogger<PriorityAccessRepository> logger)
+  : IPriorityAccessRepository
+{
+  public async Task<Result<IEnumerable<PriorityAccess>>> List()
+  {
+    try
+    {
+      logger.LogInformation("Listing priority access users");
+      var r = await db
+        .PriorityAccesses.OrderBy(x => x.CreatedAt)
+        .ThenBy(x => x.UserId)
+        .ToArrayAsync();
+      return r.Select(x => x.ToDomain()).ToResult();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed listing priority access users");
+      return e;
+    }
+  }
+
+  public async Task<Result<PriorityAccess>> Add(string userId)
+  {
+    try
+    {
+      logger.LogInformation("Adding priority access for User '{UserId}'", userId);
+      var existing = await db
+        .PriorityAccesses.Where(x => x.UserId == userId)
+        .FirstOrDefaultAsync();
+      // idempotent: allowlisting twice is a no-op
+      if (existing != null)
+        return existing.ToDomain();
+      var data = new PriorityAccessData { UserId = userId, CreatedAt = DateTime.UtcNow };
+      var r = db.PriorityAccesses.Add(data);
+      await db.SaveChangesAsync();
+      return r.Entity.ToDomain();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to add priority access for User '{UserId}'", userId);
+      return e;
+    }
+  }
+
+  public async Task<Result<Unit?>> Remove(string userId)
+  {
+    try
+    {
+      logger.LogInformation("Removing priority access for User '{UserId}'", userId);
+      var data = await db.PriorityAccesses.Where(x => x.UserId == userId).FirstOrDefaultAsync();
+      if (data == null)
+        return (Unit?)null;
+      db.PriorityAccesses.Remove(data);
+      await db.SaveChangesAsync();
+      return new Unit();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to remove priority access for User '{UserId}'", userId);
+      return e;
+    }
+  }
+
+  public async Task<Result<bool>> Contains(string userId)
+  {
+    try
+    {
+      return await db.PriorityAccesses.AnyAsync(x => x.UserId == userId);
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to check priority access for User '{UserId}'", userId);
+      return e;
+    }
+  }
+}
+
+public static class PriorityDataMapper
+{
+  // Data -> Domain
+  public static PrioritySettingsRecord ToRecord(this PrioritySettingsData data) =>
+    new()
+    {
+      Fee = data.Fee,
+      AllowAll = data.AllowAll,
+      WindowStartSgt = data.WindowStartSgt,
+      WindowEndSgt = data.WindowEndSgt,
+    };
+
+  public static PrioritySettingsPrincipal ToPrincipal(this PrioritySettingsData data) =>
+    new()
+    {
+      Id = data.Id,
+      CreatedAt = data.CreatedAt,
+      Record = data.ToRecord(),
+    };
+
+  public static PriorityAccess ToDomain(this PriorityAccessData data) =>
+    new() { UserId = data.UserId, CreatedAt = data.CreatedAt };
+
+  // Domain -> Data
+  public static PrioritySettingsData UpdateData(
+    this PrioritySettingsData data,
+    PrioritySettingsRecord record
+  )
+  {
+    data.Fee = record.Fee;
+    data.AllowAll = record.AllowAll;
+    data.WindowStartSgt = record.WindowStartSgt;
+    data.WindowEndSgt = record.WindowEndSgt;
+    return data;
+  }
+}

--- a/App/Modules/Costs/API/V1/CostController.cs
+++ b/App/Modules/Costs/API/V1/CostController.cs
@@ -19,6 +19,8 @@ namespace App.Modules.Costs.API.V1;
 public class CostController(
   ICostService service,
   CreateCostReqValidator costReqValidator,
+  CostPolicyReqValidator costPolicyReqValidator,
+  CostSummaryQueryValidator costSummaryQueryValidator,
   IAuthHelper h
 ) : AtomiControllerBase(h)
 {
@@ -56,11 +58,74 @@ public class CostController(
   {
     var sub = this.Sub()!;
     var role = h.FieldToScope(HttpContext.User, AuthRoles.Field);
-    var cost = await service.Materialize(sub, role.ToArray()).Then(x => x?.ToRes(), Errors.MapNone);
+    var cost = await service
+      .Materialize(sub, role.ToArray(), null)
+      .Then(x => x?.ToRes(), Errors.MapNone);
 
     return this.ReturnNullableResult(
       cost,
       new EntityNotFound("Cost Not Found", typeof(CostPrincipal), "none")
+    );
+  }
+
+  // the full price breakdown for one booking spec, for the CALLING user —
+  // powers the purchase page and the admin costs page live preview
+  [Authorize, HttpGet("summary")]
+  public async Task<ActionResult<CostSummaryRes>> Summary([FromQuery] CostSummaryQuery query)
+  {
+    var sub = this.Sub()!;
+    var role = h.FieldToScope(HttpContext.User, AuthRoles.Field);
+    var cost = await costSummaryQueryValidator
+      .ValidateAsyncResult(query, "Invalid CostSummaryQuery")
+      .ThenAwait(q => service.Materialize(sub, role.ToArray(), q.ToDomain()))
+      .Then(x => x.ToSummaryRes(), Errors.MapNone);
+
+    return this.ReturnResult(cost);
+  }
+
+  // Policies: pricing rules that add signed deltas onto the base cost
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("policies")]
+  public async Task<ActionResult<IEnumerable<CostPolicyPrincipalRes>>> ListPolicies()
+  {
+    var x = await service.ListPolicies().Then(p => p.Select(a => a.ToRes()), Errors.MapNone);
+    return this.ReturnResult(x);
+  }
+
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpPost("policies")]
+  public async Task<ActionResult<CostPolicyPrincipalRes>> CreatePolicy(
+    [FromBody] CostPolicyReq req
+  )
+  {
+    var x = await costPolicyReqValidator
+      .ValidateAsyncResult(req, "Invalid CostPolicyReq")
+      .ThenAwait(r => service.CreatePolicy(r.ToDomain()))
+      .Then(p => p.ToRes(), Errors.MapNone);
+    return this.ReturnResult(x);
+  }
+
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpPut("policies/{id:guid}")]
+  public async Task<ActionResult<CostPolicyPrincipalRes>> UpdatePolicy(
+    Guid id,
+    [FromBody] CostPolicyReq req
+  )
+  {
+    var x = await costPolicyReqValidator
+      .ValidateAsyncResult(req, "Invalid CostPolicyReq")
+      .ThenAwait(r => service.UpdatePolicy(id, r.ToDomain()))
+      .Then(p => p?.ToRes(), Errors.MapNone);
+    return this.ReturnNullableResult(
+      x,
+      new EntityNotFound("Cost Policy Not Found", typeof(CostPolicyPrincipal), id.ToString())
+    );
+  }
+
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpDelete("policies/{id:guid}")]
+  public async Task<ActionResult> DeletePolicy(Guid id)
+  {
+    var x = await service.DeletePolicy(id);
+    return this.ReturnUnitNullableResult(
+      x,
+      new EntityNotFound("Cost Policy Not Found", typeof(CostPolicyPrincipal), id.ToString())
     );
   }
 }

--- a/App/Modules/Costs/API/V1/CostMapper.cs
+++ b/App/Modules/Costs/API/V1/CostMapper.cs
@@ -1,4 +1,6 @@
 using App.Modules.Discounts.API.V1;
+using App.Modules.Timings.API.V1;
+using App.Utility;
 using Domain.Cost;
 
 namespace App.Modules.Costs.API.V1;
@@ -9,9 +11,69 @@ public static class CostMapper
   public static CostPrincipalRes ToRes(this CostPrincipal principal) =>
     new(principal.Id, principal.CreatedAt, principal.Record.Cost);
 
+  public static CostPolicyLineRes ToRes(this CostPolicyLine line) => new(line.Name, line.Delta);
+
   public static MaterializedCostRes ToRes(this MaterializedCost cost) =>
-    new(cost.Cost, cost.Final, cost.Discounts.Select(x => x.ToRes()).ToArray());
+    new(
+      cost.Cost,
+      cost.PolicyLines.Select(x => x.ToRes()).ToArray(),
+      cost.Subtotal,
+      cost.Final,
+      cost.Discounts.Select(x => x.ToRes()).ToArray()
+    );
+
+  public static CostSummaryRes ToSummaryRes(this MaterializedCost cost) =>
+    new(
+      cost.Cost,
+      cost.PolicyLines.Select(x => x.ToRes()).ToArray(),
+      cost.Subtotal,
+      cost.Discounts.Select(x => x.ToRes()).ToArray(),
+      cost.Final
+    );
+
+  public static CostPolicyPrincipalRes ToRes(this CostPolicyPrincipal principal) =>
+    new(
+      principal.Id,
+      principal.CreatedAt,
+      principal.Record.Name,
+      principal.Record.Enabled,
+      principal.Record.MatchDate?.ToStandardDateFormat(),
+      principal.Record.MatchTime?.ToStandardTimeFormat(),
+      principal.Record.MatchDayOfWeek?.ToString(),
+      principal.Record.MatchDirection?.ToRes(),
+      principal.Record.LeadTimeUnderHours,
+      principal.Record.Amount,
+      principal.Record.IsPercentage,
+      principal.Record.EffectiveAt,
+      principal.Record.ExpiresAt
+    );
 
   // REQ -> Domain
   public static CostRecord ToDomain(this CreateCostReq req) => new() { Cost = req.Cost };
+
+  public static CostPolicyRecord ToDomain(this CostPolicyReq req) =>
+    new()
+    {
+      Name = req.Name,
+      Enabled = req.Enabled,
+      MatchDate = req.MatchDate?.ToDate(),
+      MatchTime = req.MatchTime?.ToTime(),
+      MatchDayOfWeek = req.MatchDayOfWeek == null
+        ? null
+        : Enum.Parse<DayOfWeek>(req.MatchDayOfWeek),
+      MatchDirection = req.MatchDirection?.DirectionToDomain(),
+      LeadTimeUnderHours = req.LeadTimeUnderHours,
+      Amount = req.Amount,
+      IsPercentage = req.IsPercentage,
+      EffectiveAt = req.EffectiveAt,
+      ExpiresAt = req.ExpiresAt,
+    };
+
+  public static BookingCostSpec ToDomain(this CostSummaryQuery query) =>
+    new()
+    {
+      Date = query.Date.ToDate(),
+      Time = query.Time.ToTime(),
+      Direction = query.Direction.DirectionToDomain(),
+    };
 }

--- a/App/Modules/Costs/API/V1/CostModel.cs
+++ b/App/Modules/Costs/API/V1/CostModel.cs
@@ -4,7 +4,64 @@ namespace App.Modules.Costs.API.V1;
 
 public record CreateCostReq(decimal Cost);
 
+// REQ
+// A pricing rule. Match* null = matches any value for that dimension.
+// MatchDate: dd-MM-yyyy, MatchTime: HH:mm:ss, MatchDayOfWeek: Monday..Sunday,
+// MatchDirection: JToW | WToJ. Amount is SIGNED (negative = discount) and a
+// percent of the base cost when IsPercentage.
+public record CostPolicyReq(
+  string Name,
+  bool Enabled,
+  string? MatchDate,
+  string? MatchTime,
+  string? MatchDayOfWeek,
+  string? MatchDirection,
+  int? LeadTimeUnderHours,
+  decimal Amount,
+  bool IsPercentage,
+  DateTime? EffectiveAt,
+  DateTime? ExpiresAt
+);
+
+// query for the price breakdown of a hypothetical booking spec
+public record CostSummaryQuery(string Date, string Time, string Direction);
+
 // RESP
 public record CostPrincipalRes(Guid Id, DateTime CreatedAt, decimal Cost);
 
-public record MaterializedCostRes(decimal Cost, decimal Final, DiscountRecordRes[] Discounts);
+public record CostPolicyLineRes(string Name, decimal Delta);
+
+public record MaterializedCostRes(
+  decimal Cost,
+  CostPolicyLineRes[] PolicyLines,
+  decimal Subtotal,
+  decimal Final,
+  DiscountRecordRes[] Discounts
+);
+
+// the full price breakdown for one booking spec — every step adds up:
+// BaseCost + sum(PolicyLines.Delta) = Subtotal (floored at 0), Subtotal
+// less Discounts = Final
+public record CostSummaryRes(
+  decimal BaseCost,
+  CostPolicyLineRes[] PolicyLines,
+  decimal Subtotal,
+  DiscountRecordRes[] Discounts,
+  decimal Final
+);
+
+public record CostPolicyPrincipalRes(
+  Guid Id,
+  DateTime CreatedAt,
+  string Name,
+  bool Enabled,
+  string? MatchDate,
+  string? MatchTime,
+  string? MatchDayOfWeek,
+  string? MatchDirection,
+  int? LeadTimeUnderHours,
+  decimal Amount,
+  bool IsPercentage,
+  DateTime? EffectiveAt,
+  DateTime? ExpiresAt
+);

--- a/App/Modules/Costs/API/V1/CostValidator.cs
+++ b/App/Modules/Costs/API/V1/CostValidator.cs
@@ -1,3 +1,4 @@
+using App.Utility;
 using FluentValidation;
 
 namespace App.Modules.Costs.API.V1;
@@ -9,5 +10,49 @@ public class CreateCostReqValidator : AbstractValidator<CreateCostReq>
     this.RuleFor(x => x.Cost)
       .GreaterThanOrEqualTo(0)
       .WithMessage("Cost has to be larger than or equal to 0");
+  }
+}
+
+public class CostPolicyReqValidator : AbstractValidator<CostPolicyReq>
+{
+  public CostPolicyReqValidator()
+  {
+    this.RuleFor(x => x.Name).NotNull().NameValid();
+    this.RuleFor(x => x.MatchDate).NullableDateValid();
+    this.RuleFor(x => x.MatchTime).NullableTimeValid();
+    // Enum.TryParse would happily accept numerics ("9") — names only
+    this.RuleFor(x => x.MatchDayOfWeek)
+      .Must(x => x is null || Enum.GetNames<DayOfWeek>().Contains(x))
+      .WithMessage("MatchDayOfWeek must be one of: Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday");
+    this.RuleFor(x => x.MatchDirection)!.TrainDirectionValid();
+    this.RuleFor(x => x.LeadTimeUnderHours)
+      .GreaterThanOrEqualTo(1)
+      .LessThanOrEqualTo(8760)
+      .When(x => x.LeadTimeUnderHours != null)
+      .WithMessage("LeadTimeUnderHours must be between 1 and 8760 (a year)");
+    // Amount is deliberately SIGNED: negative = discount
+    this.RuleFor(x => x.Amount)
+      .GreaterThanOrEqualTo(-100)
+      .LessThanOrEqualTo(100)
+      .When(x => x.IsPercentage)
+      .WithMessage("A percentage Amount must be between -100 and 100");
+    this.RuleFor(x => x.Amount)
+      .GreaterThanOrEqualTo(-10_000)
+      .LessThanOrEqualTo(10_000)
+      .When(x => !x.IsPercentage)
+      .WithMessage("A flat Amount must be between -10000 and 10000");
+    this.RuleFor(x => x.ExpiresAt)
+      .Must((req, x) => x == null || req.EffectiveAt == null || x > req.EffectiveAt)
+      .WithMessage("ExpiresAt must be after EffectiveAt");
+  }
+}
+
+public class CostSummaryQueryValidator : AbstractValidator<CostSummaryQuery>
+{
+  public CostSummaryQueryValidator()
+  {
+    this.RuleFor(x => x.Date).NotNull().DateValid();
+    this.RuleFor(x => x.Time).NotNull().TimeValid();
+    this.RuleFor(x => x.Direction).NotNull().TrainDirectionValid();
   }
 }

--- a/App/Modules/Costs/Data/CostPolicyData.cs
+++ b/App/Modules/Costs/Data/CostPolicyData.cs
@@ -1,0 +1,42 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace App.Modules.Costs.Data;
+
+// A pricing rule row: every non-null Match* dimension must equal the
+// booking's for the (signed) Amount to be added to the base cost
+public class CostPolicyData
+{
+  public Guid Id { get; set; }
+
+  public DateTime CreatedAt { get; set; }
+
+  // Record
+  [MaxLength(256)]
+  public string Name { get; set; } = string.Empty;
+
+  public bool Enabled { get; set; }
+
+  public DateOnly? MatchDate { get; set; }
+
+  public TimeOnly? MatchTime { get; set; }
+
+  // Domain DayOfWeek: 0 = Sunday ... 6 = Saturday
+  public byte? MatchDayOfWeek { get; set; }
+
+  // TrainDirection via TimingMapper.ToData: 1 = JToW, 2 = WToJ
+  public int? MatchDirection { get; set; }
+
+  public int? LeadTimeUnderHours { get; set; }
+
+  // SIGNED: negative = discount; percent of base cost when IsPercentage
+  [Precision(16, 8)]
+  public decimal Amount { get; set; }
+
+  public bool IsPercentage { get; set; }
+
+  // active window [EffectiveAt, ExpiresAt); null = unbounded on that side
+  public DateTime? EffectiveAt { get; set; }
+
+  public DateTime? ExpiresAt { get; set; }
+}

--- a/App/Modules/Costs/Data/CostPolicyRepository.cs
+++ b/App/Modules/Costs/Data/CostPolicyRepository.cs
@@ -1,0 +1,139 @@
+using App.Modules.Timings.Data;
+using App.StartUp.Database;
+using App.Utility;
+using CSharp_Result;
+using Domain.Cost;
+using Microsoft.EntityFrameworkCore;
+
+namespace App.Modules.Costs.Data;
+
+public class CostPolicyRepository(MainDbContext db, ILogger<CostPolicyRepository> logger)
+  : ICostPolicyRepository
+{
+  public async Task<Result<IEnumerable<CostPolicyPrincipal>>> List()
+  {
+    try
+    {
+      logger.LogInformation("Listing cost policies");
+      var r = await db.CostPolicies.OrderByDescending(x => x.CreatedAt).ThenBy(x => x.Id).ToArrayAsync();
+      return r.Select(x => x.ToPrincipal()).ToResult();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed listing cost policies");
+      return e;
+    }
+  }
+
+  public async Task<Result<CostPolicyPrincipal>> Create(CostPolicyRecord record)
+  {
+    try
+    {
+      logger.LogInformation("Creating CostPolicy: {@Record}", record.ToJson());
+      var data = new CostPolicyData { CreatedAt = DateTime.UtcNow };
+      data.UpdateData(record);
+      var r = db.CostPolicies.Add(data);
+      await db.SaveChangesAsync();
+      return r.Entity.ToPrincipal();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to create CostPolicy {@Record}", record.ToJson());
+      return e;
+    }
+  }
+
+  public async Task<Result<CostPolicyPrincipal?>> Update(Guid id, CostPolicyRecord record)
+  {
+    try
+    {
+      logger.LogInformation("Updating CostPolicy '{Id}' with: {@Record}", id, record.ToJson());
+      var data = await db.CostPolicies.Where(x => x.Id == id).FirstOrDefaultAsync();
+      if (data == null)
+        return (CostPolicyPrincipal?)null;
+      data.UpdateData(record);
+      await db.SaveChangesAsync();
+      return data.ToPrincipal();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to update CostPolicy '{Id}' with {@Record}", id, record.ToJson());
+      return e;
+    }
+  }
+
+  public async Task<Result<Unit?>> Delete(Guid id)
+  {
+    try
+    {
+      logger.LogInformation("Deleting CostPolicy '{Id}'", id);
+      var data = await db.CostPolicies.Where(x => x.Id == id).FirstOrDefaultAsync();
+      if (data == null)
+        return (Unit?)null;
+      db.CostPolicies.Remove(data);
+      await db.SaveChangesAsync();
+      return new Unit();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to delete CostPolicy '{Id}'", id);
+      return e;
+    }
+  }
+}
+
+public static class CostPolicyDataMapper
+{
+  // Data -> Domain
+  public static CostPolicyRecord ToRecord(this CostPolicyData data) =>
+    new()
+    {
+      Name = data.Name,
+      Enabled = data.Enabled,
+      MatchDate = data.MatchDate,
+      MatchTime = data.MatchTime,
+      MatchDayOfWeek = data.MatchDayOfWeek == null ? null : (DayOfWeek)data.MatchDayOfWeek.Value,
+      MatchDirection = data.MatchDirection?.ToTrainDirection(),
+      LeadTimeUnderHours = data.LeadTimeUnderHours,
+      Amount = data.Amount,
+      IsPercentage = data.IsPercentage,
+      EffectiveAt = data.EffectiveAt,
+      ExpiresAt = data.ExpiresAt,
+    };
+
+  public static CostPolicyPrincipal ToPrincipal(this CostPolicyData data) =>
+    new()
+    {
+      Id = data.Id,
+      CreatedAt = data.CreatedAt,
+      Record = data.ToRecord(),
+    };
+
+  // Domain -> Data
+  public static CostPolicyData UpdateData(this CostPolicyData data, CostPolicyRecord record)
+  {
+    data.Name = record.Name;
+    data.Enabled = record.Enabled;
+    data.MatchDate = record.MatchDate;
+    data.MatchTime = record.MatchTime;
+    data.MatchDayOfWeek = record.MatchDayOfWeek == null ? null : (byte)record.MatchDayOfWeek.Value;
+    data.MatchDirection = record.MatchDirection?.ToData();
+    data.LeadTimeUnderHours = record.LeadTimeUnderHours;
+    data.Amount = record.Amount;
+    data.IsPercentage = record.IsPercentage;
+    // normalize to UTC: JSON without a Z suffix binds as Unspecified and an
+    // offset binds as Local — Npgsql rejects both for timestamptz
+    data.EffectiveAt = record.EffectiveAt.ToUtcOrNull();
+    data.ExpiresAt = record.ExpiresAt.ToUtcOrNull();
+    return data;
+  }
+
+  private static DateTime? ToUtcOrNull(this DateTime? at) =>
+    at?.Kind switch
+    {
+      null => null,
+      DateTimeKind.Utc => at.Value,
+      DateTimeKind.Local => at.Value.ToUniversalTime(),
+      _ => DateTime.SpecifyKind(at.Value, DateTimeKind.Utc),
+    };
+}

--- a/App/Modules/DomainServices.cs
+++ b/App/Modules/DomainServices.cs
@@ -70,6 +70,13 @@ public static class DomainServices
     s.AddScoped<IBookingTerminatorRepository, BookingTerminatorRepository>()
       .AutoTrace<IBookingTerminatorRepository>();
 
+    // Priority queue
+    s.AddScoped<IPrioritySettingsRepository, PrioritySettingsRepository>()
+      .AutoTrace<IPrioritySettingsRepository>();
+
+    s.AddScoped<IPriorityAccessRepository, PriorityAccessRepository>()
+      .AutoTrace<IPriorityAccessRepository>();
+
     // Transaction
     s.AddScoped<ITransactionService, TransactionService>().AutoTrace<ITimingService>();
 
@@ -119,6 +126,8 @@ public static class DomainServices
     s.AddScoped<IDiscountCalculator, DiscountCalculator>().AutoTrace<IDiscountCalculator>();
 
     s.AddScoped<ICostRepository, CostRepository>().AutoTrace<ICostRepository>();
+
+    s.AddScoped<ICostPolicyRepository, CostPolicyRepository>().AutoTrace<ICostPolicyRepository>();
 
     s.AddScoped<IDiscountRepository, DiscountRepository>().AutoTrace<IDiscountRepository>();
 

--- a/App/Modules/Transactions/API/V1/TransactionMapper.cs
+++ b/App/Modules/Transactions/API/V1/TransactionMapper.cs
@@ -26,6 +26,7 @@ public static class TransactionMapper
       TransactionType.WithdrawCancelled => TransactionTypes.WithdrawCancelled,
       TransactionType.WithdrawFee => TransactionTypes.WithdrawFee,
       TransactionType.DepositFee => TransactionTypes.DepositFee,
+      TransactionType.PriorityFee => TransactionTypes.PriorityFee,
       _ => throw new ArgumentOutOfRangeException(nameof(type), type, null),
     };
 
@@ -63,6 +64,7 @@ public static class TransactionMapper
       TransactionTypes.WithdrawCancelled => TransactionType.WithdrawCancelled,
       TransactionTypes.WithdrawFee => TransactionType.WithdrawFee,
       TransactionTypes.DepositFee => TransactionType.DepositFee,
+      TransactionTypes.PriorityFee => TransactionType.PriorityFee,
       _ => throw new ArgumentOutOfRangeException(nameof(type), type, null),
     };
 

--- a/App/StartUp/Database/MainDbContext.cs
+++ b/App/StartUp/Database/MainDbContext.cs
@@ -31,6 +31,8 @@ public class MainDbContext(
   public DbSet<DiscountData> Discounts { get; set; }
   public DbSet<CostData> Costs { get; set; }
 
+  public DbSet<CostPolicyData> CostPolicies { get; set; }
+
   public DbSet<WalletData> Wallets { get; set; }
 
   public DbSet<WithdrawalData> Withdrawals { get; set; }
@@ -44,6 +46,10 @@ public class MainDbContext(
   public DbSet<PassengerData> Passengers { get; set; }
 
   public DbSet<BookingData> Bookings { get; set; }
+
+  public DbSet<PrioritySettingsData> PrioritySettings { get; set; }
+
+  public DbSet<PriorityAccessData> PriorityAccesses { get; set; }
 
   public DbSet<ScheduleData> Schedules { get; set; }
 

--- a/Domain/Booking/BookingOperations.cs
+++ b/Domain/Booking/BookingOperations.cs
@@ -23,4 +23,6 @@ public static class BookingOperations
   public const string Revert = "Revert";
 
   public const string CompleteNoCollect = "CompleteNoCollect";
+
+  public const string Prioritize = "Prioritize";
 }

--- a/Domain/Booking/IService.cs
+++ b/Domain/Booking/IService.cs
@@ -54,4 +54,10 @@ public interface IBookingService
   Task<Result<IEnumerable<BookingCount>>> Count();
 
   Task<Result<IEnumerable<BookingCount>>> Count(BookingCountSearch query);
+
+  // may this user prioritize a booking right now, and at what fee
+  Task<Result<PriorityEligibility>> PriorityEligibility(string userId);
+
+  // charge the priority fee and move the booking to the front of its queue
+  Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id);
 }

--- a/Domain/Booking/Model.cs
+++ b/Domain/Booking/Model.cs
@@ -102,6 +102,14 @@ public record BookingPrincipal
   public required BookingStatus Status { get; init; }
 
   public required BookingComplete Complete { get; init; }
+
+  // priority bookings jump to the front of their timeslot's purchase queue
+  // (defaults keep pre-priority construction sites valid)
+  public bool Priority { get; init; }
+
+  // snapshot of the fee charged when the booking was prioritized; refunded
+  // to Usable when the booking ends Refunded or Cancelled
+  public decimal? PriorityFee { get; init; }
 }
 
 public record BookingComplete

--- a/Domain/Booking/Priority.cs
+++ b/Domain/Booking/Priority.cs
@@ -58,12 +58,14 @@ public record PriorityEligibility
 public static class PriorityRules
 {
   // half-open [start, end); start > end wraps midnight; either bound null =
-  // always open
+  // always open. start == end is ALSO always open: an admin writing
+  // 00:00 -> 00:00 means "all day", and the strict half-open reading would
+  // silently brick the feature
   public static bool WindowOpen(TimeOnly? start, TimeOnly? end, TimeOnly nowSgt)
   {
-    if (start == null || end == null)
+    if (start == null || end == null || start.Value == end.Value)
       return true;
-    return start.Value <= end.Value
+    return start.Value < end.Value
       ? nowSgt >= start.Value && nowSgt < end.Value
       : nowSgt >= start.Value || nowSgt < end.Value;
   }

--- a/Domain/Booking/Priority.cs
+++ b/Domain/Booking/Priority.cs
@@ -1,0 +1,97 @@
+using CSharp_Result;
+
+namespace Domain.Booking;
+
+// Admin-editable priority-queue settings (insert-only, newest row wins —
+// same pattern as Cost). With no row the defaults apply.
+public record PrioritySettingsRecord
+{
+  public required decimal Fee { get; init; }
+
+  // true = every user may prioritize; false = allowlisted users only
+  public required bool AllowAll { get; init; }
+
+  // SGT wall-clock window [WindowStartSgt, WindowEndSgt) in which
+  // prioritizing is available; null = always available. May wrap midnight
+  // (start > end).
+  public required TimeOnly? WindowStartSgt { get; init; }
+
+  public required TimeOnly? WindowEndSgt { get; init; }
+
+  public static readonly PrioritySettingsRecord Default = new()
+  {
+    Fee = 10m,
+    AllowAll = false,
+    WindowStartSgt = null,
+    WindowEndSgt = null,
+  };
+}
+
+public record PrioritySettingsPrincipal
+{
+  public required Guid Id { get; init; }
+
+  public required DateTime CreatedAt { get; init; }
+
+  public required PrioritySettingsRecord Record { get; init; }
+}
+
+// A user allowed to prioritize bookings (when AllowAll is off)
+public record PriorityAccess
+{
+  public required string UserId { get; init; }
+
+  public required DateTime CreatedAt { get; init; }
+}
+
+// What the eligibility endpoint (and the prioritize guard) answers: may this
+// user prioritize right now, and at what fee
+public record PriorityEligibility
+{
+  public required bool Eligible { get; init; }
+
+  public required decimal Fee { get; init; }
+}
+
+// Pure eligibility rules, shared by the endpoint, the prioritize guard and
+// the unit tests
+public static class PriorityRules
+{
+  // half-open [start, end); start > end wraps midnight; either bound null =
+  // always open
+  public static bool WindowOpen(TimeOnly? start, TimeOnly? end, TimeOnly nowSgt)
+  {
+    if (start == null || end == null)
+      return true;
+    return start.Value <= end.Value
+      ? nowSgt >= start.Value && nowSgt < end.Value
+      : nowSgt >= start.Value || nowSgt < end.Value;
+  }
+
+  public static bool Eligible(bool allowlisted, PrioritySettingsRecord settings, TimeOnly nowSgt)
+  {
+    return (allowlisted || settings.AllowAll)
+      && WindowOpen(settings.WindowStartSgt, settings.WindowEndSgt, nowSgt);
+  }
+}
+
+public interface IPrioritySettingsRepository
+{
+  // the newest settings row, or null when none was ever written (defaults apply)
+  Task<Result<PrioritySettingsPrincipal?>> GetCurrent();
+
+  Task<Result<PrioritySettingsPrincipal>> Create(PrioritySettingsRecord record);
+}
+
+public interface IPriorityAccessRepository
+{
+  Task<Result<IEnumerable<PriorityAccess>>> List();
+
+  // idempotent: adding an already-allowlisted user returns the existing row
+  Task<Result<PriorityAccess>> Add(string userId);
+
+  // null when the user was not allowlisted
+  Task<Result<Unit?>> Remove(string userId);
+
+  Task<Result<bool>> Contains(string userId);
+}

--- a/Domain/Booking/Repository.cs
+++ b/Domain/Booking/Repository.cs
@@ -32,6 +32,10 @@ public interface IBookingRepository
 
   Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly Time);
 
+  // marks the booking priority (front of its queue) and snapshots the fee
+  // charged; null when the booking does not exist (or is not visible to userId)
+  Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal fee);
+
   Task<Result<Unit?>> Delete(string? userId, Guid id);
 
   Task<Result<IEnumerable<BookingCount>>> Count(

--- a/Domain/Booking/Service.cs
+++ b/Domain/Booking/Service.cs
@@ -606,6 +606,11 @@ public class BookingService(
                   transactionGenerator.DuplicateBooking(b.Transaction.Record, b.Principal.Record)
                 )
             )
+            // return the priority fee: no ticket was delivered by us, so the
+            // paid-for queue jump was never consumed — same policy as Refund
+            // and Cancel (Duplicate is terminal; keeping the fee would be a
+            // silent, unledgered retention)
+            .DoAwait(DoType.MapErrors, this.RefundPriorityFeeIfAny)
             // update the booking
             .ThenAwait(x =>
               repo.Update(

--- a/Domain/Booking/Service.cs
+++ b/Domain/Booking/Service.cs
@@ -18,6 +18,8 @@ public class BookingService(
   IBookingTerminatorRepository terminatorRepository,
   IBookingCdcRepository cdcRepository,
   IBookingNotificationService notificationService,
+  IPrioritySettingsRepository prioritySettingsRepo,
+  IPriorityAccessRepository priorityAccessRepo,
   ILogger<BookingService> logger
 ) : IBookingService
 {
@@ -519,6 +521,9 @@ public class BookingService(
                   transactionGenerator.CancelBooking(b.Transaction.Record, b.Principal.Record)
                 )
             )
+            // return the priority fee: the user backed out before delivery,
+            // so the paid-for queue jump was never consumed
+            .DoAwait(DoType.MapErrors, this.RefundPriorityFeeIfAny)
             // update the booking
             .ThenAwait(x =>
               repo.Update(
@@ -764,6 +769,9 @@ public class BookingService(
                   transactionGenerator.RefundBooking(b.Transaction.Record, b.Principal.Record)
                 )
             )
+            // return the priority fee: zinc failed to secure the ticket, so
+            // the paid-for queue jump delivered nothing
+            .DoAwait(DoType.MapErrors, this.RefundPriorityFeeIfAny)
             // update the booking
             .ThenAwait(x =>
               repo.Update(
@@ -812,5 +820,125 @@ public class BookingService(
     logger.LogInformation("Get booking count after {Date} {Time}", dateNow, timeNow);
 
     return repo.Count(dateNow, timeNow, query.Date, query.Direction);
+  }
+
+  // Returns the priority-fee snapshot to Usable with a ledger row. Runs inside
+  // the caller's Refund/Cancel transaction, right after the booking-amount
+  // refund, so fee and amount always move together. Terminated/Completed keep
+  // the fee: the queue jump was consumed (a ticket was secured).
+  private Task<Result<int>> RefundPriorityFeeIfAny(Booking b)
+  {
+    if (!b.Principal.Priority || b.Principal.PriorityFee is not > 0)
+      return Task.FromResult((Result<int>)0);
+    var fee = b.Principal.PriorityFee.Value;
+    return walletRepo
+      .Deposit(b.Wallet.Id, fee)
+      .NullToError(b.Wallet.Id.ToString())
+      .ThenAwait(_ =>
+        transactionRepo.Create(
+          b.Wallet.Id,
+          transactionGenerator.RefundPriorityFee(fee, b.Principal.Record)
+        )
+      )
+      .Then(_ => 0, Errors.MapNone);
+  }
+
+  // Eligibility: (allowlisted OR AllowAll) AND the SGT availability window
+  // (when configured) is open right now. Also carries the fee the user would
+  // be charged, for pre-submission display.
+  public Task<Result<PriorityEligibility>> PriorityEligibility(string userId)
+  {
+    return prioritySettingsRepo
+      .GetCurrent()
+      .Then(s => s?.Record ?? PrioritySettingsRecord.Default, Errors.MapNone)
+      .ThenAwait(s =>
+        priorityAccessRepo.Contains(userId).Then(allowed => (s, allowed), Errors.MapNone)
+      )
+      .Then(
+        t =>
+        {
+          var singapore = TimeZoneInfo.FindSystemTimeZoneById("Singapore");
+          var nowSgt = TimeOnly.FromDateTime(
+            TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, singapore)
+          );
+          return new PriorityEligibility
+          {
+            Eligible = PriorityRules.Eligible(t.allowed, t.s, nowSgt),
+            Fee = t.s.Fee,
+          };
+        },
+        Errors.MapNone
+      );
+  }
+
+  // Moves a booking to the front of its timeslot's purchase queue. Guarded
+  // (Pending only, not already priority, owner eligible) and wrapped in ONE
+  // RepeatableRead transaction so the guard read, the fee collection from
+  // Usable, the ledger row and the priority flag can never diverge — an
+  // insufficient balance rolls everything back and surfaces as its own error.
+  public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id)
+  {
+    return transaction
+      .Start(
+        () =>
+          repo.Get(userId, id)
+            .NullToError(id.ToString())
+            // guard: only a Pending, not-yet-priority booking may jump
+            .DoAwait(
+              DoType.MapErrors,
+              b =>
+              {
+                if (b.Principal.Status.Status == BookStatus.Pending && !b.Principal.Priority)
+                  return Task.FromResult((Result<int>)0);
+                var r = new InvalidBookingOperationException(
+                  b.Principal.Priority
+                    ? "Prioritize requires a booking that is not already priority"
+                    : "Prioritize requires a booking in 'Pending' Status",
+                  b.Principal.Status.Status,
+                  BookingOperations.Prioritize
+                );
+                return Task.FromResult((Result<int>)r);
+              }
+            )
+            // guard: the booking's owner must be eligible right now
+            .ThenAwait(b =>
+              this.PriorityEligibility(b.Principal.UserId)
+                .ThenAwait(e =>
+                {
+                  if (e.Eligible)
+                    return Task.FromResult((Result<(Booking b, decimal Fee)>)(b, e.Fee));
+                  var r = new InvalidBookingOperationException(
+                    "Prioritize requires the booking's owner to be eligible (allowlisted or allow-all, within the availability window)",
+                    b.Principal.Status.Status,
+                    BookingOperations.Prioritize
+                  );
+                  return Task.FromResult((Result<(Booking b, decimal Fee)>)r);
+                })
+            )
+            // collect the fee from Usable + ledger row (a zero fee books
+            // neither — a "SGD 0.00 charged" row would contradict the fee
+            // being disabled)
+            .DoAwait(
+              DoType.MapErrors,
+              t =>
+                t.Fee > 0
+                  ? walletRepo
+                    .Collect(t.b.Wallet.Id, t.Fee)
+                    .NullToError(t.b.Wallet.Id.ToString())
+                    .ThenAwait(_ =>
+                      transactionRepo.Create(
+                        t.b.Wallet.Id,
+                        transactionGenerator.PriorityFeeCharge(t.Fee, t.b.Principal.Record)
+                      )
+                    )
+                    .Then(_ => 0, Errors.MapNone)
+                  : Task.FromResult((Result<int>)0)
+            )
+            // flag the booking + snapshot the charged fee for the refund path
+            .ThenAwait(t => repo.Prioritize(userId, id, t.Fee))
+            .NullToError(id.ToString())
+      )
+      .DoAwait(DoType.Ignore, _ => cdcRepository.Add("update"))
+      .Then(BookingPrincipal? (x) => x, Errors.MapNone);
   }
 }

--- a/Domain/Cost/CostCalculator.cs
+++ b/Domain/Cost/CostCalculator.cs
@@ -7,6 +7,13 @@ public class CostCalculator(ICostService service) : ICostCalculator
 {
   public Task<Result<decimal>> BookingCost(string userId, string[] roles, BookingRecord record)
   {
-    return service.Materialize(userId, roles).Then(x => x.Final, Errors.MapNone);
+    // booking-aware: pricing policies match on the booking's date/time/direction
+    var spec = new BookingCostSpec
+    {
+      Date = record.Date,
+      Time = record.Time,
+      Direction = record.Direction,
+    };
+    return service.Materialize(userId, roles, spec).Then(x => x.Final, Errors.MapNone);
   }
 }

--- a/Domain/Cost/CostModel.cs
+++ b/Domain/Cost/CostModel.cs
@@ -1,4 +1,5 @@
 using Domain.Discount;
+using Domain.Timings;
 
 namespace Domain.Cost;
 
@@ -16,9 +17,78 @@ public record CostRecord
   public required decimal Cost { get; init; }
 }
 
+// The booking dimensions pricing policies match on — a lightweight spec so
+// callers (e.g. the purchase-page live preview) can price a booking without
+// fabricating passenger details
+public record BookingCostSpec
+{
+  public required DateOnly Date { get; init; }
+
+  public required TimeOnly Time { get; init; }
+
+  public required TrainDirection Direction { get; init; }
+}
+
+// A pricing rule: when every non-null Match* dimension equals the booking's,
+// the (signed) Amount is added to the base cost — negative = discount,
+// IsPercentage = percent of the base cost instead of a flat SGD amount
+public record CostPolicyRecord
+{
+  public required string Name { get; init; }
+
+  public required bool Enabled { get; init; }
+
+  // null = matches any value for that dimension (all null = matches everything)
+  public required DateOnly? MatchDate { get; init; }
+
+  public required TimeOnly? MatchTime { get; init; }
+
+  public required DayOfWeek? MatchDayOfWeek { get; init; }
+
+  public required TrainDirection? MatchDirection { get; init; }
+
+  // applies only when the booking is made this close (or closer) to departure
+  public required int? LeadTimeUnderHours { get; init; }
+
+  // SIGNED: negative = discount; percent of base cost when IsPercentage
+  public required decimal Amount { get; init; }
+
+  public required bool IsPercentage { get; init; }
+
+  // active window [EffectiveAt, ExpiresAt); null = unbounded on that side
+  public required DateTime? EffectiveAt { get; init; }
+
+  public required DateTime? ExpiresAt { get; init; }
+}
+
+public record CostPolicyPrincipal
+{
+  public required Guid Id { get; init; }
+
+  public required DateTime CreatedAt { get; init; }
+
+  public required CostPolicyRecord Record { get; init; }
+}
+
+// One applied policy's contribution to the price breakdown
+public record CostPolicyLine
+{
+  public required string Name { get; init; }
+
+  // the delta actually added (already resolved from percentage where needed)
+  public required decimal Delta { get; init; }
+}
+
+// The full price breakdown: Cost (base) + PolicyLines = Subtotal (floored at
+// 0), then Discounts bring Subtotal down to Final — every step adds up
 public record MaterializedCost
 {
   public required decimal Cost { get; init; }
+
+  public required IEnumerable<CostPolicyLine> PolicyLines { get; init; }
+
+  public required decimal Subtotal { get; init; }
+
   public required decimal Final { get; init; }
 
   public required IEnumerable<DiscountRecord> Discounts { get; init; }

--- a/Domain/Cost/CostPolicyMatcher.cs
+++ b/Domain/Cost/CostPolicyMatcher.cs
@@ -33,7 +33,9 @@ public static class CostPolicyMatcher
     if (policy.LeadTimeUnderHours != null)
     {
       var lead = DepartureUtc(spec) - nowUtc;
-      if (lead.TotalHours > policy.LeadTimeUnderHours.Value)
+      // a departed slot has no lead time at all — an "under N hours"
+      // surcharge must not match bookings for the past
+      if (lead <= TimeSpan.Zero || lead.TotalHours > policy.LeadTimeUnderHours.Value)
         return false;
     }
 

--- a/Domain/Cost/CostPolicyMatcher.cs
+++ b/Domain/Cost/CostPolicyMatcher.cs
@@ -1,0 +1,42 @@
+namespace Domain.Cost;
+
+// Pure policy matching rules, shared by pricing and (unit) tests
+public static class CostPolicyMatcher
+{
+  // Booking Date + Time are SGT (UTC+8) wall clock; see BookingStats for the
+  // established departure-instant pattern
+  public static DateTime DepartureUtc(BookingCostSpec spec) =>
+    spec.Date.ToDateTime(spec.Time, DateTimeKind.Unspecified).AddHours(-8);
+
+  // A policy applies iff it is enabled, nowUtc is within its active window
+  // [EffectiveAt, ExpiresAt), every non-null Match* dimension equals the
+  // booking's, and the purchase-to-departure lead time is under the cap
+  public static bool Applies(CostPolicyRecord policy, BookingCostSpec spec, DateTime nowUtc)
+  {
+    if (!policy.Enabled)
+      return false;
+
+    if (policy.EffectiveAt != null && nowUtc < policy.EffectiveAt)
+      return false;
+    if (policy.ExpiresAt != null && nowUtc >= policy.ExpiresAt)
+      return false;
+
+    if (policy.MatchDate != null && policy.MatchDate != spec.Date)
+      return false;
+    if (policy.MatchTime != null && policy.MatchTime != spec.Time)
+      return false;
+    if (policy.MatchDayOfWeek != null && policy.MatchDayOfWeek != spec.Date.DayOfWeek)
+      return false;
+    if (policy.MatchDirection != null && policy.MatchDirection != spec.Direction)
+      return false;
+
+    if (policy.LeadTimeUnderHours != null)
+    {
+      var lead = DepartureUtc(spec) - nowUtc;
+      if (lead.TotalHours > policy.LeadTimeUnderHours.Value)
+        return false;
+    }
+
+    return true;
+  }
+}

--- a/Domain/Cost/CostService.cs
+++ b/Domain/Cost/CostService.cs
@@ -6,6 +6,7 @@ namespace Domain.Cost;
 
 public class CostService(
   ICostRepository costRepo,
+  ICostPolicyRepository policyRepo,
   IDiscountRepository discountRepo,
   IDiscountMatcher discountMatcher,
   IDiscountCalculator discountCalculator,
@@ -27,31 +28,94 @@ public class CostService(
     return costRepo.GetCurrent();
   }
 
-  public Task<Result<MaterializedCost>> Materialize(string userId, string[] roles)
+  public Task<Result<IEnumerable<CostPolicyPrincipal>>> ListPolicies()
+  {
+    return policyRepo.List();
+  }
+
+  public Task<Result<CostPolicyPrincipal>> CreatePolicy(CostPolicyRecord record)
+  {
+    return policyRepo.Create(record);
+  }
+
+  public Task<Result<CostPolicyPrincipal?>> UpdatePolicy(Guid id, CostPolicyRecord record)
+  {
+    return policyRepo.Update(id, record);
+  }
+
+  public Task<Result<Unit?>> DeletePolicy(Guid id)
+  {
+    return policyRepo.Delete(id);
+  }
+
+  // The breakdown always adds up: base (newest Cost row) + one line per
+  // applicable policy = Subtotal (floored at 0), then per-user Discounts
+  // bring the Subtotal down to Final. spec = null skips policies entirely.
+  public Task<Result<MaterializedCost>> Materialize(
+    string userId,
+    string[] roles,
+    BookingCostSpec? spec
+  )
   {
     var r = roles.Concat([userId]).ToArray();
-    return discountRepo
-      .Search(new DiscountSearch { MatchTarget = r, Disabled = false })
-      .ThenAwait(d => costRepo.GetCurrent().NullToError("latest").Then(c => (c, d), Errors.MapNone))
+    var policies =
+      spec == null
+        ? Task.FromResult<Result<IEnumerable<CostPolicyPrincipal>>>(
+          Array.Empty<CostPolicyPrincipal>()
+        )
+        : policyRepo.List();
+    return policies
+      .ThenAwait(p =>
+        discountRepo
+          .Search(new DiscountSearch { MatchTarget = r, Disabled = false })
+          .Then(d => (p, d), Errors.MapNone)
+      )
+      .ThenAwait(pd =>
+        costRepo.GetCurrent().NullToError("latest").Then(c => (pd.p, pd.d, c), Errors.MapNone)
+      )
       .Then(
         tuple =>
         {
-          var (c, d) = tuple;
+          var (p, d, c) = tuple;
+          var baseCost = c.Record.Cost;
+          var now = DateTime.UtcNow;
+
+          var lines =
+            spec == null
+              ? []
+              : p.Where(x => CostPolicyMatcher.Applies(x.Record, spec, now))
+                .Select(x => new CostPolicyLine
+                {
+                  Name = x.Record.Name,
+                  // banker's rounding keeps percentage lines in even cents
+                  Delta = x.Record.IsPercentage
+                    ? Math.Round(baseCost * x.Record.Amount / 100m, 2, MidpointRounding.ToEven)
+                    : x.Record.Amount,
+                })
+                .ToArray();
+
+          var subtotal = Math.Max(baseCost + lines.Sum(x => x.Delta), 0m);
+
           var discountsApplicable = d.Where(x => discountMatcher.Match(x.Target, userId, roles))
             .ToArray();
 
           logger.LogInformation(
-            "Applying discounts {@Discounts} to cost {@Cost}",
+            "Applying policies {@Policies} and discounts {@Discounts} to cost {@Cost}",
+            lines,
             discountsApplicable,
             c.Record
           );
 
-          var cost = c.Record.Cost;
-          var f = discountCalculator.Calculate(cost, discountsApplicable.Select(x => x.Record));
+          var f = discountCalculator.Calculate(
+            subtotal,
+            discountsApplicable.Select(x => x.Record)
+          );
 
           return new MaterializedCost
           {
-            Cost = cost,
+            Cost = baseCost,
+            PolicyLines = lines,
+            Subtotal = subtotal,
             Final = f,
             Discounts = discountsApplicable.Select(x => x.Record),
           };

--- a/Domain/Cost/ICostPolicyRepository.cs
+++ b/Domain/Cost/ICostPolicyRepository.cs
@@ -1,0 +1,18 @@
+using CSharp_Result;
+
+namespace Domain.Cost;
+
+public interface ICostPolicyRepository
+{
+  // all policies, newest first (the admin page shows the full list; pricing
+  // filters applicability in the domain)
+  Task<Result<IEnumerable<CostPolicyPrincipal>>> List();
+
+  Task<Result<CostPolicyPrincipal>> Create(CostPolicyRecord record);
+
+  // full-record replace; null when no such policy exists
+  Task<Result<CostPolicyPrincipal?>> Update(Guid id, CostPolicyRecord record);
+
+  // null when no such policy exists
+  Task<Result<Unit?>> Delete(Guid id);
+}

--- a/Domain/Cost/ICostService.cs
+++ b/Domain/Cost/ICostService.cs
@@ -10,5 +10,15 @@ public interface ICostService
 
   Task<Result<CostPrincipal?>> GetCurrent();
 
-  Task<Result<MaterializedCost>> Materialize(string userId, string[] roles);
+  // spec = null prices without booking-aware policies (base + discounts only)
+  Task<Result<MaterializedCost>> Materialize(string userId, string[] roles, BookingCostSpec? spec);
+
+  // Policies (pricing rules)
+  Task<Result<IEnumerable<CostPolicyPrincipal>>> ListPolicies();
+
+  Task<Result<CostPolicyPrincipal>> CreatePolicy(CostPolicyRecord record);
+
+  Task<Result<CostPolicyPrincipal?>> UpdatePolicy(Guid id, CostPolicyRecord record);
+
+  Task<Result<Unit?>> DeletePolicy(Guid id);
 }

--- a/Domain/Transaction/Accounts.cs
+++ b/Domain/Transaction/Accounts.cs
@@ -14,4 +14,8 @@ public static class Accounts
     "BunnyBooker Withdrawal Fee"
   );
   public static Account DepositFee = new("BUNNY_BOOKER_DEPOSIT_FEE", "BunnyBooker Deposit Fee");
+  public static Account PriorityFee = new(
+    "BUNNY_BOOKER_PRIORITY_FEE",
+    "BunnyBooker Priority Fee"
+  );
 }

--- a/Domain/Transaction/Generator.cs
+++ b/Domain/Transaction/Generator.cs
@@ -39,6 +39,12 @@ public interface ITransactionGenerator
   public TransactionRecord Deposit(PaymentPrincipal principal);
 
   public TransactionRecord DepositFeeCharge(PaymentPrincipal principal, decimal fee);
+
+  // Priority queue: fee charged from Usable to jump the purchase queue, and
+  // its refund when the prioritized booking is refunded or cancelled
+  public TransactionRecord PriorityFeeCharge(decimal fee, BookingRecord booking);
+
+  public TransactionRecord RefundPriorityFee(decimal fee, BookingRecord booking);
 }
 
 public class TransactionGenerator(IRefundCalculator calculator) : ITransactionGenerator
@@ -302,6 +308,40 @@ public class TransactionGenerator(IRefundCalculator calculator) : ITransactionGe
       Type = TransactionType.DepositFee,
       From = Accounts.Usable.DisplayName,
       To = Accounts.DepositFee.DisplayName,
+    };
+  }
+
+  public TransactionRecord PriorityFeeCharge(decimal fee, BookingRecord booking)
+  {
+    return new TransactionRecord
+    {
+      Name = "Priority Queue Fee",
+      Description =
+        $"A priority fee of SGD {fee:0.00} has been charged to move the booking for "
+        + $"'{booking.Passenger.FullName}' in the direction '{booking.Direction.ToHuman()}' on "
+        + $"{booking.Date.ToHuman()} at {booking.Time.ToHuman()} to the front of its purchase "
+        + $"queue. The fee has been collected from your Usable Account.",
+      Type = TransactionType.PriorityFee,
+      Amount = fee,
+      From = Accounts.Usable.DisplayName,
+      To = Accounts.PriorityFee.DisplayName,
+    };
+  }
+
+  public TransactionRecord RefundPriorityFee(decimal fee, BookingRecord booking)
+  {
+    return new TransactionRecord
+    {
+      Name = "Priority Queue Fee Refunded",
+      Description =
+        $"The prioritized booking for '{booking.Passenger.FullName}' in the direction "
+        + $"'{booking.Direction.ToHuman()}' on {booking.Date.ToHuman()} at "
+        + $"{booking.Time.ToHuman()} was not fulfilled. The priority fee of SGD {fee:0.00} "
+        + $"has been fully refunded to your Usable Account.",
+      Type = TransactionType.PriorityFee,
+      Amount = fee,
+      From = Accounts.PriorityFee.DisplayName,
+      To = Accounts.Usable.DisplayName,
     };
   }
 }

--- a/Domain/Transaction/Model.cs
+++ b/Domain/Transaction/Model.cs
@@ -11,6 +11,7 @@ public static class TransactionTypes
   public const string BookingCancel = "BookingCancel";
   public const string BookingTerminated = "BookingTerminated";
   public const string BookingDuplicate = "BookingDuplicate";
+  public const string PriorityFee = "PriorityFee";
 
   // Wallet Related
   public const string Deposit = "Deposit";
@@ -42,6 +43,7 @@ public static class TransactionTypes
     BookingDuplicate,
     WithdrawFee,
     DepositFee,
+    PriorityFee,
   ];
 }
 
@@ -71,6 +73,10 @@ public enum TransactionType
   // Wallet Related (appended to preserve stored smallint values)
   WithdrawFee = 13,
   DepositFee = 14,
+
+  // Product related (appended to preserve stored smallint values): the fee
+  // charged (and, on refund/cancel, returned) for jumping the purchase queue
+  PriorityFee = 15,
 }
 
 public record TransactionSearch

--- a/UnitTest/Bookings/BookingQueueTests.cs
+++ b/UnitTest/Bookings/BookingQueueTests.cs
@@ -1,0 +1,93 @@
+using App.Modules.Bookings.Data;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// The queue-position "ahead" predicate must mirror Reserve()'s ordering:
+// priority first, then oldest CreatedAt, Id tiebreak. Compiled and evaluated
+// in memory — the same expression EF translates to SQL.
+public class BookingQueueTests
+{
+  private static readonly DateTime T0 = new(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+
+  private static BookingData Row(bool priority, DateTime createdAt, Guid? id = null) =>
+    new()
+    {
+      Id = id ?? Guid.NewGuid(),
+      CreatedAt = createdAt,
+      Priority = priority,
+    };
+
+  private static bool Ahead(BookingData candidate, BookingData reference) =>
+    BookingQueue.AheadOf(reference).Compile()(candidate);
+
+  [Fact]
+  public void Priority_jumps_ahead_of_non_priority_even_when_created_later()
+  {
+    var older = Row(priority: false, T0);
+    var newerPriority = Row(priority: true, T0.AddHours(5));
+
+    Ahead(newerPriority, older).Should().BeTrue("priority outranks age");
+    Ahead(older, newerPriority).Should().BeFalse("non-priority never outranks priority");
+  }
+
+  [Fact]
+  public void Same_priority_orders_by_created_at()
+  {
+    var older = Row(priority: false, T0);
+    var newer = Row(priority: false, T0.AddMinutes(1));
+
+    Ahead(older, newer).Should().BeTrue();
+    Ahead(newer, older).Should().BeFalse();
+
+    var olderP = Row(priority: true, T0);
+    var newerP = Row(priority: true, T0.AddMinutes(1));
+
+    Ahead(olderP, newerP).Should().BeTrue("priority ties fall back to age");
+    Ahead(newerP, olderP).Should().BeFalse();
+  }
+
+  [Fact]
+  public void Created_at_ties_break_deterministically_by_id()
+  {
+    var low = Row(priority: false, T0, new Guid("00000000-0000-0000-0000-000000000001"));
+    var high = Row(priority: false, T0, new Guid("00000000-0000-0000-0000-000000000002"));
+
+    Ahead(low, high).Should().BeTrue();
+    Ahead(high, low).Should().BeFalse();
+  }
+
+  [Fact]
+  public void A_booking_is_never_ahead_of_itself()
+  {
+    var b = Row(priority: true, T0);
+    Ahead(b, b).Should().BeFalse();
+  }
+
+  [Fact]
+  public void Predicate_agrees_with_reserves_ordering()
+  {
+    // Reserve() sorts: Priority desc, CreatedAt asc, Id asc — for every pair
+    // the predicate must agree with that ordering
+    var rows = new[]
+    {
+      Row(false, T0),
+      Row(true, T0.AddHours(2)),
+      Row(false, T0.AddHours(1)),
+      Row(true, T0.AddHours(3)),
+      Row(false, T0, new Guid("00000000-0000-0000-0000-00000000000a")),
+    };
+
+    var sorted = rows
+      .OrderByDescending(x => x.Priority)
+      .ThenBy(x => x.CreatedAt)
+      .ThenBy(x => x.Id)
+      .ToArray();
+
+    for (var i = 0; i < sorted.Length; i++)
+    {
+      var aheadCount = rows.Count(x => Ahead(x, sorted[i]));
+      aheadCount.Should().Be(i, $"position {i + 1} must have exactly {i} bookings ahead");
+    }
+  }
+}

--- a/UnitTest/Bookings/BookingServiceBuyingGuardTests.cs
+++ b/UnitTest/Bookings/BookingServiceBuyingGuardTests.cs
@@ -30,6 +30,8 @@ public class BookingServiceBuyingGuardTests
       null!,
       null!,
       null!,
+      null!,
+      null!,
       null!
     );
 
@@ -209,6 +211,9 @@ public class BookingServiceBuyingGuardTests
       throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly time) =>
+      throw new NotImplementedException();
+
+    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal fee) =>
       throw new NotImplementedException();
 
     public Task<Result<Unit?>> Delete(string? userId, Guid id) =>

--- a/UnitTest/Bookings/BookingServiceCompleteNoCollectTests.cs
+++ b/UnitTest/Bookings/BookingServiceCompleteNoCollectTests.cs
@@ -33,6 +33,8 @@ public class BookingServiceCompleteNoCollectTests
       null!,
       new FakeCdc(),
       new FakeNotifier(),
+      null!,
+      null!,
       null!
     );
 
@@ -203,6 +205,9 @@ public class BookingServiceCompleteNoCollectTests
       throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly time) =>
+      throw new NotImplementedException();
+
+    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal fee) =>
       throw new NotImplementedException();
 
     public Task<Result<Unit?>> Delete(string? userId, Guid id) =>

--- a/UnitTest/Bookings/BookingServicePrioritizeTests.cs
+++ b/UnitTest/Bookings/BookingServicePrioritizeTests.cs
@@ -218,24 +218,39 @@ public class BookingServicePrioritizeTests
   [Fact]
   public async Task Prioritize_outside_the_window_is_rejected()
   {
-    // a degenerate 1-minute window makes "now" fall outside deterministically
-    // for at least one of the two assertions below; instead pin the window to
-    // something that can never contain any time of day: start == end is an
-    // empty half-open interval
+    // pin a 1-hour window that deterministically excludes "now" regardless of
+    // when the test runs: [now+1h, now+2h) in SGT (wrap-around is handled by
+    // the rules, so crossing midnight is fine)
+    var nowSgt = TimeOnly.FromDateTime(DateTime.UtcNow.AddHours(8));
     var b = BookingWith(BookStatus.Pending);
     var settings = PrioritySettingsRecord.Default with
     {
       AllowAll = true,
-      WindowStartSgt = new TimeOnly(12, 0),
-      WindowEndSgt = new TimeOnly(12, 0),
+      WindowStartSgt = nowSgt.AddHours(1),
+      WindowEndSgt = nowSgt.AddHours(2),
     };
     var (service, _, wallet, txn) = Make(b, settings);
 
     var result = await service.Prioritize("user-1", b.Principal.Id);
 
-    result.IsSuccess().Should().BeFalse("an empty window is never open");
+    result.IsSuccess().Should().BeFalse("now is outside the configured window");
     wallet.CollectCalls.Should().Be(0);
     txn.Records.Should().BeEmpty();
+  }
+
+  [Fact]
+  public void Equal_window_bounds_mean_all_day_not_never()
+  {
+    // an admin writing 00:00 -> 00:00 means "all day"; the strict half-open
+    // reading would silently brick prioritization
+    PriorityRules
+      .WindowOpen(new TimeOnly(12, 0), new TimeOnly(12, 0), new TimeOnly(3, 33))
+      .Should()
+      .BeTrue();
+    PriorityRules
+      .WindowOpen(new TimeOnly(0, 0), new TimeOnly(0, 0), new TimeOnly(12, 0))
+      .Should()
+      .BeTrue();
   }
 
   [Fact]

--- a/UnitTest/Bookings/BookingServicePrioritizeTests.cs
+++ b/UnitTest/Bookings/BookingServicePrioritizeTests.cs
@@ -1,0 +1,635 @@
+using CSharp_Result;
+using Domain;
+using Domain.Booking;
+using Domain.Exceptions;
+using Domain.Passenger;
+using Domain.Timings;
+using Domain.Transaction;
+using Domain.User;
+using Domain.Wallet;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace UnitTest.Bookings;
+
+// Prioritize guards + money movement, and the priority-fee refund on the
+// Refund/Cancel flows. Invariants: the fee is collected at most once and only
+// from an eligible owner's Pending, not-yet-priority booking; the ledger row
+// always matches the wallet movement; Refunded/Cancelled return the snapshot
+// fee, Terminated/Completed keep it.
+public class BookingServicePrioritizeTests
+{
+  private const decimal Fee = 10m;
+  private const decimal Cost = 16m;
+
+  private static (
+    BookingService Service,
+    FakeBookingRepository Repo,
+    FakeWalletRepository Wallet,
+    FakeTransactionRepository Txn
+  ) Make(
+    Booking? booking,
+    PrioritySettingsRecord? settings = null,
+    bool allowlisted = false,
+    bool walletInsufficient = false
+  )
+  {
+    var repo = new FakeBookingRepository(booking);
+    var wallet = new FakeWalletRepository(walletInsufficient);
+    var txn = new FakeTransactionRepository();
+    var service = new BookingService(
+      repo,
+      null!,
+      wallet,
+      txn,
+      new PassThroughTransactionManager(),
+      new TransactionGenerator(new FixedRefundCalculator()),
+      new FixedRefundCalculator(),
+      new FakeTerminator(),
+      new FakeCdc(),
+      new FakeNotifier(),
+      new FakePrioritySettingsRepository(settings),
+      new FakePriorityAccessRepository(allowlisted),
+      NullLogger<BookingService>.Instance
+    );
+    return (service, repo, wallet, txn);
+  }
+
+  private static Booking BookingWith(
+    BookStatus status,
+    bool priority = false,
+    decimal? priorityFee = null
+  )
+  {
+    var id = Guid.NewGuid();
+    return new Booking
+    {
+      Principal = new BookingPrincipal
+      {
+        Id = id,
+        UserId = "user-1",
+        CreatedAt = DateTime.UtcNow,
+        Record = new BookingRecord
+        {
+          Date = new DateOnly(2026, 7, 15),
+          Time = new TimeOnly(8, 30),
+          Direction = TrainDirection.JToW,
+          Passenger = new PassengerRecord
+          {
+            FullName = "Test Passenger",
+            Gender = PassengerGender.M,
+            PassportExpiry = new DateOnly(2030, 1, 1),
+            PassportNumber = "P1234567",
+          },
+        },
+        Status = new BookingStatus { Status = status, CompletedAt = null },
+        Complete = new BookingComplete
+        {
+          Ticket = null,
+          BookingNumber = null,
+          TicketNumber = null,
+        },
+        Priority = priority,
+        PriorityFee = priorityFee,
+      },
+      User = new UserPrincipal
+      {
+        Id = "user-1",
+        Record = new UserRecord { Username = "tester" },
+      },
+      Transaction = new TransactionPrincipal
+      {
+        Id = Guid.NewGuid(),
+        CreatedAt = DateTime.UtcNow,
+        Record = new TransactionRecord
+        {
+          Name = "Purchased Booking Service",
+          Description = "test",
+          Type = TransactionType.BookingRequest,
+          Amount = Cost,
+          From = Accounts.Usable.DisplayName,
+          To = Accounts.BookingReserve.DisplayName,
+        },
+      },
+      Wallet = new WalletPrincipal
+      {
+        Id = Guid.NewGuid(),
+        UserId = "user-1",
+        Record = new WalletRecord
+        {
+          Usable = 100m,
+          WithdrawReserve = 0m,
+          BookingReserve = Cost,
+        },
+      },
+    };
+  }
+
+  // ---- Prioritize ----
+
+  [Fact]
+  public async Task Prioritize_pending_eligible_collects_fee_and_books_the_ledger()
+  {
+    var b = BookingWith(BookStatus.Pending);
+    var (service, repo, wallet, txn) = Make(b, allowlisted: true);
+
+    var result = await service.Prioritize("user-1", b.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    wallet.CollectCalls.Should().Be(1);
+    wallet.LastCollectAmount.Should().Be(Fee);
+    txn.Records.Should().ContainSingle();
+    txn.Records[0].Type.Should().Be(TransactionType.PriorityFee);
+    txn.Records[0].Amount.Should().Be(Fee);
+    txn.Records[0].From.Should().Be(Accounts.Usable.DisplayName);
+    txn.Records[0].To.Should().Be(Accounts.PriorityFee.DisplayName);
+    repo.PrioritizeCalls.Should().Be(1);
+    repo.LastPrioritizeFee.Should().Be(Fee, "the charged fee is snapshotted for the refund path");
+    result.SuccessOrDefault()!.Priority.Should().BeTrue();
+  }
+
+  [Theory]
+  [InlineData(BookStatus.Buying)]
+  [InlineData(BookStatus.Completed)]
+  [InlineData(BookStatus.Cancelled)]
+  [InlineData(BookStatus.Refunded)]
+  [InlineData(BookStatus.Terminated)]
+  [InlineData(BookStatus.Recovering)]
+  [InlineData(BookStatus.Duplicate)]
+  [InlineData(BookStatus.RequireManualIntervention)]
+  public async Task Prioritize_non_pending_is_rejected_and_moves_no_money(BookStatus status)
+  {
+    var b = BookingWith(status);
+    var (service, repo, wallet, txn) = Make(b, allowlisted: true);
+
+    var result = await service.Prioritize("user-1", b.Principal.Id);
+
+    result.IsSuccess().Should().BeFalse($"a '{status}' booking must not be prioritized");
+    result.FailureOrDefault().Should().BeOfType<InvalidBookingOperationException>();
+    wallet.CollectCalls.Should().Be(0);
+    txn.Records.Should().BeEmpty();
+    repo.PrioritizeCalls.Should().Be(0);
+  }
+
+  [Fact]
+  public async Task Prioritize_already_priority_is_rejected_and_never_double_charges()
+  {
+    var b = BookingWith(BookStatus.Pending, priority: true, priorityFee: Fee);
+    var (service, repo, wallet, txn) = Make(b, allowlisted: true);
+
+    var result = await service.Prioritize("user-1", b.Principal.Id);
+
+    result.IsSuccess().Should().BeFalse();
+    result.FailureOrDefault().Should().BeOfType<InvalidBookingOperationException>();
+    wallet.CollectCalls.Should().Be(0);
+    txn.Records.Should().BeEmpty();
+    repo.PrioritizeCalls.Should().Be(0);
+  }
+
+  [Fact]
+  public async Task Prioritize_ineligible_owner_is_rejected_and_moves_no_money()
+  {
+    var b = BookingWith(BookStatus.Pending);
+    var (service, repo, wallet, txn) = Make(b, allowlisted: false);
+
+    var result = await service.Prioritize("user-1", b.Principal.Id);
+
+    result.IsSuccess().Should().BeFalse("neither allowlisted nor allow-all");
+    result.FailureOrDefault().Should().BeOfType<InvalidBookingOperationException>();
+    wallet.CollectCalls.Should().Be(0);
+    txn.Records.Should().BeEmpty();
+    repo.PrioritizeCalls.Should().Be(0);
+  }
+
+  [Fact]
+  public async Task Prioritize_allowed_via_allow_all()
+  {
+    var b = BookingWith(BookStatus.Pending);
+    var settings = PrioritySettingsRecord.Default with { AllowAll = true };
+    var (service, repo, wallet, _) = Make(b, settings, allowlisted: false);
+
+    var result = await service.Prioritize("user-1", b.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    wallet.CollectCalls.Should().Be(1);
+    repo.PrioritizeCalls.Should().Be(1);
+  }
+
+  [Fact]
+  public async Task Prioritize_outside_the_window_is_rejected()
+  {
+    // a degenerate 1-minute window makes "now" fall outside deterministically
+    // for at least one of the two assertions below; instead pin the window to
+    // something that can never contain any time of day: start == end is an
+    // empty half-open interval
+    var b = BookingWith(BookStatus.Pending);
+    var settings = PrioritySettingsRecord.Default with
+    {
+      AllowAll = true,
+      WindowStartSgt = new TimeOnly(12, 0),
+      WindowEndSgt = new TimeOnly(12, 0),
+    };
+    var (service, _, wallet, txn) = Make(b, settings);
+
+    var result = await service.Prioritize("user-1", b.Principal.Id);
+
+    result.IsSuccess().Should().BeFalse("an empty window is never open");
+    wallet.CollectCalls.Should().Be(0);
+    txn.Records.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task Prioritize_with_insufficient_balance_fails_and_never_flags_the_booking()
+  {
+    var b = BookingWith(BookStatus.Pending);
+    var (service, repo, wallet, txn) = Make(b, allowlisted: true, walletInsufficient: true);
+
+    var result = await service.Prioritize("user-1", b.Principal.Id);
+
+    result.IsSuccess().Should().BeFalse("the collect failed");
+    wallet.CollectCalls.Should().Be(1);
+    txn.Records.Should().BeEmpty("no ledger row without a successful collect");
+    repo.PrioritizeCalls.Should().Be(0, "the booking must not be flagged priority unpaid");
+  }
+
+  [Fact]
+  public async Task Prioritize_with_zero_fee_flags_without_wallet_or_ledger()
+  {
+    var b = BookingWith(BookStatus.Pending);
+    var settings = PrioritySettingsRecord.Default with { Fee = 0m, AllowAll = true };
+    var (service, repo, wallet, txn) = Make(b, settings);
+
+    var result = await service.Prioritize("user-1", b.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    wallet.CollectCalls.Should().Be(0, "a zero fee moves no money");
+    txn.Records.Should().BeEmpty("a 'SGD 0.00 charged' ledger row would be noise");
+    repo.PrioritizeCalls.Should().Be(1);
+    repo.LastPrioritizeFee.Should().Be(0m);
+  }
+
+  [Fact]
+  public async Task PriorityEligibility_reports_fee_and_defaults()
+  {
+    var (service, _, _, _) = Make(null, allowlisted: true);
+
+    var result = await service.PriorityEligibility("user-1");
+
+    result.IsSuccess().Should().BeTrue();
+    result.SuccessOrDefault().Eligible.Should().BeTrue();
+    result.SuccessOrDefault().Fee.Should().Be(Fee, "the default fee is 10");
+  }
+
+  // ---- priority fee refunds ----
+
+  [Fact]
+  public async Task Refund_of_priority_booking_returns_fee_with_its_own_ledger_row()
+  {
+    var b = BookingWith(BookStatus.Pending, priority: true, priorityFee: Fee);
+    var (service, _, wallet, txn) = Make(b);
+
+    var result = await service.Refund(b.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    wallet.BookEndCalls.Should().Be(1, "the booking amount refund is untouched");
+    wallet.LastBookEndRevert.Should().Be(Cost);
+    wallet.DepositCalls.Should().Be(1, "the priority fee goes back to Usable");
+    wallet.LastDepositAmount.Should().Be(Fee);
+    txn.Records.Should().HaveCount(2);
+    txn.Records[0].Type.Should().Be(TransactionType.BookingRefund);
+    txn.Records[1].Type.Should().Be(TransactionType.PriorityFee);
+    txn.Records[1].Amount.Should().Be(Fee);
+    txn.Records[1].From.Should().Be(Accounts.PriorityFee.DisplayName);
+    txn.Records[1].To.Should().Be(Accounts.Usable.DisplayName);
+  }
+
+  [Fact]
+  public async Task Cancel_of_priority_booking_returns_fee_with_its_own_ledger_row()
+  {
+    var b = BookingWith(BookStatus.Pending, priority: true, priorityFee: Fee);
+    var (service, _, wallet, txn) = Make(b);
+
+    var result = await service.Cancel("user-1", b.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    wallet.DepositCalls.Should().Be(1);
+    wallet.LastDepositAmount.Should().Be(Fee);
+    txn.Records.Should().HaveCount(2);
+    txn.Records[0].Type.Should().Be(TransactionType.BookingCancel);
+    txn.Records[1].Type.Should().Be(TransactionType.PriorityFee);
+    txn.Records[1].To.Should().Be(Accounts.Usable.DisplayName);
+  }
+
+  [Fact]
+  public async Task Refund_of_non_priority_booking_refunds_no_fee()
+  {
+    var b = BookingWith(BookStatus.Pending);
+    var (service, _, wallet, txn) = Make(b);
+
+    var result = await service.Refund(b.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    wallet.DepositCalls.Should().Be(0);
+    txn.Records.Should().ContainSingle(r => r.Type == TransactionType.BookingRefund);
+    txn.Records.Should().NotContain(r => r.Type == TransactionType.PriorityFee);
+  }
+
+  [Fact]
+  public async Task Terminate_keeps_the_priority_fee()
+  {
+    var b = BookingWith(BookStatus.Completed, priority: true, priorityFee: Fee);
+    var (service, _, wallet, txn) = Make(b);
+
+    var result = await service.Terminate(
+      "user-1",
+      b.Principal.Id,
+      DateTime.UtcNow // well before the 2026 departure
+    );
+
+    result.IsSuccess().Should().BeTrue();
+    txn.Records.Should().NotContain(
+      r => r.Type == TransactionType.PriorityFee,
+      "the queue jump was consumed — a secured ticket keeps the fee"
+    );
+    wallet.LastDepositAmount.Should().Be(
+      Cost * 0.5m,
+      "only the termination refund is deposited, never the priority fee"
+    );
+  }
+
+  // ---- fakes ----
+
+  private sealed class PassThroughTransactionManager : ITransactionManager
+  {
+    public Task<Result<T>> Start<T>(Func<Task<Result<T>>> func) => func();
+  }
+
+  private sealed class FixedRefundCalculator : IRefundCalculator
+  {
+    public decimal RefundRate => 0.5m;
+    public decimal PenaltyRate => 0.5m;
+  }
+
+  private sealed class FakeCdc : IBookingCdcRepository
+  {
+    public Task<Result<Unit>> Add(string action) => Task.FromResult((Result<Unit>)new Unit());
+  }
+
+  private sealed class FakeTerminator : IBookingTerminatorRepository
+  {
+    public Task<Result<Unit>> Terminate(BookingTermination termination) =>
+      Task.FromResult((Result<Unit>)new Unit());
+  }
+
+  private sealed class FakeNotifier : IBookingNotificationService
+  {
+    public Task<Result<Unit>> NotifyBookingCompleted(Booking booking) =>
+      Task.FromResult((Result<Unit>)new Unit());
+
+    public Task<Result<Unit>> NotifyBookingCancelled(Booking booking) =>
+      Task.FromResult((Result<Unit>)new Unit());
+
+    public Task<Result<Unit>> NotifyBookingTerminated(Booking booking) =>
+      Task.FromResult((Result<Unit>)new Unit());
+
+    public Task<Result<Unit>> NotifyBookingRefunded(Booking booking) =>
+      Task.FromResult((Result<Unit>)new Unit());
+
+    public Task<Result<Unit>> NotifyBookingDuplicate(Booking booking) =>
+      Task.FromResult((Result<Unit>)new Unit());
+
+    public Task<Result<Unit>> NotifyBookingManualIntervention(Booking booking) =>
+      Task.FromResult((Result<Unit>)new Unit());
+  }
+
+  private sealed class FakePrioritySettingsRepository(PrioritySettingsRecord? settings)
+    : IPrioritySettingsRepository
+  {
+    public Task<Result<PrioritySettingsPrincipal?>> GetCurrent() =>
+      Task.FromResult(
+        (Result<PrioritySettingsPrincipal?>)(
+          settings == null
+            ? null
+            : new PrioritySettingsPrincipal
+            {
+              Id = Guid.NewGuid(),
+              CreatedAt = DateTime.UtcNow,
+              Record = settings,
+            }
+        )
+      );
+
+    public Task<Result<PrioritySettingsPrincipal>> Create(PrioritySettingsRecord record) =>
+      throw new NotImplementedException();
+  }
+
+  private sealed class FakePriorityAccessRepository(bool allowlisted)
+    : IPriorityAccessRepository
+  {
+    public Task<Result<bool>> Contains(string userId) =>
+      Task.FromResult((Result<bool>)allowlisted);
+
+    public Task<Result<IEnumerable<PriorityAccess>>> List() =>
+      throw new NotImplementedException();
+
+    public Task<Result<PriorityAccess>> Add(string userId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Unit?>> Remove(string userId) => throw new NotImplementedException();
+  }
+
+  private sealed class FakeBookingRepository(Booking? booking) : IBookingRepository
+  {
+    private BookStatus? statusOverride;
+    private bool priorityOverride;
+    private decimal? feeOverride;
+
+    public int PrioritizeCalls { get; private set; }
+    public decimal? LastPrioritizeFee { get; private set; }
+    public List<BookingStatus> StatusWrites { get; } = [];
+
+    private Booking? Current()
+    {
+      if (booking == null)
+        return null;
+      var p = booking.Principal with
+      {
+        Status =
+          statusOverride == null
+            ? booking.Principal.Status
+            : booking.Principal.Status with
+            {
+              Status = statusOverride.Value,
+            },
+        Priority = priorityOverride || booking.Principal.Priority,
+        PriorityFee = feeOverride ?? booking.Principal.PriorityFee,
+      };
+      return booking with { Principal = p };
+    }
+
+    public Task<Result<Booking?>> Get(string? userId, Guid id) =>
+      Task.FromResult((Result<Booking?>)Current());
+
+    public Task<Result<BookingPrincipal?>> Update(
+      string? userId,
+      Guid id,
+      BookingStatus? status,
+      BookingRecord? record,
+      BookingComplete? complete
+    )
+    {
+      if (status != null)
+      {
+        StatusWrites.Add(status);
+        statusOverride = status.Status;
+      }
+      return Task.FromResult((Result<BookingPrincipal?>)Current()!.Principal);
+    }
+
+    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal fee)
+    {
+      PrioritizeCalls++;
+      LastPrioritizeFee = fee;
+      priorityOverride = true;
+      feeOverride = fee;
+      return Task.FromResult((Result<BookingPrincipal?>)Current()!.Principal);
+    }
+
+    public Task<Result<IEnumerable<BookingPrincipal>>> Search(BookingSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<int>> SearchCount(BookingSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<BookingQueuePosition?>> QueuePosition(string? userId, Guid id) =>
+      throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingStatRow>>> Stats(BookingStatsQuery query) =>
+      throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingPrincipal>>> RefundList(DateOnly date, TimeOnly time) =>
+      throw new NotImplementedException();
+
+    public Task<Result<BookingPrincipal>> Create(
+      string userId,
+      Guid transactionId,
+      BookingRecord record
+    ) => throw new NotImplementedException();
+
+    public Task<Result<BookingPrincipal?>> Reserve(
+      TrainDirection direction,
+      DateOnly date,
+      TimeOnly time
+    ) => throw new NotImplementedException();
+
+    public Task<Result<Unit?>> Delete(string? userId, Guid id) =>
+      throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingCount>>> Count(
+      DateOnly date,
+      TimeOnly time,
+      DateOnly? filterDate,
+      TrainDirection? filterDirection
+    ) => throw new NotImplementedException();
+  }
+
+  private sealed class FakeWalletRepository(bool insufficient) : IWalletRepository
+  {
+    public int CollectCalls { get; private set; }
+    public int DepositCalls { get; private set; }
+    public int BookEndCalls { get; private set; }
+    public decimal? LastCollectAmount { get; private set; }
+    public decimal? LastDepositAmount { get; private set; }
+    public decimal? LastBookEndRevert { get; private set; }
+
+    private static WalletPrincipal Wallet(Guid id) =>
+      new()
+      {
+        Id = id,
+        UserId = "user-1",
+        Record = new WalletRecord
+        {
+          Usable = 100m,
+          WithdrawReserve = 0m,
+          BookingReserve = 0m,
+        },
+      };
+
+    public Task<Result<WalletPrincipal?>> Collect(Guid id, decimal amount)
+    {
+      CollectCalls++;
+      LastCollectAmount = amount;
+      if (insufficient)
+        return Task.FromResult(
+          (Result<WalletPrincipal?>)new InvalidOperationException("insufficient balance")
+        );
+      return Task.FromResult((Result<WalletPrincipal?>)Wallet(id));
+    }
+
+    public Task<Result<WalletPrincipal?>> Deposit(Guid id, decimal amount)
+    {
+      DepositCalls++;
+      LastDepositAmount = amount;
+      return Task.FromResult((Result<WalletPrincipal?>)Wallet(id));
+    }
+
+    public Task<Result<WalletPrincipal?>> BookEnd(Guid id, decimal revert, decimal collect)
+    {
+      BookEndCalls++;
+      LastBookEndRevert = revert;
+      return Task.FromResult((Result<WalletPrincipal?>)Wallet(id));
+    }
+
+    public Task<Result<IEnumerable<WalletPrincipal>>> Search(WalletSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Wallet?>> Get(Guid id, string? userId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Wallet?>> GetByUserId(string userId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WalletPrincipal?>> PrepareWithdraw(Guid id, decimal amount) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WalletPrincipal?>> Withdraw(Guid id, decimal amount) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WalletPrincipal?>> CancelWithdraw(Guid id, decimal amount) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WalletPrincipal?>> BookStart(Guid id, decimal amount) =>
+      throw new NotImplementedException();
+  }
+
+  private sealed class FakeTransactionRepository : ITransactionRepository
+  {
+    public List<TransactionRecord> Records { get; } = [];
+
+    public Task<Result<TransactionPrincipal>> Create(
+      Guid walletId,
+      TransactionRecord record,
+      Guid? paymentId = null
+    )
+    {
+      Records.Add(record);
+      return Task.FromResult(
+        (Result<TransactionPrincipal>)
+          new TransactionPrincipal
+          {
+            Id = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+            Record = record,
+          }
+      );
+    }
+
+    public Task<Result<IEnumerable<TransactionPrincipal>>> Search(TransactionSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Transaction?>> Get(Guid id, string? userId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Unit?>> Delete(Guid id) => throw new NotImplementedException();
+  }
+}

--- a/UnitTest/Bookings/BookingServiceRevertGuardTests.cs
+++ b/UnitTest/Bookings/BookingServiceRevertGuardTests.cs
@@ -32,6 +32,8 @@ public class BookingServiceRevertGuardTests
       null!,
       null!,
       null!,
+      null!,
+      null!,
       null!
     );
 
@@ -342,6 +344,9 @@ public class BookingServiceRevertGuardTests
       throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly time) =>
+      throw new NotImplementedException();
+
+    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal fee) =>
       throw new NotImplementedException();
 
     public Task<Result<Unit?>> Delete(string? userId, Guid id) =>

--- a/UnitTest/Bookings/PriorityRulesTests.cs
+++ b/UnitTest/Bookings/PriorityRulesTests.cs
@@ -1,0 +1,103 @@
+using Domain.Booking;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// The pure eligibility rules: (allowlisted OR AllowAll) AND the SGT
+// availability window (half-open, wrap-around midnight supported)
+public class PriorityRulesTests
+{
+  private static PrioritySettingsRecord Settings(
+    bool allowAll = false,
+    TimeOnly? start = null,
+    TimeOnly? end = null
+  ) =>
+    new()
+    {
+      Fee = 10m,
+      AllowAll = allowAll,
+      WindowStartSgt = start,
+      WindowEndSgt = end,
+    };
+
+  private static readonly TimeOnly Noon = new(12, 0);
+
+  // ---- who may prioritize ----
+
+  [Fact]
+  public void Not_allowlisted_and_not_allow_all_is_ineligible()
+  {
+    PriorityRules.Eligible(false, Settings(), Noon).Should().BeFalse();
+  }
+
+  [Fact]
+  public void Allowlisted_user_is_eligible()
+  {
+    PriorityRules.Eligible(true, Settings(), Noon).Should().BeTrue();
+  }
+
+  [Fact]
+  public void Allow_all_makes_everyone_eligible()
+  {
+    PriorityRules.Eligible(false, Settings(allowAll: true), Noon).Should().BeTrue();
+  }
+
+  // ---- availability window ----
+
+  [Fact]
+  public void No_window_means_always_available()
+  {
+    PriorityRules.WindowOpen(null, null, new TimeOnly(3, 59)).Should().BeTrue();
+  }
+
+  [Fact]
+  public void Normal_window_is_half_open()
+  {
+    var start = new TimeOnly(9, 0);
+    var end = new TimeOnly(17, 0);
+
+    PriorityRules.WindowOpen(start, end, new TimeOnly(9, 0)).Should().BeTrue("start inclusive");
+    PriorityRules.WindowOpen(start, end, Noon).Should().BeTrue();
+    PriorityRules.WindowOpen(start, end, new TimeOnly(17, 0)).Should().BeFalse("end exclusive");
+    PriorityRules.WindowOpen(start, end, new TimeOnly(8, 59)).Should().BeFalse();
+    PriorityRules.WindowOpen(start, end, new TimeOnly(23, 0)).Should().BeFalse();
+  }
+
+  [Fact]
+  public void Wrap_around_midnight_window_covers_both_sides()
+  {
+    var start = new TimeOnly(22, 0);
+    var end = new TimeOnly(2, 0);
+
+    PriorityRules.WindowOpen(start, end, new TimeOnly(23, 30)).Should().BeTrue("before midnight");
+    PriorityRules.WindowOpen(start, end, new TimeOnly(1, 30)).Should().BeTrue("after midnight");
+    PriorityRules.WindowOpen(start, end, new TimeOnly(22, 0)).Should().BeTrue("start inclusive");
+    PriorityRules.WindowOpen(start, end, new TimeOnly(2, 0)).Should().BeFalse("end exclusive");
+    PriorityRules.WindowOpen(start, end, Noon).Should().BeFalse("the gap is closed");
+  }
+
+  [Fact]
+  public void Eligibility_combines_allowlist_and_window()
+  {
+    var inWindow = new TimeOnly(23, 0);
+    var outOfWindow = new TimeOnly(12, 0);
+    var s = Settings(start: new TimeOnly(22, 0), end: new TimeOnly(2, 0));
+
+    PriorityRules.Eligible(true, s, inWindow).Should().BeTrue();
+    PriorityRules.Eligible(true, s, outOfWindow).Should().BeFalse("outside the window");
+    PriorityRules.Eligible(false, s, inWindow).Should().BeFalse("not allowlisted");
+    PriorityRules
+      .Eligible(false, Settings(allowAll: true, start: new TimeOnly(22, 0), end: new TimeOnly(2, 0)), inWindow)
+      .Should()
+      .BeTrue();
+  }
+
+  [Fact]
+  public void Defaults_are_fee_ten_allowlist_only_no_window()
+  {
+    PrioritySettingsRecord.Default.Fee.Should().Be(10m);
+    PrioritySettingsRecord.Default.AllowAll.Should().BeFalse();
+    PrioritySettingsRecord.Default.WindowStartSgt.Should().BeNull();
+    PrioritySettingsRecord.Default.WindowEndSgt.Should().BeNull();
+  }
+}

--- a/UnitTest/Costs/CostPolicyMatcherTests.cs
+++ b/UnitTest/Costs/CostPolicyMatcherTests.cs
@@ -1,0 +1,203 @@
+using Domain.Cost;
+using Domain.Timings;
+using FluentAssertions;
+
+namespace UnitTest.Costs;
+
+// The policy applicability matrix: every Match* dimension, their
+// combinations, the lead-time boundary, the effective window and the
+// enabled flag. Booking Date+Time are SGT wall clock; departure instant is
+// date+time minus 8h (the BookingStats convention).
+public class CostPolicyMatcherTests
+{
+  // 2026-07-15 is a Wednesday
+  private static readonly BookingCostSpec Spec = new()
+  {
+    Date = new DateOnly(2026, 7, 15),
+    Time = new TimeOnly(8, 30),
+    Direction = TrainDirection.JToW,
+  };
+
+  // departure UTC = 2026-07-15 00:30 UTC; a week earlier leaves lots of lead
+  private static readonly DateTime NowUtc = new(2026, 7, 8, 0, 30, 0, DateTimeKind.Utc);
+
+  private static CostPolicyRecord Policy(
+    bool enabled = true,
+    DateOnly? matchDate = null,
+    TimeOnly? matchTime = null,
+    DayOfWeek? matchDayOfWeek = null,
+    TrainDirection? matchDirection = null,
+    int? leadTimeUnderHours = null,
+    DateTime? effectiveAt = null,
+    DateTime? expiresAt = null
+  ) =>
+    new()
+    {
+      Name = "policy",
+      Enabled = enabled,
+      MatchDate = matchDate,
+      MatchTime = matchTime,
+      MatchDayOfWeek = matchDayOfWeek,
+      MatchDirection = matchDirection,
+      LeadTimeUnderHours = leadTimeUnderHours,
+      Amount = 1m,
+      IsPercentage = false,
+      EffectiveAt = effectiveAt,
+      ExpiresAt = expiresAt,
+    };
+
+  [Fact]
+  public void All_null_matches_everything()
+  {
+    CostPolicyMatcher.Applies(Policy(), Spec, NowUtc).Should().BeTrue();
+  }
+
+  [Fact]
+  public void Disabled_policy_never_applies()
+  {
+    CostPolicyMatcher.Applies(Policy(enabled: false), Spec, NowUtc).Should().BeFalse();
+  }
+
+  [Fact]
+  public void Date_dimension_matches_exactly()
+  {
+    CostPolicyMatcher.Applies(Policy(matchDate: Spec.Date), Spec, NowUtc).Should().BeTrue();
+    CostPolicyMatcher
+      .Applies(Policy(matchDate: Spec.Date.AddDays(1)), Spec, NowUtc)
+      .Should()
+      .BeFalse();
+  }
+
+  [Fact]
+  public void Time_dimension_matches_exactly()
+  {
+    CostPolicyMatcher.Applies(Policy(matchTime: Spec.Time), Spec, NowUtc).Should().BeTrue();
+    CostPolicyMatcher
+      .Applies(Policy(matchTime: new TimeOnly(9, 45)), Spec, NowUtc)
+      .Should()
+      .BeFalse();
+  }
+
+  [Fact]
+  public void DayOfWeek_dimension_matches_the_travel_dates_weekday()
+  {
+    CostPolicyMatcher
+      .Applies(Policy(matchDayOfWeek: DayOfWeek.Wednesday), Spec, NowUtc)
+      .Should()
+      .BeTrue();
+    CostPolicyMatcher
+      .Applies(Policy(matchDayOfWeek: DayOfWeek.Saturday), Spec, NowUtc)
+      .Should()
+      .BeFalse();
+  }
+
+  [Fact]
+  public void Direction_dimension_matches_exactly()
+  {
+    CostPolicyMatcher
+      .Applies(Policy(matchDirection: TrainDirection.JToW), Spec, NowUtc)
+      .Should()
+      .BeTrue();
+    CostPolicyMatcher
+      .Applies(Policy(matchDirection: TrainDirection.WToJ), Spec, NowUtc)
+      .Should()
+      .BeFalse();
+  }
+
+  [Fact]
+  public void Combined_dimensions_all_must_match()
+  {
+    // both match
+    CostPolicyMatcher
+      .Applies(
+        Policy(matchDayOfWeek: DayOfWeek.Wednesday, matchDirection: TrainDirection.JToW),
+        Spec,
+        NowUtc
+      )
+      .Should()
+      .BeTrue();
+    // one matches, one does not: AND semantics
+    CostPolicyMatcher
+      .Applies(
+        Policy(matchDayOfWeek: DayOfWeek.Wednesday, matchDirection: TrainDirection.WToJ),
+        Spec,
+        NowUtc
+      )
+      .Should()
+      .BeFalse();
+  }
+
+  [Fact]
+  public void Lead_time_boundary_is_inclusive()
+  {
+    // departure UTC is 2026-07-15 00:30; now exactly 24h before
+    var now = new DateTime(2026, 7, 14, 0, 30, 0, DateTimeKind.Utc);
+    CostPolicyMatcher.Applies(Policy(leadTimeUnderHours: 24), Spec, now).Should().BeTrue();
+
+    // one second earlier the lead exceeds 24h — no longer "under"
+    var earlier = now.AddSeconds(-1);
+    CostPolicyMatcher.Applies(Policy(leadTimeUnderHours: 24), Spec, earlier).Should().BeFalse();
+  }
+
+  [Fact]
+  public void Lead_time_uses_sgt_departure_instant()
+  {
+    // 08:30 on 2026-07-15 is SGT wall clock = 00:30 UTC. At 23:30 UTC on the
+    // 14th only 1h of lead remains, so a 2h cap applies — had the departure
+    // been misread as 08:30 UTC the lead would be 9h and it would not.
+    var now = new DateTime(2026, 7, 14, 23, 30, 0, DateTimeKind.Utc);
+    CostPolicyMatcher.Applies(Policy(leadTimeUnderHours: 2), Spec, now).Should().BeTrue();
+    CostPolicyMatcher.Applies(Policy(leadTimeUnderHours: 1), Spec, now).Should().BeTrue();
+  }
+
+  [Fact]
+  public void Effective_window_is_half_open()
+  {
+    var effective = NowUtc.AddHours(-1);
+    var expires = NowUtc.AddHours(1);
+
+    // inside the window
+    CostPolicyMatcher
+      .Applies(Policy(effectiveAt: effective, expiresAt: expires), Spec, NowUtc)
+      .Should()
+      .BeTrue();
+
+    // exactly at EffectiveAt: inclusive
+    CostPolicyMatcher
+      .Applies(Policy(effectiveAt: NowUtc, expiresAt: expires), Spec, NowUtc)
+      .Should()
+      .BeTrue();
+
+    // exactly at ExpiresAt: exclusive
+    CostPolicyMatcher
+      .Applies(Policy(effectiveAt: effective, expiresAt: NowUtc), Spec, NowUtc)
+      .Should()
+      .BeFalse();
+  }
+
+  [Fact]
+  public void Not_yet_effective_or_expired_policies_never_apply()
+  {
+    CostPolicyMatcher
+      .Applies(Policy(effectiveAt: NowUtc.AddDays(1)), Spec, NowUtc)
+      .Should()
+      .BeFalse("the policy only starts tomorrow");
+    CostPolicyMatcher
+      .Applies(Policy(expiresAt: NowUtc.AddDays(-1)), Spec, NowUtc)
+      .Should()
+      .BeFalse("the policy expired yesterday");
+  }
+
+  [Fact]
+  public void Unbounded_window_sides_are_open_ended()
+  {
+    CostPolicyMatcher
+      .Applies(Policy(effectiveAt: null, expiresAt: NowUtc.AddDays(1)), Spec, NowUtc)
+      .Should()
+      .BeTrue();
+    CostPolicyMatcher
+      .Applies(Policy(effectiveAt: NowUtc.AddDays(-1), expiresAt: null), Spec, NowUtc)
+      .Should()
+      .BeTrue();
+  }
+}

--- a/UnitTest/Costs/CostServiceMaterializeTests.cs
+++ b/UnitTest/Costs/CostServiceMaterializeTests.cs
@@ -1,0 +1,237 @@
+using CSharp_Result;
+using Domain.Cost;
+using Domain.Discount;
+using Domain.Timings;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace UnitTest.Costs;
+
+// The pricing math must add up visibly: base (newest Cost row) + one delta
+// per applicable policy = Subtotal (floored at 0), then discounts bring the
+// Subtotal down to Final. Percentages use banker's rounding to even cents.
+public class CostServiceMaterializeTests
+{
+  private static readonly BookingCostSpec Spec = new()
+  {
+    Date = new DateOnly(2026, 7, 15), // a Wednesday
+    Time = new TimeOnly(8, 30),
+    Direction = TrainDirection.JToW,
+  };
+
+  private static CostService Make(
+    decimal baseCost,
+    IEnumerable<CostPolicyPrincipal>? policies = null,
+    IEnumerable<DiscountPrincipal>? discounts = null
+  ) =>
+    new(
+      new FakeCostRepository(baseCost),
+      new FakeCostPolicyRepository(policies ?? []),
+      new FakeDiscountRepository(discounts ?? []),
+      new DiscountMatcher(NullLogger<DiscountMatcher>.Instance),
+      new DiscountCalculator(),
+      NullLogger<CostService>.Instance
+    );
+
+  private static CostPolicyPrincipal Policy(
+    string name,
+    decimal amount,
+    bool isPercentage = false,
+    bool enabled = true,
+    TrainDirection? matchDirection = null
+  ) =>
+    new()
+    {
+      Id = Guid.NewGuid(),
+      CreatedAt = DateTime.UtcNow,
+      Record = new CostPolicyRecord
+      {
+        Name = name,
+        Enabled = enabled,
+        MatchDate = null,
+        MatchTime = null,
+        MatchDayOfWeek = null,
+        MatchDirection = matchDirection,
+        LeadTimeUnderHours = null,
+        Amount = amount,
+        IsPercentage = isPercentage,
+        EffectiveAt = null,
+        ExpiresAt = null,
+      },
+    };
+
+  private static DiscountPrincipal FlatDiscountForEveryone(decimal amount) =>
+    new()
+    {
+      Id = Guid.NewGuid(),
+      Record = new DiscountRecord
+      {
+        Name = "flat",
+        Description = "flat discount",
+        Amount = amount,
+        Type = DiscountType.Flat,
+      },
+      Target = new DiscountTarget { MatchMode = DiscountMatchMode.None, Matches = [] },
+      Status = new DiscountStatus { Disabled = false },
+    };
+
+  [Fact]
+  public async Task Without_a_spec_no_policies_apply_and_subtotal_equals_base()
+  {
+    var service = Make(14m, [Policy("weekend surcharge", 5m)]);
+
+    var result = await service.Materialize("user-1", [], null);
+
+    result.IsSuccess().Should().BeTrue();
+    var m = result.SuccessOrDefault();
+    m.Cost.Should().Be(14m);
+    m.PolicyLines.Should().BeEmpty();
+    m.Subtotal.Should().Be(14m);
+    m.Final.Should().Be(14m);
+  }
+
+  [Fact]
+  public async Task Flat_and_percentage_policies_add_up_to_the_subtotal()
+  {
+    var service = Make(
+      14m,
+      [Policy("peak surcharge", 5m), Policy("promo", -10m, isPercentage: true)]
+    );
+
+    var result = await service.Materialize("user-1", [], Spec);
+
+    result.IsSuccess().Should().BeTrue();
+    var m = result.SuccessOrDefault();
+    m.Cost.Should().Be(14m);
+    m.PolicyLines.Should().HaveCount(2);
+    m.PolicyLines.Single(x => x.Name == "peak surcharge").Delta.Should().Be(5m);
+    m.PolicyLines.Single(x => x.Name == "promo").Delta.Should().Be(-1.40m, "-10% of 14");
+    m.Subtotal.Should().Be(14m + 5m - 1.40m);
+    m.Subtotal.Should().Be(m.Cost + m.PolicyLines.Sum(x => x.Delta), "the math must add up");
+    m.Final.Should().Be(m.Subtotal, "no discounts configured");
+  }
+
+  [Fact]
+  public async Task Percentage_deltas_use_bankers_rounding_to_even_cents()
+  {
+    // 0.5% of 25 = 0.125 → rounds to 0.12 (even), not 0.13
+    var even = await Make(25m, [Policy("p", 0.5m, isPercentage: true)])
+      .Materialize("user-1", [], Spec);
+    even.SuccessOrDefault().PolicyLines.Single().Delta.Should().Be(0.12m);
+
+    // 1.5% of 25 = 0.375 → rounds to 0.38 (even)
+    var odd = await Make(25m, [Policy("p", 1.5m, isPercentage: true)])
+      .Materialize("user-1", [], Spec);
+    odd.SuccessOrDefault().PolicyLines.Single().Delta.Should().Be(0.38m);
+  }
+
+  [Fact]
+  public async Task Subtotal_is_floored_at_zero()
+  {
+    var service = Make(14m, [Policy("mega discount", -20m)]);
+
+    var result = await service.Materialize("user-1", [], Spec);
+
+    var m = result.SuccessOrDefault();
+    m.Subtotal.Should().Be(0m, "base 14 - 20 floors at 0");
+    m.Final.Should().Be(0m);
+  }
+
+  [Fact]
+  public async Task Disabled_and_non_matching_policies_contribute_no_lines()
+  {
+    var service = Make(
+      14m,
+      [
+        Policy("disabled", 5m, enabled: false),
+        Policy("wrong direction", 5m, matchDirection: TrainDirection.WToJ),
+        Policy("applies", 2m, matchDirection: TrainDirection.JToW),
+      ]
+    );
+
+    var result = await service.Materialize("user-1", [], Spec);
+
+    var m = result.SuccessOrDefault();
+    m.PolicyLines.Should().ContainSingle(x => x.Name == "applies");
+    m.Subtotal.Should().Be(16m);
+  }
+
+  [Fact]
+  public async Task Discounts_apply_on_the_policy_subtotal_and_everything_adds_up()
+  {
+    var service = Make(
+      14m,
+      [Policy("peak surcharge", 6m)],
+      [FlatDiscountForEveryone(3m)]
+    );
+
+    var result = await service.Materialize("user-1", [], Spec);
+
+    var m = result.SuccessOrDefault();
+    m.Cost.Should().Be(14m);
+    m.Subtotal.Should().Be(20m, "base 14 + surcharge 6");
+    m.Discounts.Should().ContainSingle();
+    m.Final.Should().Be(17m, "the flat 3 discount applies on the subtotal, not the base");
+    (m.Cost + m.PolicyLines.Sum(x => x.Delta) - m.Discounts.Sum(d => d.Amount))
+      .Should()
+      .Be(m.Final, "base + policies - discounts = final");
+  }
+
+  // ---- fakes ----
+
+  private sealed class FakeCostRepository(decimal baseCost) : ICostRepository
+  {
+    public Task<Result<CostPrincipal?>> GetCurrent() =>
+      Task.FromResult(
+        (Result<CostPrincipal?>)
+          new CostPrincipal
+          {
+            Id = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+            Record = new CostRecord { Cost = baseCost },
+          }
+      );
+
+    public Task<Result<IEnumerable<CostPrincipal>>> History() =>
+      throw new NotImplementedException();
+
+    public Task<Result<CostPrincipal>> Create(CostRecord record) =>
+      throw new NotImplementedException();
+  }
+
+  private sealed class FakeCostPolicyRepository(IEnumerable<CostPolicyPrincipal> policies)
+    : ICostPolicyRepository
+  {
+    public Task<Result<IEnumerable<CostPolicyPrincipal>>> List() =>
+      Task.FromResult((Result<IEnumerable<CostPolicyPrincipal>>)policies.ToArray());
+
+    public Task<Result<CostPolicyPrincipal>> Create(CostPolicyRecord record) =>
+      throw new NotImplementedException();
+
+    public Task<Result<CostPolicyPrincipal?>> Update(Guid id, CostPolicyRecord record) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Unit?>> Delete(Guid id) => throw new NotImplementedException();
+  }
+
+  private sealed class FakeDiscountRepository(IEnumerable<DiscountPrincipal> discounts)
+    : IDiscountRepository
+  {
+    public Task<Result<IEnumerable<DiscountPrincipal>>> Search(DiscountSearch search) =>
+      Task.FromResult((Result<IEnumerable<DiscountPrincipal>>)discounts.ToArray());
+
+    public Task<Result<DiscountPrincipal?>> Get(Guid id) => throw new NotImplementedException();
+
+    public Task<Result<DiscountPrincipal>> Create(DiscountRecord record, DiscountTarget target) =>
+      throw new NotImplementedException();
+
+    public Task<Result<DiscountPrincipal?>> Update(
+      Guid id,
+      DiscountStatus? status,
+      DiscountRecord? record,
+      DiscountTarget? target
+    ) => throw new NotImplementedException();
+
+    public Task<Result<Unit?>> Delete(Guid id) => throw new NotImplementedException();
+  }
+}

--- a/UnitTest/Transactions/TransactionGeneratorTests.cs
+++ b/UnitTest/Transactions/TransactionGeneratorTests.cs
@@ -80,4 +80,37 @@ public class TransactionGeneratorTests
     TransactionTypes.Values.Should().Contain(TransactionTypes.BookingDuplicate);
     ((int)TransactionType.BookingDuplicate).Should().Be(12);
   }
+
+  [Fact]
+  public void TransactionTypes_values_contains_priority_fee()
+  {
+    TransactionTypes.Values.Should().Contain(TransactionTypes.PriorityFee);
+    ((int)TransactionType.PriorityFee).Should().Be(15);
+  }
+
+  [Fact]
+  public void PriorityFeeCharge_moves_the_fee_from_usable_to_the_priority_fee_account()
+  {
+    var generator = new TransactionGenerator(new StubCalculator());
+
+    var record = generator.PriorityFeeCharge(10m, SampleBooking());
+
+    record.Type.Should().Be(TransactionType.PriorityFee);
+    record.Amount.Should().Be(10m);
+    record.From.Should().Be(Accounts.Usable.DisplayName);
+    record.To.Should().Be(Accounts.PriorityFee.DisplayName);
+  }
+
+  [Fact]
+  public void RefundPriorityFee_reverses_the_charge()
+  {
+    var generator = new TransactionGenerator(new StubCalculator());
+
+    var record = generator.RefundPriorityFee(10m, SampleBooking());
+
+    record.Type.Should().Be(TransactionType.PriorityFee);
+    record.Amount.Should().Be(10m);
+    record.From.Should().Be(Accounts.PriorityFee.DisplayName);
+    record.To.Should().Be(Accounts.Usable.DisplayName);
+  }
 }


### PR DESCRIPTION
## Cost policies
Pricing rules that all add up in an itemized summary (base + each policy ± + discounts = final):
- ±flat / ±percentage matched on **any combination** of date, time, day-of-week, direction
- lead-time rules (e.g. "under 12h before departure → +X"), never matching departed slots
- schedulable via effective/expiry windows; admin CRUD at `/Cost/policies`; live breakdown at `GET /Cost/summary?Date=&Time=&Direction=` (priced for the caller)

## Priority queue
- `POST Booking/{id}/prioritize`: charges the fee (default S$10, admin-configurable) from Usable into a new **BunnyBooker Priority Fee** account in one RepeatableRead transaction; booking jumps to the front of its timeslot's buy queue (Reserve + QueuePosition share one ordering: priority desc → oldest first)
- **tin needs no changes** — the buyer already pulls its next booking from zinc's Reserve
- Fee is snapshot on the booking and **refunded whenever we fail to deliver** (Refund, Cancel, Duplicate); kept on Completed/Terminated
- Gating: per-user allowlist + global allow-all + SGT time window (equal bounds = all day), admin endpoints under `/Booking/priority/*`, user-facing `GET /Booking/priority/eligibility`

## Review
Adversarially reviewed: race analysis (concurrent prioritize/buy/cancel — safe under RepeatableRead first-updater-wins), refund idempotency, ordering equivalence, migration safety (purely additive, no seed churn) all CONFIRMED clean; 3 findings fixed in the follow-up commit (Duplicate fee leak, equal-bounds window, past-slot lead-time match).

## ⚠️ Rollout note
The deployed purchase page prices via `/Cost/self` (no policies). **Do not create any cost policy until the argon update (summary-based pricing) is live**, or users will see a stale price. 196 tests green.

## Sign-off wanted
Admins can prioritize on behalf of a user, which charges the **owner's** wallet (eligibility is checked against the owner). Flagged by review as consent-free debit — current behavior kept; say the word if you want it restricted to self-service only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added booking priority support, including priority eligibility checks, priority access management, and a new prioritize action.
  * Added cost policy management and booking cost summaries with richer pricing breakdowns.
  * Expanded transaction handling to include priority fee charges and refunds.

* **Bug Fixes**
  * Priority bookings now move ahead of non-priority bookings in queue ordering.
  * Priority fees can be refunded when eligible bookings are cancelled, duplicated, or refunded.

* **Tests**
  * Added coverage for priority rules, booking prioritization, cost policy matching, cost materialization, and priority fee transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->