### PR TITLE
fix(booking): enforce Singapore cutoff and harden stats

### DIFF
--- a/App/Error/V1/BookingPriceChanged.cs
+++ b/App/Error/V1/BookingPriceChanged.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace App.Error.V1;
+
+[Description(
+  "The booking price changed between the quote the customer confirmed and the purchase; the purchase was rejected without charging"
+)]
+public class BookingPriceChanged : IDomainProblem
+{
+  public BookingPriceChanged() { }
+
+  public BookingPriceChanged(string detail, string expected, string actual)
+  {
+    this.Detail = detail;
+    this.Expected = expected;
+    this.Actual = actual;
+  }
+
+  [JsonIgnore]
+  public string Id { get; } = "booking_price_changed";
+
+  [JsonIgnore]
+  public string Title { get; } = "Booking Price Changed";
+
+  [JsonIgnore]
+  public string Version { get; } = "v1";
+
+  public string Detail { get; } = string.Empty;
+
+  [Description("The canonical quote the customer confirmed")]
+  public string Expected { get; } = string.Empty;
+
+  [Description("The canonical price computed at purchase time")]
+  public string Actual { get; } = string.Empty;
+}

--- a/App/Modules/Bookings/API/V1/BookingController.cs
+++ b/App/Modules/Bookings/API/V1/BookingController.cs
@@ -334,6 +334,7 @@ public class BookingController(
           .ThenAwait(roles =>
             costCalculator
               .BookingCost(userId, roles, rec!)
+              .Then(cost => BookingPriceQuote.Validate(cost, req.ExpectedCost))
               .Then(cost => (c: cost, r: rec!), Errors.MapNone)
           )
       )

--- a/App/Modules/Bookings/API/V1/BookingController.cs
+++ b/App/Modules/Bookings/API/V1/BookingController.cs
@@ -317,24 +317,40 @@ public class BookingController(
       // Reject an expired/cutoff slot before user lookup or pricing. The
       // domain Create boundary repeats this immediately before wallet work.
       .Then(r => BookingPurchaseTiming.Validate(r!, DateTimeOffset.UtcNow), Errors.MapNone)
-      // PRICING roles = JWT roles ∪ admin-granted ExtraRoles — the SAME union
-      // the Cost summary endpoints use, so the price previewed is the price
-      // charged (an extra-role-targeted discount must not vanish at purchase)
+      // PRICING roles = the TARGET user's roles ∪ their admin-granted
+      // ExtraRoles — the SAME union the Cost summary endpoints compute for
+      // that user, so the price previewed is the price charged (an
+      // extra-role-targeted discount must not vanish at purchase, and an
+      // admin purchasing for X must not price with the admin's own roles).
+      // Self-purchase uses the caller's JWT roles exactly like Cost/summary;
+      // admin-assisted falls back to X's persisted Descope-synced Roles.
       .ThenAwait(rec =>
         userService
           .GetById(userId)
           .Then(
             u =>
-              helper
-                .FieldToScope(this.HttpContext.User, AuthRoles.Field)
-                .Union(u?.Principal.Record.ExtraRoles ?? [])
-                .ToArray(),
+              PurchasePricingRoles.For(
+                this.Sub() == userId,
+                helper.FieldToScope(this.HttpContext.User, AuthRoles.Field),
+                u?.Principal.Record
+              ),
             Errors.MapNone
           )
           .ThenAwait(roles =>
             costCalculator
               .BookingCost(userId, roles, rec!)
-              .Then(cost => BookingPriceQuote.Validate(cost, req.ExpectedCost))
+              .Then(cost =>
+              {
+                // Optional for one release: old (raichu) argon clients don't
+                // send the quote yet — charge the server-computed price and
+                // tighten to required after raichu argon ships the quote.
+                if (req.ExpectedCost == null)
+                  logger.LogWarning(
+                    "Purchase without confirmed quote (legacy client): User '{UserId}'",
+                    userId
+                  );
+                return BookingPriceQuote.Validate(cost, req.ExpectedCost);
+              })
               .Then(cost => (c: cost, r: rec!), Errors.MapNone)
           )
       )

--- a/App/Modules/Bookings/API/V1/BookingController.cs
+++ b/App/Modules/Bookings/API/V1/BookingController.cs
@@ -314,6 +314,9 @@ public class BookingController(
         createBookingReqValidator.ValidateAsyncResult(req, "Failed to validate CreateBookingReq")
       )
       .Then(r => r.ToRecord(), Errors.MapNone)
+      // Reject an expired/cutoff slot before user lookup or pricing. The
+      // domain Create boundary repeats this immediately before wallet work.
+      .Then(r => BookingPurchaseTiming.Validate(r!, DateTimeOffset.UtcNow), Errors.MapNone)
       // PRICING roles = JWT roles ∪ admin-granted ExtraRoles — the SAME union
       // the Cost summary endpoints use, so the price previewed is the price
       // charged (an extra-role-targeted discount must not vanish at purchase)
@@ -330,11 +333,11 @@ public class BookingController(
           )
           .ThenAwait(roles =>
             costCalculator
-              .BookingCost(userId, roles, rec)
-              .Then(cost => (c: cost, r: rec), Errors.MapNone)
+              .BookingCost(userId, roles, rec!)
+              .Then(cost => (c: cost, r: rec!), Errors.MapNone)
           )
       )
-      .ThenAwait(cr => service.Create(userId, cr.c, cr.r))
+      .ThenAwait(cr => service.Create(userId, cr.c, cr.r!))
       .Then(b => b.ToRes(), Errors.MapNone);
 
     return this.ReturnResult(p);

--- a/App/Modules/Bookings/API/V1/BookingModel.cs
+++ b/App/Modules/Bookings/API/V1/BookingModel.cs
@@ -35,9 +35,9 @@ public record CreateBookingReq(
   string Time,
   string Direction,
   BookingPassengerReq Passenger,
-  // Optional for backwards compatibility. Current clients send the exact
-  // quote they confirmed; purchase rejects atomically if pricing changed.
-  decimal? ExpectedCost = null
+  // Canonical quote returned by Cost/summary. Purchase rejects atomically if
+  // pricing changed after the customer opened confirmation.
+  string ExpectedCost
 );
 
 public record UpdateBookingReq(

--- a/App/Modules/Bookings/API/V1/BookingModel.cs
+++ b/App/Modules/Bookings/API/V1/BookingModel.cs
@@ -36,8 +36,10 @@ public record CreateBookingReq(
   string Direction,
   BookingPassengerReq Passenger,
   // Canonical quote returned by Cost/summary. Purchase rejects atomically if
-  // pricing changed after the customer opened confirmation.
-  string ExpectedCost
+  // pricing changed after the customer opened confirmation. Optional for one
+  // release: old (raichu) argon clients don't send the quote yet — tighten to
+  // required after raichu argon ships it.
+  string? ExpectedCost
 );
 
 public record UpdateBookingReq(

--- a/App/Modules/Bookings/API/V1/BookingModel.cs
+++ b/App/Modules/Bookings/API/V1/BookingModel.cs
@@ -34,7 +34,10 @@ public record CreateBookingReq(
   string Date,
   string Time,
   string Direction,
-  BookingPassengerReq Passenger
+  BookingPassengerReq Passenger,
+  // Optional for backwards compatibility. Current clients send the exact
+  // quote they confirmed; purchase rejects atomically if pricing changed.
+  decimal? ExpectedCost = null
 );
 
 public record UpdateBookingReq(

--- a/App/Modules/Bookings/API/V1/BookingValidator.cs
+++ b/App/Modules/Bookings/API/V1/BookingValidator.cs
@@ -23,6 +23,10 @@ public class CreateBookingReqValidator : AbstractValidator<CreateBookingReq>
     this.RuleFor(x => x.Time).NotNull().TimeValid();
     this.RuleFor(x => x.Direction).NotNull().TrainDirectionValid();
     this.RuleFor(x => x.Passenger).NotNull().SetValidator(new BookingPassengerReqValidator());
+    this.RuleFor(x => x.ExpectedCost)
+      .GreaterThanOrEqualTo(0)
+      .When(x => x.ExpectedCost != null)
+      .WithMessage("ExpectedCost must be at least 0");
   }
 }
 

--- a/App/Modules/Bookings/API/V1/BookingValidator.cs
+++ b/App/Modules/Bookings/API/V1/BookingValidator.cs
@@ -24,10 +24,11 @@ public class CreateBookingReqValidator : AbstractValidator<CreateBookingReq>
     this.RuleFor(x => x.Time).NotNull().TimeValid();
     this.RuleFor(x => x.Direction).NotNull().TrainDirectionValid();
     this.RuleFor(x => x.Passenger).NotNull().SetValidator(new BookingPassengerReqValidator());
+    // null = legacy (raichu) argon client without the quote flow; when the
+    // quote is present it must be the canonical token Cost/summary returned
     this.RuleFor(x => x.ExpectedCost)
-      .NotEmpty()
-      .Must(x => x != null && BookingPriceQuote.IsCanonical(x))
-      .WithMessage("ExpectedCost must be a canonical non-negative decimal quote");
+      .Must(x => x == null || BookingPriceQuote.IsCanonical(x))
+      .WithMessage("ExpectedCost must be a canonical non-negative decimal quote when provided");
   }
 }
 

--- a/App/Modules/Bookings/API/V1/BookingValidator.cs
+++ b/App/Modules/Bookings/API/V1/BookingValidator.cs
@@ -1,4 +1,5 @@
 using App.Utility;
+using Domain.Booking;
 using FluentValidation;
 
 namespace App.Modules.Bookings.API.V1;
@@ -24,9 +25,9 @@ public class CreateBookingReqValidator : AbstractValidator<CreateBookingReq>
     this.RuleFor(x => x.Direction).NotNull().TrainDirectionValid();
     this.RuleFor(x => x.Passenger).NotNull().SetValidator(new BookingPassengerReqValidator());
     this.RuleFor(x => x.ExpectedCost)
-      .GreaterThanOrEqualTo(0)
-      .When(x => x.ExpectedCost != null)
-      .WithMessage("ExpectedCost must be at least 0");
+      .NotEmpty()
+      .Must(x => x != null && BookingPriceQuote.IsCanonical(x))
+      .WithMessage("ExpectedCost must be a canonical non-negative decimal quote");
   }
 }
 

--- a/App/Modules/Bookings/Data/BookingRepository.cs
+++ b/App/Modules/Bookings/Data/BookingRepository.cs
@@ -8,6 +8,7 @@ using Domain.Booking;
 using Domain.Timings;
 using EntityFramework.Exceptions.Common;
 using Microsoft.EntityFrameworkCore;
+using Npgsql.EntityFrameworkCore.PostgreSQL;
 
 namespace App.Modules.Bookings.Data;
 
@@ -232,39 +233,54 @@ public class BookingRepository(
   {
     try
     {
-      await RefreshStatsViewIfStale();
+      // Managed Postgres occasionally terminates established connections
+      // during a handoff (57P01). A stats read is side-effect free, so retry it
+      // on a fresh connection instead of turning that brief event into a 500.
+      // Keep this local rather than enabling global EF retries: write paths use
+      // ambient TransactionScope transactions and need different semantics.
+      var retry = new NpgsqlRetryingExecutionStrategy(
+        db,
+        maxRetryCount: 3,
+        maxRetryDelay: TimeSpan.FromSeconds(1),
+        errorCodesToAdd: ["57P01", "57P02", "57P03"]
+      );
 
-      var query = db.BookingStats.AsQueryable();
-      if (statsQuery.After != null)
-        query = query.Where(x => x.Date >= statsQuery.After);
-      if (statsQuery.Before != null)
-        query = query.Where(x => x.Date <= statsQuery.Before);
+      var rows = await retry.ExecuteAsync(async () =>
+      {
+        await RefreshStatsViewIfStale();
 
-      // the view's grain keeps the travel date (for the range filter above);
-      // the response aggregates it away, so re-group DB-side on everything
-      // else and sum the precomputed counts
-      var rows = await query
-        .GroupBy(x => new
-        {
-          x.DayOfWeek,
-          x.Time,
-          x.Direction,
-          x.Priority,
-          x.LeadBucket,
-          x.DemandBucket,
-          x.DeliveryBucket,
-        })
-        .Select(g => new
-        {
-          g.Key,
-          Total = g.Sum(x => x.Total),
-          Completed = g.Sum(x => x.Completed),
-          Refunded = g.Sum(x => x.Refunded),
-          Cancelled = g.Sum(x => x.Cancelled),
-          Terminated = g.Sum(x => x.Terminated),
-          Other = g.Sum(x => x.Other),
-        })
-        .ToArrayAsync();
+        var query = db.BookingStats.AsQueryable();
+        if (statsQuery.After != null)
+          query = query.Where(x => x.Date >= statsQuery.After);
+        if (statsQuery.Before != null)
+          query = query.Where(x => x.Date <= statsQuery.Before);
+
+        // the view's grain keeps the travel date (for the range filter above);
+        // the response aggregates it away, so re-group DB-side on everything
+        // else and sum the precomputed counts
+        return await query
+          .GroupBy(x => new
+          {
+            x.DayOfWeek,
+            x.Time,
+            x.Direction,
+            x.Priority,
+            x.LeadBucket,
+            x.DemandBucket,
+            x.DeliveryBucket,
+          })
+          .Select(g => new
+          {
+            g.Key,
+            Total = g.Sum(x => x.Total),
+            Completed = g.Sum(x => x.Completed),
+            Refunded = g.Sum(x => x.Refunded),
+            Cancelled = g.Sum(x => x.Cancelled),
+            Terminated = g.Sum(x => x.Terminated),
+            Other = g.Sum(x => x.Other),
+          })
+          .ToArrayAsync();
+      });
 
       return rows
         .Select(x => new BookingStatRow

--- a/App/Modules/Bookings/Data/BookingRepository.cs
+++ b/App/Modules/Bookings/Data/BookingRepository.cs
@@ -191,7 +191,13 @@ public class BookingRepository(
   {
     if (DateTime.UtcNow - statsRefreshedAtUtc < StatsMaxStaleness)
       return;
-    if (db.Database.CurrentTransaction != null)
+    // writes use ambient TransactionScope (TransactionManager), which never
+    // surfaces on CurrentTransaction — check both so REFRESH CONCURRENTLY
+    // can never be dragged into a transaction
+    if (
+      db.Database.CurrentTransaction != null
+      || global::System.Transactions.Transaction.Current != null
+    )
       return;
 
     try

--- a/App/Modules/Bookings/Data/BookingRepository.cs
+++ b/App/Modules/Bookings/Data/BookingRepository.cs
@@ -240,7 +240,8 @@ public class BookingRepository(
       // ambient TransactionScope transactions and need different semantics.
       var retry = new NpgsqlRetryingExecutionStrategy(
         db,
-        maxRetryCount: 3,
+        // one initial attempt plus two retries
+        maxRetryCount: 2,
         maxRetryDelay: TimeSpan.FromSeconds(1),
         errorCodesToAdd: ["57P01", "57P02", "57P03"]
       );

--- a/App/Modules/Bookings/Data/BookingStats.cs
+++ b/App/Modules/Bookings/Data/BookingStats.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Domain.Booking;
 
 namespace App.Modules.Bookings.Data;
 
@@ -78,7 +79,7 @@ public static class BookingStats
 
   public static string LeadTimeBucket(DateOnly date, TimeOnly time, DateTime createdAtUtc)
   {
-    var departureUtc = date.ToDateTime(time, DateTimeKind.Unspecified).AddHours(-8);
+    var departureUtc = BookingPurchaseTiming.DepartureUtc(date, time);
     var lead = departureUtc - createdAtUtc;
     return Bucket(lead.TotalHours, LeadLadder, LeadOverflow);
   }

--- a/App/Modules/Common/BaseController.cs
+++ b/App/Modules/Common/BaseController.cs
@@ -7,6 +7,7 @@ using App.StartUp.Services.Auth;
 using App.Utility;
 using CSharp_Result;
 using Domain.Exceptions;
+using Domain.Booking;
 using Microsoft.AspNetCore.Mvc;
 
 namespace App.Modules.Common;
@@ -53,6 +54,10 @@ public class AtomiControllerBase(IAuthHelper h) : ControllerBase
       InvalidBookingOperationException iboe => this.Error(
         HttpStatusCode.BadRequest,
         new InvalidBookingOperation(iboe.Message, iboe.BookStatus, iboe.Operation)
+      ),
+      BookingPriceChangedException bpce => this.Error(
+        HttpStatusCode.Conflict,
+        new EntityConflict(bpce.Message, typeof(BookingPrincipal))
       ),
       InvalidWithdrawalOperationException iwoe => this.Error(
         HttpStatusCode.BadRequest,

--- a/App/Modules/Common/BaseController.cs
+++ b/App/Modules/Common/BaseController.cs
@@ -6,8 +6,8 @@ using App.StartUp.Registry;
 using App.StartUp.Services.Auth;
 using App.Utility;
 using CSharp_Result;
-using Domain.Exceptions;
 using Domain.Booking;
+using Domain.Exceptions;
 using Microsoft.AspNetCore.Mvc;
 
 namespace App.Modules.Common;
@@ -57,7 +57,7 @@ public class AtomiControllerBase(IAuthHelper h) : ControllerBase
       ),
       BookingPriceChangedException bpce => this.Error(
         HttpStatusCode.Conflict,
-        new EntityConflict(bpce.Message, typeof(BookingPrincipal))
+        new BookingPriceChanged(bpce.Message, bpce.Expected, bpce.Actual)
       ),
       InvalidWithdrawalOperationException iwoe => this.Error(
         HttpStatusCode.BadRequest,

--- a/App/Modules/Costs/API/V1/CostMapper.cs
+++ b/App/Modules/Costs/API/V1/CostMapper.cs
@@ -1,6 +1,7 @@
 using App.Modules.Discounts.API.V1;
 using App.Modules.Timings.API.V1;
 using App.Utility;
+using Domain.Booking;
 using Domain.Cost;
 
 namespace App.Modules.Costs.API.V1;
@@ -28,7 +29,8 @@ public static class CostMapper
       cost.PolicyLines.Select(x => x.ToRes()).ToArray(),
       cost.Subtotal,
       cost.Discounts.Select(x => x.ToRes()).ToArray(),
-      cost.Final
+      cost.Final,
+      BookingPriceQuote.Create(cost.Final)
     );
 
   public static CostSlotSummaryRes ToRes(this MaterializedCostSlot slot) =>
@@ -38,7 +40,8 @@ public static class CostMapper
       slot.Cost.PolicyLines.Select(x => x.ToRes()).ToArray(),
       slot.Cost.Subtotal,
       slot.Cost.Discounts.Select(x => x.ToRes()).ToArray(),
-      slot.Cost.Final
+      slot.Cost.Final,
+      BookingPriceQuote.Create(slot.Cost.Final)
     );
 
   public static CostPolicyPrincipalRes ToRes(this CostPolicyPrincipal principal) =>

--- a/App/Modules/Costs/API/V1/CostModel.cs
+++ b/App/Modules/Costs/API/V1/CostModel.cs
@@ -51,7 +51,10 @@ public record CostSummaryRes(
   CostPolicyLineRes[] PolicyLines,
   decimal Subtotal,
   DiscountRecordRes[] Discounts,
-  decimal Final
+  decimal Final,
+  // Canonical decimal text used as the purchase quote lock. Unlike a JSON
+  // number, this round-trips all decimal precision through JavaScript.
+  string Quote
 );
 
 // one slot of the batch preview: the same breakdown as CostSummaryRes for
@@ -62,7 +65,8 @@ public record CostSlotSummaryRes(
   CostPolicyLineRes[] PolicyLines,
   decimal Subtotal,
   DiscountRecordRes[] Discounts,
-  decimal Final
+  decimal Final,
+  string Quote
 );
 
 public record CostPolicyPrincipalRes(

--- a/Domain/Booking/BookingPriceQuote.cs
+++ b/Domain/Booking/BookingPriceQuote.cs
@@ -1,18 +1,26 @@
+using System.Globalization;
 using CSharp_Result;
 using Domain.Exceptions;
 
 namespace Domain.Booking;
 
 // The price accepted by the customer must be the exact price charged by this
-// purchase request. Null keeps older API clients compatible; current clients
-// always send the quote they displayed.
+// purchase request. JavaScript transports the canonical token as text so no
+// decimal precision is lost.
 public static class BookingPriceQuote
 {
-  public static Result<decimal> Validate(decimal actual, decimal? expected)
+  public static string Create(decimal cost) => cost.ToString("G29", CultureInfo.InvariantCulture);
+
+  public static bool IsCanonical(string token) =>
+    decimal.TryParse(token, NumberStyles.Float, CultureInfo.InvariantCulture, out var cost)
+    && cost >= 0
+    && Create(cost) == token;
+
+  public static Result<decimal> Validate(decimal actual, string expected)
   {
-    if (expected == null || actual == expected.Value)
+    if (Create(actual) == expected)
       return actual;
 
-    return new BookingPriceChangedException(expected.Value, actual);
+    return new BookingPriceChangedException(expected, Create(actual));
   }
 }

--- a/Domain/Booking/BookingPriceQuote.cs
+++ b/Domain/Booking/BookingPriceQuote.cs
@@ -1,0 +1,18 @@
+using CSharp_Result;
+using Domain.Exceptions;
+
+namespace Domain.Booking;
+
+// The price accepted by the customer must be the exact price charged by this
+// purchase request. Null keeps older API clients compatible; current clients
+// always send the quote they displayed.
+public static class BookingPriceQuote
+{
+  public static Result<decimal> Validate(decimal actual, decimal? expected)
+  {
+    if (expected == null || actual == expected.Value)
+      return actual;
+
+    return new BookingPriceChangedException(expected.Value, actual);
+  }
+}

--- a/Domain/Booking/BookingPriceQuote.cs
+++ b/Domain/Booking/BookingPriceQuote.cs
@@ -9,16 +9,25 @@ namespace Domain.Booking;
 // decimal precision is lost.
 public static class BookingPriceQuote
 {
-  public static string Create(decimal cost) => cost.ToString("G29", CultureInfo.InvariantCulture);
+  // fixed-point, trailing zeros trimmed: "G29" would emit scientific notation
+  // below 1e-4 ("1E-05" instead of "0.00001"). 28 fractional places is
+  // decimal's full scale, so this stays lossless for every representable cost.
+  private const string FixedPoint = "0.############################";
+
+  public static string Create(decimal cost) =>
+    cost.ToString(FixedPoint, CultureInfo.InvariantCulture);
 
   public static bool IsCanonical(string token) =>
     decimal.TryParse(token, NumberStyles.Float, CultureInfo.InvariantCulture, out var cost)
     && cost >= 0
     && Create(cost) == token;
 
-  public static Result<decimal> Validate(decimal actual, string expected)
+  // A null expected quote is allowed for one release: old (raichu) argon
+  // clients don't send it yet, so they are charged the server-computed price
+  // unchecked. Tighten to required after raichu argon ships the quote flow.
+  public static Result<decimal> Validate(decimal actual, string? expected)
   {
-    if (Create(actual) == expected)
+    if (expected == null || Create(actual) == expected)
       return actual;
 
     return new BookingPriceChangedException(expected, Create(actual));

--- a/Domain/Booking/BookingPurchaseTiming.cs
+++ b/Domain/Booking/BookingPurchaseTiming.cs
@@ -15,7 +15,13 @@ public static class BookingPurchaseTiming
   public static DateTime DepartureUtc(DateOnly date, TimeOnly time)
   {
     var singaporeWallClock = date.ToDateTime(time, DateTimeKind.Unspecified);
-    return new DateTimeOffset(singaporeWallClock, SingaporeUtcOffset).UtcDateTime;
+    // DateOnly accepts year 1, whose first eight Singapore hours would map
+    // before DateTime.MinValue in UTC. Treat that impossible booking instant
+    // as the earliest UTC value so cutoff checks reject it instead of 500ing.
+    if (singaporeWallClock < DateTime.MinValue.Add(SingaporeUtcOffset))
+      return DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc);
+
+    return DateTime.SpecifyKind(singaporeWallClock.Subtract(SingaporeUtcOffset), DateTimeKind.Utc);
   }
 
   public static TimeSpan LeadTime(DateOnly date, TimeOnly time, DateTimeOffset now) =>

--- a/Domain/Booking/BookingPurchaseTiming.cs
+++ b/Domain/Booking/BookingPurchaseTiming.cs
@@ -1,0 +1,40 @@
+using CSharp_Result;
+using Domain.Exceptions;
+
+namespace Domain.Booking;
+
+// One clock rule for every booking boundary: Date + Time are Singapore wall
+// clock, and a customer may purchase only while at least three hours remain.
+// Callers supply `now` so the conversion and cutoff stay pure and testable.
+public static class BookingPurchaseTiming
+{
+  private static readonly TimeSpan SingaporeUtcOffset = TimeSpan.FromHours(8);
+
+  public static readonly TimeSpan MinimumLeadTime = TimeSpan.FromHours(3);
+
+  public static DateTime DepartureUtc(DateOnly date, TimeOnly time)
+  {
+    var singaporeWallClock = date.ToDateTime(time, DateTimeKind.Unspecified);
+    return new DateTimeOffset(singaporeWallClock, SingaporeUtcOffset).UtcDateTime;
+  }
+
+  public static TimeSpan LeadTime(DateOnly date, TimeOnly time, DateTimeOffset now) =>
+    DepartureUtc(date, time) - now.UtcDateTime;
+
+  // "Three hours before departure" is inclusive: exactly 03:00:00 remains
+  // purchasable; 02:59:59.999... does not.
+  public static bool CanPurchase(DateOnly date, TimeOnly time, DateTimeOffset now) =>
+    LeadTime(date, time, now) >= MinimumLeadTime;
+
+  public static Result<BookingRecord> Validate(BookingRecord record, DateTimeOffset now)
+  {
+    if (CanPurchase(record.Date, record.Time, now))
+      return record;
+
+    return new InvalidBookingOperationException(
+      "Bookings must be purchased at least 3 hours before departure",
+      BookStatus.Pending,
+      BookingOperations.Purchase
+    );
+  }
+}

--- a/Domain/Booking/Service.cs
+++ b/Domain/Booking/Service.cs
@@ -20,9 +20,12 @@ public class BookingService(
   IBookingNotificationService notificationService,
   IPrioritySettingsRepository prioritySettingsRepo,
   IPriorityAccessRepository priorityAccessRepo,
-  ILogger<BookingService> logger
+  ILogger<BookingService> logger,
+  TimeProvider? timeProvider = null
 ) : IBookingService
 {
+  private TimeProvider Clock { get; } = timeProvider ?? TimeProvider.System;
+
   public Task<Result<IEnumerable<BookingPrincipal>>> Search(BookingSearch search)
   {
     return repo.Search(search);
@@ -65,7 +68,7 @@ public class BookingService(
   {
     // Defense in depth: API Purchase checks before pricing, and this domain
     // boundary checks again before opening a transaction or touching a wallet.
-    var timing = BookingPurchaseTiming.Validate(record, DateTimeOffset.UtcNow);
+    var timing = BookingPurchaseTiming.Validate(record, this.Clock.GetUtcNow());
     if (!timing.IsSuccess())
       return Task.FromResult((Result<BookingPrincipal>)timing.FailureOrDefault());
 
@@ -75,6 +78,14 @@ public class BookingService(
           walletRepo
             .GetByUserId(userId)
             .NullToError(userId)
+            // The user/wallet lookup can cross the exact cutoff. Re-read the
+            // clock inside the transaction immediately before BookStart so a
+            // newly expired request cannot reserve any money.
+            .Then(w =>
+              BookingPurchaseTiming
+                .Validate(record, this.Clock.GetUtcNow())
+                .Then(_ => w, Errors.MapNone)
+            )
             .ThenAwait(x => walletRepo.BookStart(x.Principal.Id, cost))
             .NullToError(userId)
             .ThenAwait(w =>

--- a/Domain/Booking/Service.cs
+++ b/Domain/Booking/Service.cs
@@ -63,6 +63,12 @@ public class BookingService(
   // When user creates a booking
   public Task<Result<BookingPrincipal>> Create(string userId, decimal cost, BookingRecord record)
   {
+    // Defense in depth: API Purchase checks before pricing, and this domain
+    // boundary checks again before opening a transaction or touching a wallet.
+    var timing = BookingPurchaseTiming.Validate(record, DateTimeOffset.UtcNow);
+    if (!timing.IsSuccess())
+      return Task.FromResult((Result<BookingPrincipal>)timing.FailureOrDefault());
+
     return transaction
       .Start(
         () =>

--- a/Domain/Cost/CostPolicyMatcher.cs
+++ b/Domain/Cost/CostPolicyMatcher.cs
@@ -1,3 +1,5 @@
+using Domain.Booking;
+
 namespace Domain.Cost;
 
 // Pure policy matching rules, shared by pricing and (unit) tests
@@ -6,7 +8,7 @@ public static class CostPolicyMatcher
   // Booking Date + Time are SGT (UTC+8) wall clock; see BookingStats for the
   // established departure-instant pattern
   public static DateTime DepartureUtc(BookingCostSpec spec) =>
-    spec.Date.ToDateTime(spec.Time, DateTimeKind.Unspecified).AddHours(-8);
+    BookingPurchaseTiming.DepartureUtc(spec.Date, spec.Time);
 
   // A policy applies iff it is enabled, nowUtc is within its active window
   // [EffectiveAt, ExpiresAt), every non-null Match* dimension equals the

--- a/Domain/Cost/CostService.cs
+++ b/Domain/Cost/CostService.cs
@@ -181,7 +181,15 @@ public class CostService(
       baseCost
     );
 
-    var f = discountCalculator.Calculate(subtotal, discountsApplicable.Select(x => x.Record));
+    // Monetary columns persist at numeric(16,8). Normalize here so the API
+    // quote, stale-price validation and wallet transaction all use exactly
+    // the same value PostgreSQL stores. PostgreSQL rounds numeric ties away
+    // from zero; costs are non-negative but use the matching mode explicitly.
+    var f = Math.Round(
+      discountCalculator.Calculate(subtotal, discountsApplicable.Select(x => x.Record)),
+      8,
+      MidpointRounding.AwayFromZero
+    );
 
     return new MaterializedCost
     {

--- a/Domain/Exceptions/BookingPriceChangedException.cs
+++ b/Domain/Exceptions/BookingPriceChangedException.cs
@@ -1,0 +1,9 @@
+namespace Domain.Exceptions;
+
+public class BookingPriceChangedException(decimal expected, decimal actual)
+  : Exception("The booking price changed. Refresh the quote and confirm again.")
+{
+  public decimal Expected { get; } = expected;
+
+  public decimal Actual { get; } = actual;
+}

--- a/Domain/Exceptions/BookingPriceChangedException.cs
+++ b/Domain/Exceptions/BookingPriceChangedException.cs
@@ -1,9 +1,9 @@
 namespace Domain.Exceptions;
 
-public class BookingPriceChangedException(decimal expected, decimal actual)
+public class BookingPriceChangedException(string expected, string actual)
   : Exception("The booking price changed. Refresh the quote and confirm again.")
 {
-  public decimal Expected { get; } = expected;
+  public string Expected { get; } = expected;
 
-  public decimal Actual { get; } = actual;
+  public string Actual { get; } = actual;
 }

--- a/Domain/User/PurchasePricingRoles.cs
+++ b/Domain/User/PurchasePricingRoles.cs
@@ -1,0 +1,23 @@
+namespace Domain.User;
+
+// PRICING roles for a purchase made on behalf of a target user: the TARGET
+// user's roles ∪ their admin-granted ExtraRoles — the same union the Cost
+// summary endpoints compute for that user, so the price previewed is the
+// price charged (an extra-role-targeted discount must not vanish at
+// purchase, and an admin-assisted purchase must not be priced with the
+// admin's own roles). When the caller IS the target their JWT is
+// authoritative, exactly like Cost/summary; when an admin purchases for
+// someone else that user's JWT is absent, so fall back to the persisted
+// Roles mirror (UserRecord.Roles, synced from the Descope token). Pricing
+// only — never used for authorization.
+public static class PurchasePricingRoles
+{
+  public static string[] For(
+    bool callerIsTarget,
+    IEnumerable<string> callerTokenRoles,
+    UserRecord? target
+  ) =>
+    (callerIsTarget ? callerTokenRoles : target?.Roles ?? [])
+      .Union(target?.ExtraRoles ?? [])
+      .ToArray();
+}

--- a/UnitTest/Bookings/BookingPriceQuoteTests.cs
+++ b/UnitTest/Bookings/BookingPriceQuoteTests.cs
@@ -9,23 +9,42 @@ public class BookingPriceQuoteTests
   [Fact]
   public void Matching_expected_price_is_accepted()
   {
-    BookingPriceQuote.Validate(15.12345678m, 15.12345678m).Get().Should().Be(15.12345678m);
-  }
+    var quote = BookingPriceQuote.Create(15.12345678m);
 
-  [Fact]
-  public void Missing_expected_price_keeps_older_clients_compatible()
-  {
-    BookingPriceQuote.Validate(15m, null).Get().Should().Be(15m);
+    quote.Should().Be("15.12345678");
+    BookingPriceQuote.Validate(15.12345678m, quote).Get().Should().Be(15.12345678m);
   }
 
   [Fact]
   public void Any_price_change_is_rejected_even_below_one_cent()
   {
-    var result = BookingPriceQuote.Validate(1.005m, 1.004m);
+    var result = BookingPriceQuote.Validate(1.005m, BookingPriceQuote.Create(1.004m));
 
     result.IsSuccess().Should().BeFalse();
     var error = result.FailureOrDefault().Should().BeOfType<BookingPriceChangedException>().Subject;
-    error.Expected.Should().Be(1.004m);
-    error.Actual.Should().Be(1.005m);
+    error.Expected.Should().Be("1.004");
+    error.Actual.Should().Be("1.005");
+  }
+
+  [Fact]
+  public void Quote_preserves_decimal_precision_that_json_numbers_cannot()
+  {
+    const decimal final = 13.2563635034720316m;
+
+    BookingPriceQuote.Create(final).Should().Be("13.2563635034720316");
+    BookingPriceQuote.Validate(final, "13.2563635034720316").IsSuccess().Should().BeTrue();
+    BookingPriceQuote.IsCanonical("13.2563635034720316").Should().BeTrue();
+    BookingPriceQuote.IsCanonical("13.256363503472032").Should().BeTrue();
+    BookingPriceQuote.Validate(final, "13.256363503472032").IsSuccess().Should().BeFalse();
+  }
+
+  [Theory]
+  [InlineData("01.00")]
+  [InlineData("1.0")]
+  [InlineData("-1")]
+  [InlineData("not-a-price")]
+  public void Noncanonical_quote_tokens_are_rejected(string token)
+  {
+    BookingPriceQuote.IsCanonical(token).Should().BeFalse();
   }
 }

--- a/UnitTest/Bookings/BookingPriceQuoteTests.cs
+++ b/UnitTest/Bookings/BookingPriceQuoteTests.cs
@@ -1,0 +1,31 @@
+using Domain.Booking;
+using Domain.Exceptions;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+public class BookingPriceQuoteTests
+{
+  [Fact]
+  public void Matching_expected_price_is_accepted()
+  {
+    BookingPriceQuote.Validate(15.12345678m, 15.12345678m).Get().Should().Be(15.12345678m);
+  }
+
+  [Fact]
+  public void Missing_expected_price_keeps_older_clients_compatible()
+  {
+    BookingPriceQuote.Validate(15m, null).Get().Should().Be(15m);
+  }
+
+  [Fact]
+  public void Any_price_change_is_rejected_even_below_one_cent()
+  {
+    var result = BookingPriceQuote.Validate(1.005m, 1.004m);
+
+    result.IsSuccess().Should().BeFalse();
+    var error = result.FailureOrDefault().Should().BeOfType<BookingPriceChangedException>().Subject;
+    error.Expected.Should().Be(1.004m);
+    error.Actual.Should().Be(1.005m);
+  }
+}

--- a/UnitTest/Bookings/BookingPriceQuoteTests.cs
+++ b/UnitTest/Bookings/BookingPriceQuoteTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Domain.Booking;
 using Domain.Exceptions;
 using FluentAssertions;
@@ -43,8 +44,32 @@ public class BookingPriceQuoteTests
   [InlineData("1.0")]
   [InlineData("-1")]
   [InlineData("not-a-price")]
+  [InlineData("1E-05")] // scientific notation is not the canonical form
   public void Noncanonical_quote_tokens_are_rejected(string token)
   {
     BookingPriceQuote.IsCanonical(token).Should().BeFalse();
+  }
+
+  // "G29" would render these as "1E-05"/"1E-08"; the canonical token must be
+  // plain fixed-point so JavaScript, the validator regex-free canonical check
+  // and the customer all see the same digits
+  [Theory]
+  [InlineData("0.00001")]
+  [InlineData("0.00000001")]
+  public void Tiny_quotes_are_fixed_point_not_scientific(string token)
+  {
+    var cost = decimal.Parse(token, CultureInfo.InvariantCulture);
+
+    BookingPriceQuote.Create(cost).Should().Be(token);
+    BookingPriceQuote.IsCanonical(token).Should().BeTrue();
+    BookingPriceQuote.Validate(cost, token).IsSuccess().Should().BeTrue();
+  }
+
+  // Optional for one release: old (raichu) argon clients don't send the
+  // quote — a null quote skips validation and charges the server price
+  [Fact]
+  public void Null_quote_is_accepted_at_the_server_price()
+  {
+    BookingPriceQuote.Validate(15.12345678m, null).Get().Should().Be(15.12345678m);
   }
 }

--- a/UnitTest/Bookings/BookingPurchaseTimingTests.cs
+++ b/UnitTest/Bookings/BookingPurchaseTimingTests.cs
@@ -1,10 +1,12 @@
 using System.Reflection;
+using CSharp_Result;
 using Domain;
 using Domain.Booking;
 using Domain.Exceptions;
 using Domain.Passenger;
 using Domain.Timings;
 using Domain.Transaction;
+using Domain.User;
 using Domain.Wallet;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -126,6 +128,148 @@ public class BookingPurchaseTimingTests
     notificationCalls.Should().BeEmpty();
     settingsCalls.Should().BeEmpty();
     accessCalls.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task Domain_create_rechecks_cutoff_immediately_before_wallet_mutation()
+  {
+    var departureUtc = BookingPurchaseTiming.DepartureUtc(DepartureDate, DepartureTime);
+    var clock = new SequenceTimeProvider(
+      new DateTimeOffset(departureUtc - TimeSpan.FromHours(3)),
+      new DateTimeOffset(departureUtc - TimeSpan.FromHours(3) + TimeSpan.FromTicks(1))
+    );
+    var wallet = new CutoffWalletRepository();
+    var bookingRepo = RecordCalls<IBookingRepository>(out var bookingCalls);
+    var storage = RecordCalls<IBookingStorage>(out var storageCalls);
+    var transactionRepo = RecordCalls<ITransactionRepository>(out var transactionRepoCalls);
+    var transactionGenerator = RecordCalls<ITransactionGenerator>(out var generatorCalls);
+    var fee = RecordCalls<IFeeCalculator>(out var feeCalls);
+    var terminator = RecordCalls<IBookingTerminatorRepository>(out var terminatorCalls);
+    var cdc = RecordCalls<IBookingCdcRepository>(out var cdcCalls);
+    var notifications = RecordCalls<IBookingNotificationService>(out var notificationCalls);
+    var settings = RecordCalls<IPrioritySettingsRepository>(out var settingsCalls);
+    var access = RecordCalls<IPriorityAccessRepository>(out var accessCalls);
+
+    var service = new BookingService(
+      bookingRepo,
+      storage,
+      wallet,
+      transactionRepo,
+      new ImmediateTransactionManager(),
+      transactionGenerator,
+      fee,
+      terminator,
+      cdc,
+      notifications,
+      settings,
+      access,
+      NullLogger<BookingService>.Instance,
+      clock
+    );
+
+    var result = await service.Create("user", 10m, Record(DepartureDate, DepartureTime));
+
+    result.FailureOrDefault().Should().BeOfType<InvalidBookingOperationException>();
+    clock.Reads.Should().Be(2);
+    wallet.GetByUserIdCalls.Should().Be(1);
+    wallet.BookStartCalls.Should().Be(0, "the final clock check must happen before reservation");
+    bookingCalls.Should().BeEmpty();
+    storageCalls.Should().BeEmpty();
+    transactionRepoCalls.Should().BeEmpty();
+    generatorCalls.Should().BeEmpty();
+    feeCalls.Should().BeEmpty();
+    terminatorCalls.Should().BeEmpty();
+    cdcCalls.Should().BeEmpty();
+    notificationCalls.Should().BeEmpty();
+    settingsCalls.Should().BeEmpty();
+    accessCalls.Should().BeEmpty();
+  }
+
+  private sealed class SequenceTimeProvider(params DateTimeOffset[] times) : TimeProvider
+  {
+    private int index;
+
+    public int Reads => this.index;
+
+    public override DateTimeOffset GetUtcNow()
+    {
+      var value = times[Math.Min(this.index, times.Length - 1)];
+      this.index++;
+      return value;
+    }
+  }
+
+  private sealed class ImmediateTransactionManager : ITransactionManager
+  {
+    public Task<Result<T>> Start<T>(Func<Task<Result<T>>> func) => func();
+  }
+
+  private sealed class CutoffWalletRepository : IWalletRepository
+  {
+    private readonly Guid walletId = Guid.NewGuid();
+
+    public int GetByUserIdCalls { get; private set; }
+
+    public int BookStartCalls { get; private set; }
+
+    private Wallet Wallet(string userId)
+    {
+      var wallet = new WalletPrincipal
+      {
+        Id = this.walletId,
+        UserId = userId,
+        Record = new WalletRecord
+        {
+          Usable = 100m,
+          WithdrawReserve = 0m,
+          BookingReserve = 0m,
+        },
+      };
+      return new Wallet
+      {
+        Principal = wallet,
+        User = new UserPrincipal
+        {
+          Id = userId,
+          Record = new UserRecord { Username = userId },
+        },
+      };
+    }
+
+    public Task<Result<Wallet?>> GetByUserId(string userId)
+    {
+      this.GetByUserIdCalls++;
+      return Task.FromResult((Result<Wallet?>)this.Wallet(userId));
+    }
+
+    public Task<Result<WalletPrincipal?>> BookStart(Guid id, decimal amount)
+    {
+      this.BookStartCalls++;
+      throw new InvalidOperationException("BookStart must not run after the cutoff");
+    }
+
+    public Task<Result<IEnumerable<WalletPrincipal>>> Search(WalletSearch search) =>
+      throw new NotSupportedException();
+
+    public Task<Result<Wallet?>> Get(Guid id, string? userId) => throw new NotSupportedException();
+
+    public Task<Result<WalletPrincipal?>> PrepareWithdraw(Guid id, decimal amount) =>
+      throw new NotSupportedException();
+
+    public Task<Result<WalletPrincipal?>> Withdraw(Guid id, decimal amount) =>
+      throw new NotSupportedException();
+
+    public Task<Result<WalletPrincipal?>> CancelWithdraw(Guid id, decimal amount) =>
+      throw new NotSupportedException();
+
+    public Task<Result<WalletPrincipal?>> Deposit(Guid id, decimal amount) =>
+      throw new NotSupportedException();
+
+    public Task<Result<WalletPrincipal?>> Collect(Guid id, decimal amount) =>
+      throw new NotSupportedException();
+
+    public Task<Result<WalletPrincipal?>> BookEnd(Guid id, decimal revert, decimal collect) =>
+      throw new NotSupportedException();
   }
 
   private static T RecordCalls<T>(out List<string> calls)

--- a/UnitTest/Bookings/BookingPurchaseTimingTests.cs
+++ b/UnitTest/Bookings/BookingPurchaseTimingTests.cs
@@ -81,6 +81,20 @@ public class BookingPurchaseTimingTests
   }
 
   [Fact]
+  public void Earliest_parseable_date_is_rejected_without_overflowing()
+  {
+    var now = new DateTimeOffset(new DateTime(2026, 7, 15, 0, 0, 0, DateTimeKind.Utc));
+
+    var canPurchase = BookingPurchaseTiming.CanPurchase(
+      DateOnly.MinValue,
+      TimeOnly.MinValue,
+      now
+    );
+
+    canPurchase.Should().BeFalse();
+  }
+
+  [Fact]
   public async Task Domain_create_rejects_cutoff_before_wallet_or_transaction_mutation()
   {
     var bookingRepo = RecordCalls<IBookingRepository>(out var bookingCalls);

--- a/UnitTest/Bookings/BookingPurchaseTimingTests.cs
+++ b/UnitTest/Bookings/BookingPurchaseTimingTests.cs
@@ -1,0 +1,151 @@
+using System.Reflection;
+using Domain;
+using Domain.Booking;
+using Domain.Exceptions;
+using Domain.Passenger;
+using Domain.Timings;
+using Domain.Transaction;
+using Domain.Wallet;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace UnitTest.Bookings;
+
+public class BookingPurchaseTimingTests
+{
+  private static readonly DateOnly DepartureDate = new(2026, 7, 15);
+  private static readonly TimeOnly DepartureTime = new(8, 30);
+
+  private static BookingRecord Record(DateOnly date, TimeOnly time) =>
+    new()
+    {
+      Date = date,
+      Time = time,
+      Direction = TrainDirection.JToW,
+      Passenger = new PassengerRecord
+      {
+        FullName = "Test Passenger",
+        Gender = PassengerGender.M,
+        PassportExpiry = new DateOnly(2030, 1, 1),
+        PassportNumber = "TEST123",
+      },
+    };
+
+  [Fact]
+  public void Departure_uses_singapore_wall_clock()
+  {
+    BookingPurchaseTiming
+      .DepartureUtc(DepartureDate, DepartureTime)
+      .Should()
+      .Be(new DateTime(2026, 7, 15, 0, 30, 0, DateTimeKind.Utc));
+  }
+
+  [Fact]
+  public void Exact_three_hour_boundary_is_purchasable()
+  {
+    var departureUtc = BookingPurchaseTiming.DepartureUtc(DepartureDate, DepartureTime);
+    var now = new DateTimeOffset(departureUtc - TimeSpan.FromHours(3));
+
+    BookingPurchaseTiming.CanPurchase(DepartureDate, DepartureTime, now).Should().BeTrue();
+    BookingPurchaseTiming.Validate(Record(DepartureDate, DepartureTime), now).IsSuccess().Should().BeTrue();
+  }
+
+  [Fact]
+  public void Anything_below_three_hours_is_rejected()
+  {
+    var departureUtc = BookingPurchaseTiming.DepartureUtc(DepartureDate, DepartureTime);
+    var now = new DateTimeOffset(departureUtc - TimeSpan.FromHours(3) + TimeSpan.FromTicks(1));
+
+    BookingPurchaseTiming.CanPurchase(DepartureDate, DepartureTime, now).Should().BeFalse();
+    BookingPurchaseTiming
+      .Validate(Record(DepartureDate, DepartureTime), now)
+      .FailureOrDefault()
+      .Should()
+      .BeOfType<InvalidBookingOperationException>();
+  }
+
+  [Fact]
+  public void Departed_slot_is_rejected_regardless_of_callers_offset()
+  {
+    // 08:30 SGT departed at 00:30 UTC. This instant is 10:00 SGT, expressed
+    // as the previous calendar day in Los Angeles to guard the original bug.
+    var losAngelesNow = new DateTimeOffset(2026, 7, 14, 19, 0, 0, TimeSpan.FromHours(-7));
+
+    BookingPurchaseTiming
+      .LeadTime(DepartureDate, DepartureTime, losAngelesNow)
+      .Should()
+      .Be(TimeSpan.FromMinutes(-90));
+    BookingPurchaseTiming.CanPurchase(DepartureDate, DepartureTime, losAngelesNow).Should().BeFalse();
+  }
+
+  [Fact]
+  public async Task Domain_create_rejects_cutoff_before_wallet_or_transaction_mutation()
+  {
+    var bookingRepo = RecordCalls<IBookingRepository>(out var bookingCalls);
+    var storage = RecordCalls<IBookingStorage>(out var storageCalls);
+    var wallet = RecordCalls<IWalletRepository>(out var walletCalls);
+    var transactionRepo = RecordCalls<ITransactionRepository>(out var transactionRepoCalls);
+    var transaction = RecordCalls<ITransactionManager>(out var transactionCalls);
+    var transactionGenerator = RecordCalls<ITransactionGenerator>(out var generatorCalls);
+    var fee = RecordCalls<IFeeCalculator>(out var feeCalls);
+    var terminator = RecordCalls<IBookingTerminatorRepository>(out var terminatorCalls);
+    var cdc = RecordCalls<IBookingCdcRepository>(out var cdcCalls);
+    var notifications = RecordCalls<IBookingNotificationService>(out var notificationCalls);
+    var settings = RecordCalls<IPrioritySettingsRepository>(out var settingsCalls);
+    var access = RecordCalls<IPriorityAccessRepository>(out var accessCalls);
+
+    var service = new BookingService(
+      bookingRepo,
+      storage,
+      wallet,
+      transactionRepo,
+      transaction,
+      transactionGenerator,
+      fee,
+      terminator,
+      cdc,
+      notifications,
+      settings,
+      access,
+      NullLogger<BookingService>.Instance
+    );
+    var yesterday = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-1));
+
+    var result = await service.Create("user", 10m, Record(yesterday, new TimeOnly(23, 59)));
+
+    result.FailureOrDefault().Should().BeOfType<InvalidBookingOperationException>();
+    walletCalls.Should().BeEmpty("the cutoff must run before wallet lookup or reservation");
+    transactionCalls.Should().BeEmpty("the cutoff must run before opening a transaction");
+    transactionRepoCalls.Should().BeEmpty();
+    bookingCalls.Should().BeEmpty();
+    storageCalls.Should().BeEmpty();
+    generatorCalls.Should().BeEmpty();
+    feeCalls.Should().BeEmpty();
+    terminatorCalls.Should().BeEmpty();
+    cdcCalls.Should().BeEmpty();
+    notificationCalls.Should().BeEmpty();
+    settingsCalls.Should().BeEmpty();
+    accessCalls.Should().BeEmpty();
+  }
+
+  private static T RecordCalls<T>(out List<string> calls)
+    where T : class
+  {
+    var service = DispatchProxy.Create<T, RecordingProxy>();
+    var recorder = (RecordingProxy)(object)service;
+    calls = recorder.Calls;
+    return service;
+  }
+
+  public class RecordingProxy : DispatchProxy
+  {
+    public List<string> Calls { get; } = [];
+
+    protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+    {
+      var method = targetMethod?.Name ?? "unknown";
+      this.Calls.Add(method);
+      throw new InvalidOperationException($"Unexpected call to {method}");
+    }
+  }
+}

--- a/UnitTest/Bookings/CreateBookingReqValidatorTests.cs
+++ b/UnitTest/Bookings/CreateBookingReqValidatorTests.cs
@@ -1,0 +1,53 @@
+using App.Modules.Bookings.API.V1;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// ExpectedCost is optional for one release: old (raichu) argon clients don't
+// send the quote yet. Null passes; when present it must be the canonical
+// token Cost/summary returned. Tighten to required after raichu argon ships
+// the quote flow.
+public class CreateBookingReqValidatorTests
+{
+  private readonly CreateBookingReqValidator validator = new();
+
+  private static CreateBookingReq Req(string? expectedCost) =>
+    new(
+      "10-08-2026",
+      "08:30:00",
+      "JToW",
+      new BookingPassengerReq("Jane Doe", "F", "10-08-2030", "E1234567"),
+      expectedCost
+    );
+
+  [Fact]
+  public void Null_quote_passes_for_legacy_clients()
+  {
+    var result = validator.Validate(Req(null));
+    result.IsValid.Should().BeTrue();
+  }
+
+  [Theory]
+  [InlineData("15.12345678")]
+  [InlineData("0.00001")]
+  [InlineData("0")]
+  public void Canonical_quote_passes(string quote)
+  {
+    var result = validator.Validate(Req(quote));
+    result.IsValid.Should().BeTrue();
+  }
+
+  [Theory]
+  [InlineData("")]
+  [InlineData("01.00")]
+  [InlineData("1.0")]
+  [InlineData("-1")]
+  [InlineData("1E-05")]
+  [InlineData("not-a-price")]
+  public void Present_but_noncanonical_quote_fails(string quote)
+  {
+    var result = validator.Validate(Req(quote));
+    result.IsValid.Should().BeFalse();
+    result.Errors.Should().Contain(e => e.PropertyName == "ExpectedCost");
+  }
+}

--- a/UnitTest/Bookings/PurchasePricingRolesTests.cs
+++ b/UnitTest/Bookings/PurchasePricingRolesTests.cs
@@ -1,0 +1,72 @@
+using Domain.User;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// The invariant: purchase-time pricing roles must equal the roles the Cost
+// summary endpoint would price the TARGET user with — self-purchase uses the
+// caller's JWT roles ∪ ExtraRoles (identical to Cost/summary for that
+// caller), and an admin purchasing for X uses X's persisted Descope-synced
+// Roles ∪ X's ExtraRoles, never the admin's own roles. No spurious 409, no
+// admin-priced charge.
+public class PurchasePricingRolesTests
+{
+  private static UserRecord Target(string[]? roles, string[] extraRoles) =>
+    new()
+    {
+      Username = "target",
+      Roles = roles,
+      ExtraRoles = extraRoles,
+    };
+
+  [Fact]
+  public void Self_purchase_uses_the_callers_jwt_roles_union_extra_roles()
+  {
+    // identical to Cost/summary: JWT roles ∪ ExtraRoles
+    var roles = PurchasePricingRoles.For(true, ["member"], Target(["stale"], ["vip"]));
+
+    roles.Should().BeEquivalentTo("member", "vip");
+  }
+
+  [Fact]
+  public void Admin_assisted_purchase_uses_the_targets_persisted_roles_not_the_admins()
+  {
+    var roles = PurchasePricingRoles.For(false, ["admin"], Target(["member"], ["vip"]));
+
+    roles.Should().BeEquivalentTo("member", "vip");
+    roles.Should().NotContain("admin", "the admin's own roles must never price the booking");
+  }
+
+  [Fact]
+  public void Admin_assisted_purchase_for_a_user_with_no_persisted_roles_prices_on_extra_roles_only()
+  {
+    var roles = PurchasePricingRoles.For(false, ["admin"], Target(null, ["vip"]));
+
+    roles.Should().BeEquivalentTo("vip");
+  }
+
+  [Fact]
+  public void Missing_target_user_yields_no_pricing_roles_for_admin_assisted_purchase()
+  {
+    var roles = PurchasePricingRoles.For(false, ["admin"], null);
+
+    roles.Should().BeEmpty();
+  }
+
+  [Fact]
+  public void Self_purchase_with_missing_user_row_still_uses_the_jwt_roles()
+  {
+    // the caller's own JWT stays authoritative even before the user row syncs
+    var roles = PurchasePricingRoles.For(true, ["member"], null);
+
+    roles.Should().BeEquivalentTo("member");
+  }
+
+  [Fact]
+  public void The_union_deduplicates_roles_present_on_both_sides()
+  {
+    var roles = PurchasePricingRoles.For(true, ["vip"], Target(null, ["vip"]));
+
+    roles.Should().HaveCount(1).And.Contain("vip");
+  }
+}

--- a/UnitTest/Costs/CostMapperTests.cs
+++ b/UnitTest/Costs/CostMapperTests.cs
@@ -1,0 +1,32 @@
+using App.Modules.Costs.API.V1;
+using Domain.Booking;
+using Domain.Cost;
+using FluentAssertions;
+
+namespace UnitTest.Costs;
+
+public class CostMapperTests
+{
+  [Fact]
+  public void Batch_slot_exposes_the_same_lossless_quote_as_its_final()
+  {
+    var slot = new MaterializedCostSlot
+    {
+      Time = new TimeOnly(8, 30),
+      Cost = new MaterializedCost
+      {
+        Cost = 15.12345678m,
+        PolicyLines = [],
+        Subtotal = 15.12345678m,
+        Discounts = [],
+        Final = 13.25636350m,
+      },
+    };
+
+    var response = slot.ToRes();
+
+    response.Final.Should().Be(13.25636350m);
+    response.Quote.Should().Be(BookingPriceQuote.Create(response.Final));
+    response.Quote.Should().Be("13.2563635");
+  }
+}

--- a/UnitTest/Costs/CostServiceMaterializeTests.cs
+++ b/UnitTest/Costs/CostServiceMaterializeTests.cs
@@ -75,6 +75,21 @@ public class CostServiceMaterializeTests
       Status = new DiscountStatus { Disabled = false },
     };
 
+  private static DiscountPrincipal PercentageDiscountForEveryone(decimal amount) =>
+    new()
+    {
+      Id = Guid.NewGuid(),
+      Record = new DiscountRecord
+      {
+        Name = "percentage",
+        Description = "percentage discount",
+        Amount = amount,
+        Type = DiscountType.Percentage,
+      },
+      Target = new DiscountTarget { MatchMode = DiscountMatchMode.None, Matches = [] },
+      Status = new DiscountStatus { Disabled = false },
+    };
+
   [Fact]
   public async Task Without_a_spec_no_policies_apply_and_subtotal_equals_base()
   {
@@ -175,6 +190,16 @@ public class CostServiceMaterializeTests
     (m.Cost + m.PolicyLines.Sum(x => x.Delta) - m.Discounts.Sum(d => d.Amount))
       .Should()
       .Be(m.Final, "base + policies - discounts = final");
+  }
+
+  [Fact]
+  public async Task Final_is_normalized_to_the_eight_decimals_persisted_by_wallets()
+  {
+    var service = Make(15.12345678m, discounts: [PercentageDiscountForEveryone(0.12345678m)]);
+
+    var result = await service.Materialize("user-1", [], Spec);
+
+    result.SuccessOrDefault().Final.Should().Be(13.25636350m);
   }
 
   // ---- fakes ----


### PR DESCRIPTION
## What changed

- enforce one Singapore-time purchase cutoff in the API and domain: exactly 3 hours remains allowed; anything below is rejected before wallet mutation
- use the same Singapore departure instant for last-minute cost-policy matching
- require the exact canonical quote the customer confirmed and reject a changed price with HTTP 409
- normalize final prices to the same 8-decimal precision persisted by wallets and transactions
- expose lossless quote strings on single and batch pricing responses
- retry read-only stats queries across brief Postgres 57P01/57P02/57P03 handoffs
- safely reject the earliest parseable date instead of overflowing to HTTP 500

## Why

The frontend could offer departed Singapore slots when its runtime used another timezone. Last-minute policies could cross a lead-time boundary between display and purchase, and JavaScript numbers cannot round-trip every .NET decimal exactly. Pikachu also showed transient database handoffs that could surface as stats 500s.

## Validation

- clean Linux .NET 8 solution build
- 302/302 unit tests
- 1/1 integration test
- cutoff boundary, timezone, final pre-wallet clock check, canonical quote, persisted precision, batch quote, and min-date coverage
- independent final review found no remaining concrete bugs
- repository hooks passed except the two known broken macOS local hooks; equivalent container build/tests and commit validation passed

## Rollout order

The confirmed quote is now **optional for one release** (old raichu argon clients purchase at the server-computed price with a warning log), so there is no hard ordering requirement between this PR and Argon PR https://github.com/AtomiCloud/nitroso.argon/pull/225. Shipping the Argon quote flow (pichu → pikachu) first remains a nice-to-have so customers get stale-price protection immediately. Follow-up: make `ExpectedCost` required again after raichu argon ships the quote.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added booking price quotes to cost responses, preserving decimal precision.
  * Purchases can include an expected quote to prevent unexpected price changes.
  * Price changes now return a clear conflict response with expected and current prices.

* **Bug Fixes**
  * Bookings can no longer be purchased within three hours of departure.
  * Improved booking statistics reliability during database connection interruptions.
  * Standardized departure-time calculations and pricing roles for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->