### PR TITLE
fix(pricing): correct lead-time targeting

### DIFF
--- a/App/Migrations/MainDbContextModelSnapshot.cs
+++ b/App/Migrations/MainDbContextModelSnapshot.cs
@@ -311,8 +311,9 @@ namespace App.Migrations
                     b.Property<DateTime?>("ExpiresAt")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<int?>("LeadTimeUnderHours")
-                        .HasColumnType("integer");
+                    b.Property<int?>("LeadTimeAtLeastHours")
+                        .HasColumnType("integer")
+                        .HasColumnName("LeadTimeUnderHours");
 
                     b.Property<DateOnly?>("MatchDate")
                         .HasColumnType("date");

--- a/App/Modules/Costs/API/V1/CostModel.cs
+++ b/App/Modules/Costs/API/V1/CostModel.cs
@@ -8,7 +8,7 @@ public record CreateCostReq(decimal Cost);
 // A pricing rule. Match* null = matches any value for that dimension.
 // MatchDate: dd-MM-yyyy, MatchTime: HH:mm:ss, MatchDayOfWeek: Monday..Sunday,
 // MatchDirection: JToW | WToJ. Amount is SIGNED (negative = discount) and a
-// percent of the base cost when IsPercentage.
+// percent of the base cost when IsPercentage. LeadTimeUnderHours is strict.
 public record CostPolicyReq(
   string Name,
   bool Enabled,

--- a/App/Modules/Discounts/API/V1/DiscountsMapper.cs
+++ b/App/Modules/Discounts/API/V1/DiscountsMapper.cs
@@ -51,7 +51,8 @@ public static class DiscountMapper
       record.MatchTime?.ToStandardTimeFormat(),
       record.MatchDayOfWeek?.ToString(),
       record.MatchDirection?.ToRes(),
-      record.LeadTimeUnderHours,
+      record.LeadTimeAtLeastHours,
+      record.LeadTimeAtLeastHours,
       record.EffectiveAt,
       record.ExpiresAt
     );
@@ -110,7 +111,7 @@ public static class DiscountMapper
         ? null
         : Enum.Parse<DayOfWeek>(record.MatchDayOfWeek),
       MatchDirection = record.MatchDirection?.DirectionToDomain(),
-      LeadTimeUnderHours = record.LeadTimeUnderHours,
+      LeadTimeAtLeastHours = record.LeadTimeAtLeastHours ?? record.LeadTimeUnderHours,
       EffectiveAt = record.EffectiveAt,
       ExpiresAt = record.ExpiresAt,
     };

--- a/App/Modules/Discounts/API/V1/DiscountsModel.cs
+++ b/App/Modules/Discounts/API/V1/DiscountsModel.cs
@@ -14,8 +14,9 @@ public record DiscountTargetReq(string MatchMode, DiscountMatchReq[] Matches);
 
 // Slot matchers (all optional; omitted/null = wildcard for that dimension):
 // MatchDate: dd-MM-yyyy, MatchTime: HH:mm:ss, MatchDayOfWeek: Monday..Sunday,
-// MatchDirection: JToW | WToJ. When ANY is set the discount only applies to
-// slot-specific pricing (never to the non-slot Cost/self price).
+// MatchDirection: JToW | WToJ, LeadTimeAtLeastHours: inclusive minimum hours
+// before departure. When ANY is set the discount only applies to slot-specific
+// pricing (never to the non-slot Cost/self price).
 public record DiscountRecordReq(
   string Name,
   string Description,
@@ -25,6 +26,10 @@ public record DiscountRecordReq(
   string? MatchTime,
   string? MatchDayOfWeek,
   string? MatchDirection,
+  int? LeadTimeAtLeastHours,
+  // Deprecated rollout alias. Treat the old wire field as the new early-buy
+  // threshold so the currently deployed Argon cannot erase saved targeting
+  // while the backend is released first.
   int? LeadTimeUnderHours,
   DateTime? EffectiveAt,
   DateTime? ExpiresAt
@@ -54,6 +59,8 @@ public record DiscountRecordRes(
   string? MatchTime,
   string? MatchDayOfWeek,
   string? MatchDirection,
+  int? LeadTimeAtLeastHours,
+  // Deprecated response alias for the same rolling deployment window.
   int? LeadTimeUnderHours,
   DateTime? EffectiveAt,
   DateTime? ExpiresAt

--- a/App/Modules/Discounts/API/V1/DiscountsValidator.cs
+++ b/App/Modules/Discounts/API/V1/DiscountsValidator.cs
@@ -61,11 +61,19 @@ public class DiscountRecordReqValidator : AbstractValidator<DiscountRecordReq>
         "MatchDayOfWeek must be one of: Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday"
       );
     this.RuleFor(x => x.MatchDirection)!.TrainDirectionValid();
+    this.RuleFor(x => x.LeadTimeAtLeastHours)
+      .GreaterThanOrEqualTo(1)
+      .LessThanOrEqualTo(8760)
+      .When(x => x.LeadTimeAtLeastHours != null)
+      .WithMessage("LeadTimeAtLeastHours must be between 1 and 8760 (a year)");
     this.RuleFor(x => x.LeadTimeUnderHours)
       .GreaterThanOrEqualTo(1)
       .LessThanOrEqualTo(8760)
       .When(x => x.LeadTimeUnderHours != null)
       .WithMessage("LeadTimeUnderHours must be between 1 and 8760 (a year)");
+    this.RuleFor(x => x)
+      .Must(LeadTimeFieldsAgree)
+      .WithMessage("LeadTimeAtLeastHours and deprecated LeadTimeUnderHours must match");
     // compare NORMALIZED instants: JSON can mix kinds (Z suffix = Utc,
     // offset = Local, bare = Unspecified-as-UTC) and comparing the raw
     // values would let an inverted — silently dead — window through
@@ -84,6 +92,11 @@ public class DiscountRecordReqValidator : AbstractValidator<DiscountRecordReq>
       DateTimeKind.Local => at.ToUniversalTime(),
       _ => DateTime.SpecifyKind(at, DateTimeKind.Utc),
     };
+
+  public static bool LeadTimeFieldsAgree(DiscountRecordReq request) =>
+    request.LeadTimeAtLeastHours == null
+    || request.LeadTimeUnderHours == null
+    || request.LeadTimeAtLeastHours == request.LeadTimeUnderHours;
 }
 
 public class DiscountStatusReqValidator : AbstractValidator<DiscountStatusReq>

--- a/App/Modules/Discounts/Data/DiscountsData.cs
+++ b/App/Modules/Discounts/Data/DiscountsData.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 
 namespace App.Modules.Discounts.Data;
@@ -29,7 +30,11 @@ public class DiscountData
   // TrainDirection via TimingMapper.ToData: 1 = JToW, 2 = WToJ
   public int? MatchDirection { get; set; }
 
-  public int? LeadTimeUnderHours { get; set; }
+  // inclusive early-purchase threshold; null = any lead time
+  // Keep the legacy physical column name so old and new API pods can run
+  // together during rolling deployments and rollbacks.
+  [Column("LeadTimeUnderHours")]
+  public int? LeadTimeAtLeastHours { get; set; }
 
   // active window [EffectiveAt, ExpiresAt); null = unbounded on that side
   public DateTime? EffectiveAt { get; set; }

--- a/App/Modules/Discounts/Data/DiscountsMapper.cs
+++ b/App/Modules/Discounts/Data/DiscountsMapper.cs
@@ -59,7 +59,7 @@ public static class DiscountMapper
       MatchTime = data.MatchTime,
       MatchDayOfWeek = data.MatchDayOfWeek == null ? null : (DayOfWeek)data.MatchDayOfWeek.Value,
       MatchDirection = data.MatchDirection?.ToTrainDirection(),
-      LeadTimeUnderHours = data.LeadTimeUnderHours,
+      LeadTimeAtLeastHours = data.LeadTimeAtLeastHours,
       EffectiveAt = data.EffectiveAt,
       ExpiresAt = data.ExpiresAt,
     };
@@ -109,7 +109,7 @@ public static class DiscountMapper
     data.MatchTime = record.MatchTime;
     data.MatchDayOfWeek = record.MatchDayOfWeek == null ? null : (byte)record.MatchDayOfWeek.Value;
     data.MatchDirection = record.MatchDirection?.ToData();
-    data.LeadTimeUnderHours = record.LeadTimeUnderHours;
+    data.LeadTimeAtLeastHours = record.LeadTimeAtLeastHours;
     // normalize to UTC: JSON without a Z suffix binds as Unspecified and an
     // offset binds as Local — Npgsql rejects both for timestamptz
     data.EffectiveAt = record.EffectiveAt.ToUtcOrNull();

--- a/App/Modules/Discounts/Data/DiscountsRepository.cs
+++ b/App/Modules/Discounts/Data/DiscountsRepository.cs
@@ -39,9 +39,7 @@ public class DiscountRepository(MainDbContext db, ILogger<DiscountRepository> lo
       if (search.MatchTarget is not null)
       {
         var mt = search.MatchTarget;
-        query = query.Where(x =>
-          x.Target.Matches.Any(y => mt.Contains(y.Value)) || x.Target.MatchMode == "none"
-        );
+        query = query.FilterByMatchTarget(mt);
       }
 
       var r = await query.ToArrayAsync();
@@ -165,4 +163,21 @@ public class DiscountRepository(MainDbContext db, ILogger<DiscountRepository> lo
       return e;
     }
   }
+}
+
+public static class DiscountCandidateQuery
+{
+  // This is only a candidate prefilter; DiscountMatcher remains the source of
+  // truth for All/Any semantics. In particular, All + zero matches is
+  // vacuously true and must reach the matcher (Argon's former default created
+  // this shape), while Any + zero matches can never match.
+  public static IQueryable<DiscountData> FilterByMatchTarget(
+    this IQueryable<DiscountData> query,
+    string[] matchTargets
+  ) =>
+    query.Where(x =>
+      x.Target.MatchMode == "none"
+      || (x.Target.MatchMode == "all" && !x.Target.Matches.Any())
+      || x.Target.Matches.Any(y => matchTargets.Contains(y.Value))
+    );
 }

--- a/Domain/Cost/CostModel.cs
+++ b/Domain/Cost/CostModel.cs
@@ -47,7 +47,7 @@ public record CostPolicyRecord
 
   public required TrainDirection? MatchDirection { get; init; }
 
-  // applies only when the booking is made this close (or closer) to departure
+  // applies only when the booking is made strictly less than this many hours before departure
   public required int? LeadTimeUnderHours { get; init; }
 
   // SIGNED: negative = discount; percent of base cost when IsPercentage

--- a/Domain/Cost/CostPolicyMatcher.cs
+++ b/Domain/Cost/CostPolicyMatcher.cs
@@ -10,7 +10,7 @@ public static class CostPolicyMatcher
 
   // A policy applies iff it is enabled, nowUtc is within its active window
   // [EffectiveAt, ExpiresAt), every non-null Match* dimension equals the
-  // booking's, and the purchase-to-departure lead time is under the cap
+  // booking's, and the purchase-to-departure lead time is strictly under the cap
   public static bool Applies(CostPolicyRecord policy, BookingCostSpec spec, DateTime nowUtc)
   {
     if (!policy.Enabled)
@@ -35,7 +35,7 @@ public static class CostPolicyMatcher
       var lead = DepartureUtc(spec) - nowUtc;
       // a departed slot has no lead time at all — an "under N hours"
       // surcharge must not match bookings for the past
-      if (lead <= TimeSpan.Zero || lead.TotalHours > policy.LeadTimeUnderHours.Value)
+      if (lead <= TimeSpan.Zero || lead.TotalHours >= policy.LeadTimeUnderHours.Value)
         return false;
     }
 

--- a/Domain/Discount/DiscountModel.cs
+++ b/Domain/Discount/DiscountModel.cs
@@ -81,8 +81,8 @@ public record DiscountRecord
 
   public TrainDirection? MatchDirection { get; init; }
 
-  // applies only when the booking is made this close (or closer) to departure
-  public int? LeadTimeUnderHours { get; init; }
+  // applies only when the booking is made at least this many hours before departure
+  public int? LeadTimeAtLeastHours { get; init; }
 
   // active window [EffectiveAt, ExpiresAt); null = unbounded on that side
   public DateTime? EffectiveAt { get; init; }

--- a/Domain/Discount/DiscountSlotMatcher.cs
+++ b/Domain/Discount/DiscountSlotMatcher.cs
@@ -3,8 +3,9 @@ using Domain.Cost;
 namespace Domain.Discount;
 
 // Pure slot-dimension matching for discounts, mirroring
-// Domain.Cost.CostPolicyMatcher.Applies exactly (same dimensions, same
-// half-open effective window, same "a departed slot never matches" guard)
+// Domain.Cost.CostPolicyMatcher.Applies for exact slot dimensions and the
+// half-open effective window. Lead time intentionally points the other way:
+// discounts reward buying at least N hours before departure.
 public static class DiscountSlotMatcher
 {
   public static bool HasSlotMatcher(DiscountRecord record) =>
@@ -12,7 +13,7 @@ public static class DiscountSlotMatcher
     || record.MatchTime != null
     || record.MatchDayOfWeek != null
     || record.MatchDirection != null
-    || record.LeadTimeUnderHours != null;
+    || record.LeadTimeAtLeastHours != null;
 
   public static bool Applies(DiscountRecord record, BookingCostSpec? spec, DateTime nowUtc)
   {
@@ -35,12 +36,12 @@ public static class DiscountSlotMatcher
     if (record.MatchDirection != null && record.MatchDirection != spec.Direction)
       return false;
 
-    if (record.LeadTimeUnderHours != null)
+    if (record.LeadTimeAtLeastHours != null)
     {
       var lead = CostPolicyMatcher.DepartureUtc(spec) - nowUtc;
-      // a departed slot has no lead time at all — an "under N hours"
-      // discount must not match bookings for the past
-      if (lead <= TimeSpan.Zero || lead.TotalHours > record.LeadTimeUnderHours.Value)
+      // At the threshold the customer has bought early enough, so the lower
+      // bound is inclusive. A departed slot has no lead time to reward.
+      if (lead <= TimeSpan.Zero || lead.TotalHours < record.LeadTimeAtLeastHours.Value)
         return false;
     }
 

--- a/UnitTest/Costs/CostPolicyMatcherTests.cs
+++ b/UnitTest/Costs/CostPolicyMatcherTests.cs
@@ -128,15 +128,23 @@ public class CostPolicyMatcherTests
   }
 
   [Fact]
-  public void Lead_time_boundary_is_inclusive()
+  public void Lead_time_boundary_is_strictly_under_the_threshold()
   {
     // departure UTC is 2026-07-15 00:30; now exactly 24h before
     var now = new DateTime(2026, 7, 14, 0, 30, 0, DateTimeKind.Utc);
-    CostPolicyMatcher.Applies(Policy(leadTimeUnderHours: 24), Spec, now).Should().BeTrue();
+    CostPolicyMatcher
+      .Applies(Policy(leadTimeUnderHours: 24), Spec, now)
+      .Should()
+      .BeFalse("exactly 24h is not under 24h");
 
-    // one second earlier the lead exceeds 24h — no longer "under"
-    var earlier = now.AddSeconds(-1);
-    CostPolicyMatcher.Applies(Policy(leadTimeUnderHours: 24), Spec, earlier).Should().BeFalse();
+    CostPolicyMatcher
+      .Applies(Policy(leadTimeUnderHours: 24), Spec, now.AddSeconds(1))
+      .Should()
+      .BeTrue("23:59:59 is under 24h");
+    CostPolicyMatcher
+      .Applies(Policy(leadTimeUnderHours: 24), Spec, now.AddSeconds(-1))
+      .Should()
+      .BeFalse("24:00:01 is over 24h");
   }
 
   [Fact]
@@ -147,7 +155,7 @@ public class CostPolicyMatcherTests
     // been misread as 08:30 UTC the lead would be 9h and it would not.
     var now = new DateTime(2026, 7, 14, 23, 30, 0, DateTimeKind.Utc);
     CostPolicyMatcher.Applies(Policy(leadTimeUnderHours: 2), Spec, now).Should().BeTrue();
-    CostPolicyMatcher.Applies(Policy(leadTimeUnderHours: 1), Spec, now).Should().BeTrue();
+    CostPolicyMatcher.Applies(Policy(leadTimeUnderHours: 1), Spec, now).Should().BeFalse();
   }
 
   [Fact]

--- a/UnitTest/Discounts/DiscountCandidateQueryTests.cs
+++ b/UnitTest/Discounts/DiscountCandidateQueryTests.cs
@@ -1,0 +1,42 @@
+using App.Modules.Discounts.Data;
+using FluentAssertions;
+
+namespace UnitTest.Discounts;
+
+public class DiscountCandidateQueryTests
+{
+  [Fact]
+  public void Target_prefilter_keeps_every_candidate_that_can_match()
+  {
+    var rows = new[]
+    {
+      Discount("none-empty", "none"),
+      Discount("all-empty", "all"),
+      Discount("all-matching", "all", "vip"),
+      Discount("any-matching", "any", "vip"),
+      Discount("all-other", "all", "staff"),
+      Discount("any-other", "any", "staff"),
+      Discount("any-empty", "any"),
+    };
+
+    rows
+      .AsQueryable()
+      .FilterByMatchTarget(["vip", "user-1"])
+      .Select(x => x.Name)
+      .Should()
+      .BeEquivalentTo("none-empty", "all-empty", "all-matching", "any-matching");
+  }
+
+  private static DiscountData Discount(string name, string matchMode, params string[] matches) =>
+    new()
+    {
+      Name = name,
+      Target = new DiscountTargetData
+      {
+        MatchMode = matchMode,
+        Matches = matches
+          .Select(x => new DiscountMatchData { Type = "role", Value = x })
+          .ToList(),
+      },
+    };
+}

--- a/UnitTest/Discounts/DiscountLeadTimeCompatibilityTests.cs
+++ b/UnitTest/Discounts/DiscountLeadTimeCompatibilityTests.cs
@@ -1,0 +1,52 @@
+using App.Modules.Discounts.API.V1;
+using FluentAssertions;
+
+namespace UnitTest.Discounts;
+
+public class DiscountLeadTimeCompatibilityTests
+{
+  [Fact]
+  public void Deprecated_under_field_maps_to_the_early_buy_threshold()
+  {
+    var domain = Request(under: 48).ToDomain();
+
+    domain.LeadTimeAtLeastHours.Should().Be(48);
+    var response = domain.ToRes();
+    response.LeadTimeAtLeastHours.Should().Be(48);
+    response.LeadTimeUnderHours.Should().Be(48);
+  }
+
+  [Fact]
+  public void New_field_takes_precedence_when_the_alias_agrees()
+  {
+    var request = Request(atLeast: 24, under: 24);
+
+    DiscountRecordReqValidator.LeadTimeFieldsAgree(request).Should().BeTrue();
+    request.ToDomain().LeadTimeAtLeastHours.Should().Be(24);
+  }
+
+  [Fact]
+  public void Conflicting_new_and_deprecated_fields_are_rejected()
+  {
+    DiscountRecordReqValidator
+      .LeadTimeFieldsAgree(Request(atLeast: 48, under: 6))
+      .Should()
+      .BeFalse();
+  }
+
+  private static DiscountRecordReq Request(int? atLeast = null, int? under = null) =>
+    new(
+      "early bird",
+      "buy earlier",
+      0.1m,
+      "Percentage",
+      null,
+      null,
+      null,
+      null,
+      atLeast,
+      under,
+      null,
+      null
+    );
+}

--- a/UnitTest/Discounts/DiscountSlotMatcherTests.cs
+++ b/UnitTest/Discounts/DiscountSlotMatcherTests.cs
@@ -6,9 +6,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace UnitTest.Discounts;
 
-// Discount slot targeting mirrors CostPolicyMatcher.Applies exactly: every
-// Match* dimension, their combinations, the lead-time boundary (incl. the
-// "departed slot never matches" guard) and the half-open effective window.
+// Discount slot targeting mirrors CostPolicyMatcher's exact dimensions and
+// effective window, but lead time rewards buying at least N hours early.
 // CRITICAL: with no spec (the Cost/self path) a discount with ANY slot
 // matcher set must conservatively never match.
 public class DiscountSlotMatcherTests
@@ -28,7 +27,7 @@ public class DiscountSlotMatcherTests
     TimeOnly? matchTime = null,
     DayOfWeek? matchDayOfWeek = null,
     TrainDirection? matchDirection = null,
-    int? leadTimeUnderHours = null,
+    int? leadTimeAtLeastHours = null,
     DateTime? effectiveAt = null,
     DateTime? expiresAt = null
   ) =>
@@ -42,7 +41,7 @@ public class DiscountSlotMatcherTests
       MatchTime = matchTime,
       MatchDayOfWeek = matchDayOfWeek,
       MatchDirection = matchDirection,
-      LeadTimeUnderHours = leadTimeUnderHours,
+      LeadTimeAtLeastHours = leadTimeAtLeastHours,
       EffectiveAt = effectiveAt,
       ExpiresAt = expiresAt,
     };
@@ -128,17 +127,23 @@ public class DiscountSlotMatcherTests
   }
 
   [Fact]
-  public void Lead_time_boundary_is_inclusive()
+  public void Lead_time_boundary_is_at_least_the_threshold()
   {
     // departure UTC is 2026-07-15 00:30; now exactly 24h before
     var now = new DateTime(2026, 7, 14, 0, 30, 0, DateTimeKind.Utc);
-    DiscountSlotMatcher.Applies(Discount(leadTimeUnderHours: 24), Spec, now).Should().BeTrue();
-
-    // one second earlier the lead exceeds 24h — no longer "under"
     DiscountSlotMatcher
-      .Applies(Discount(leadTimeUnderHours: 24), Spec, now.AddSeconds(-1))
+      .Applies(Discount(leadTimeAtLeastHours: 24), Spec, now)
       .Should()
-      .BeFalse();
+      .BeTrue("exactly 24h is early enough");
+
+    DiscountSlotMatcher
+      .Applies(Discount(leadTimeAtLeastHours: 24), Spec, now.AddSeconds(-1))
+      .Should()
+      .BeTrue("24:00:01 is earlier than the threshold");
+    DiscountSlotMatcher
+      .Applies(Discount(leadTimeAtLeastHours: 24), Spec, now.AddSeconds(1))
+      .Should()
+      .BeFalse("23:59:59 is not early enough");
   }
 
   [Fact]
@@ -147,7 +152,7 @@ public class DiscountSlotMatcherTests
     // now is AFTER the departure instant: negative lead must never match
     var afterDeparture = new DateTime(2026, 7, 15, 1, 0, 0, DateTimeKind.Utc);
     DiscountSlotMatcher
-      .Applies(Discount(leadTimeUnderHours: 24), Spec, afterDeparture)
+      .Applies(Discount(leadTimeAtLeastHours: 24), Spec, afterDeparture)
       .Should()
       .BeFalse("a booking for the past has no lead time at all");
   }
@@ -211,7 +216,7 @@ public class DiscountSlotMatcherTests
       Discount(matchTime: new TimeOnly(8, 30)),
       Discount(matchDayOfWeek: DayOfWeek.Wednesday),
       Discount(matchDirection: TrainDirection.JToW),
-      Discount(leadTimeUnderHours: 24),
+      Discount(leadTimeAtLeastHours: 24),
       Discount(matchDate: new DateOnly(2026, 7, 15), matchDirection: TrainDirection.JToW),
     };
 
@@ -224,10 +229,9 @@ public class DiscountSlotMatcherTests
       .Should()
       .BeFalse("Cost/self is not slot-specific — slot-targeted discounts must never leak into it");
 
-    // sanity: the same discount DOES match its own slot (30 min before
-    // departure so the lead-time entry is inside its cap too)
-    var justBeforeDeparture = new DateTime(2026, 7, 15, 0, 0, 0, DateTimeKind.Utc);
-    DiscountSlotMatcher.Applies(record, Spec, justBeforeDeparture).Should().BeTrue();
+    // sanity: the same discount DOES match its own slot one week before
+    // departure, including the at-least-24h lead-time entry
+    DiscountSlotMatcher.Applies(record, Spec, NowUtc).Should().BeTrue();
   }
 
   // ---- the full matcher: user/role targeting AND slot targeting ----


### PR DESCRIPTION
## Summary

- make cost lead-time thresholds strict: 0 < lead < N
- make discount lead-time thresholds reward early booking: lead >= N
- preserve old API and database field compatibility during rolling deploys
- restore targetless Everyone discounts in candidate selection

## Validation

- 286 unit tests passed
- integration test passed
- full solution build passed
- independent rollout and semantics review clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discount targeting now supports an inclusive “at least” lead-time requirement.
  * Existing lead-time fields remain compatible during the transition, with conflicting values rejected.
  * Discount matching now preserves candidates for “any,” “all,” and unrestricted target modes.

* **Bug Fixes**
  * Cost rules now correctly treat the lead-time threshold as strictly under the configured limit.
  * Discount matching correctly handles boundary times and excludes departed slots.

* **Documentation**
  * Clarified lead-time and targeting behavior in cost and discount API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->