### PR TITLE
feat(booking): recovery retries and ticket repair

### DIFF
--- a/App/Config/schema.json
+++ b/App/Config/schema.json
@@ -52,6 +52,9 @@
     "Terminator": {
       "$ref": "#/definitions/Terminator"
     },
+    "Recovery": {
+      "$ref": "#/definitions/Recovery"
+    },
     "Smtp": {
       "$ref": "#/definitions/Smtp"
     }
@@ -1286,6 +1289,22 @@
           "type": "integer",
           "format": "int32",
           "maximum": 3600.0,
+          "minimum": 0.0
+        }
+      }
+    },
+    "Recovery": {
+      "title": "RecoveryOption",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "MaxRetries"
+      ],
+      "properties": {
+        "MaxRetries": {
+          "type": "integer",
+          "format": "int32",
+          "maximum": 1000.0,
           "minimum": 0.0
         }
       }

--- a/App/Config/settings.yaml
+++ b/App/Config/settings.yaml
@@ -188,6 +188,11 @@ Payment:
 Terminator:
   QueueName: terminator
 
+# recovery retry-before-duplicate: how many times a booking may be recycled
+# from Recovering back to Pending before requiring manual resolution
+Recovery:
+  MaxRetries: 10
+
 Smtp:
   TRANSACTIONAL:
     Host: smtp.larksuite.com

--- a/App/Error/V1/RecoveryRetriesExhausted.cs
+++ b/App/Error/V1/RecoveryRetriesExhausted.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace App.Error.V1;
+
+[Description(
+  "The booking has already been recycled from 'Recovering' back to 'Pending' the maximum number of times; it stays in 'Recovering' and must be resolved manually (e.g. marked Duplicate or moved to manual intervention)"
+)]
+public class RecoveryRetriesExhausted : IDomainProblem
+{
+  public RecoveryRetriesExhausted() { }
+
+  public RecoveryRetriesExhausted(string detail, string bookingId, int retries, int maxRetries)
+  {
+    this.Detail = detail;
+    this.BookingId = bookingId;
+    this.Retries = retries;
+    this.MaxRetries = maxRetries;
+  }
+
+  [JsonIgnore]
+  public string Id { get; } = "recovery_retries_exhausted";
+
+  [JsonIgnore]
+  public string Title { get; } = "Recovery Retries Exhausted";
+
+  [JsonIgnore]
+  public string Version { get; } = "v1";
+
+  public string Detail { get; } = string.Empty;
+
+  [Description("The booking whose recovery retries are exhausted")]
+  public string BookingId { get; } = string.Empty;
+
+  [Description("How many recovery retries the booking has consumed")]
+  public int Retries { get; }
+
+  [Description("The configured maximum number of recovery retries")]
+  public int MaxRetries { get; }
+}

--- a/App/Migrations/20260710225010_AddRecoveryRetriesAndTicketRepair.Designer.cs
+++ b/App/Migrations/20260710225010_AddRecoveryRetriesAndTicketRepair.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using App.StartUp.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace App.Migrations
 {
     [DbContext(typeof(MainDbContext))]
-    partial class MainDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260710225010_AddRecoveryRetriesAndTicketRepair")]
+    partial class AddRecoveryRetriesAndTicketRepair
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/App/Migrations/20260710225010_AddRecoveryRetriesAndTicketRepair.cs
+++ b/App/Migrations/20260710225010_AddRecoveryRetriesAndTicketRepair.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace App.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRecoveryRetriesAndTicketRepair : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "RecoveryRetries",
+                table: "Bookings",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                comment: "Times this booking was recycled from Recovering back to Pending (RecoverRevert); capped by Recovery:MaxRetries");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RecoveryRetries",
+                table: "Bookings");
+        }
+    }
+}

--- a/App/Modules/Bookings/API/V1/BookingController.cs
+++ b/App/Modules/Bookings/API/V1/BookingController.cs
@@ -34,6 +34,7 @@ public class BookingController(
   IPriorityAccessRepository priorityAccessRepo,
   IUserService userService,
   IOptions<TerminatorOption> terminatorOptions,
+  IOptions<RecoveryOption> recoveryOptions,
   ILogger<BookingController> logger,
   IBookingImageEnricher enrich,
   IAuthHelper helper
@@ -125,6 +126,24 @@ public class BookingController(
   public async Task<ActionResult<BookingPrincipalRes>> Recovering(Guid id)
   {
     var x = await service.Recovering(id).Then(x => x?.ToRes(), Errors.MapAll);
+    return this.ReturnNullableResult(
+      x,
+      new EntityNotFound("Booking not found", typeof(Booking), id.ToString())
+    );
+  }
+
+  // Recycle a 'Recovering' booking back to 'Pending' for another purchase
+  // attempt, incrementing its RecoveryRetries counter. Status-only, no money
+  // moves. Refused with 409 recovery_retries_exhausted once the booking has
+  // been recycled Recovery:MaxRetries times — then a human resolves it via
+  // duplicate/ or manual-intervention/.
+  [Authorize(Policy = AuthPolicies.AdminOrTin)]
+  [HttpPost("recover-revert/{id:guid}")]
+  public async Task<ActionResult<BookingPrincipalRes>> RecoverRevert(Guid id)
+  {
+    var x = await service
+      .RecoverRevert(id, recoveryOptions.Value.MaxRetries)
+      .Then(x => x?.ToRes(), Errors.MapAll);
     return this.ReturnNullableResult(
       x,
       new EntityNotFound("Booking not found", typeof(Booking), id.ToString())
@@ -232,6 +251,47 @@ public class BookingController(
       .CompleteNoCollect(id, bookingNo, ticketNo, stream)
       .Then(x => x?.ToRes(), Errors.MapAll)
       .ThenAwait(x => Utils.ToNullableTaskResultOr(x, r => enrich.Enrich(r)));
+    return this.ReturnNullableResult(
+      x,
+      new EntityNotFound("Booking not found", typeof(Booking), id.ToString())
+    );
+  }
+
+  // Repair the ticket artefacts of an already-Completed booking: replace the
+  // ticket file reference (dangling-ref repair) and backfill missing booking/
+  // ticket numbers. No money moves and no status change; conflicting non-null
+  // identifiers are rejected.
+  [Authorize(Policy = AuthPolicies.AdminOrTin)]
+  [HttpPost("ticket/{id:guid}")]
+  [Consumes(MediaTypeNames.Multipart.FormData)]
+  public async Task<ActionResult<BookingPrincipalRes>> AttachTicket(
+    Guid id,
+    IFormFile file,
+    string? bookingNo = null,
+    string? ticketNo = null
+  )
+  {
+    using var stream = new MemoryStream();
+    await file.CopyToAsync(stream);
+    logger.LogInformation("Stream Size: {StreamSize}", stream.Length);
+    var x = await service
+      .AttachTicket(id, bookingNo, ticketNo, stream)
+      .Then(x => x?.ToRes(), Errors.MapAll)
+      .ThenAwait(x => Utils.ToNullableTaskResultOr(x, r => enrich.Enrich(r)));
+    return this.ReturnNullableResult(
+      x,
+      new EntityNotFound("Booking not found", typeof(Booking), id.ToString())
+    );
+  }
+
+  // Cheap single-booking probe of the ticket reference: hasRef = the booking
+  // carries a ticket key, refValid = that key resolves to a real object in
+  // block storage. Surfaces dangling references without serving the object.
+  [Authorize(Policy = AuthPolicies.AdminOrTin)]
+  [HttpGet("ticket-health/{id:guid}")]
+  public async Task<ActionResult<BookingTicketHealthRes>> TicketHealth(Guid id)
+  {
+    var x = await service.TicketHealth(id).Then(h => h?.ToRes(), Errors.MapAll);
     return this.ReturnNullableResult(
       x,
       new EntityNotFound("Booking not found", typeof(Booking), id.ToString())

--- a/App/Modules/Bookings/API/V1/BookingMapper.cs
+++ b/App/Modules/Bookings/API/V1/BookingMapper.cs
@@ -44,7 +44,8 @@ public static class BookingMapper
       p.Complete.TicketNumber,
       p.Complete.BookingNumber,
       p.Status.Status.ToRes(),
-      p.Priority
+      p.Priority,
+      p.RecoveryRetries
     );
   }
 
@@ -60,6 +61,9 @@ public static class BookingMapper
 
   public static BookingQueuePositionRes ToRes(this BookingQueuePosition p) =>
     new(p.Status.ToRes(), p.Position, p.Total);
+
+  public static BookingTicketHealthRes ToRes(this BookingTicketHealth h) =>
+    new(h.HasRef, h.RefValid);
 
   public static BookingStatRes ToRes(this BookingStatRow r) =>
     new(
@@ -143,6 +147,7 @@ public static class BookingMapper
         query.StuckForMinutes != null
           ? DateTime.UtcNow.AddMinutes(-query.StuckForMinutes.Value)
           : null,
+      MissingTicket = query.MissingTicket,
       Sort = query.SortBy?.ToBookingSort(),
       Limit = query.Limit ?? 20,
       Skip = query.Skip ?? 0,

--- a/App/Modules/Bookings/API/V1/BookingModel.cs
+++ b/App/Modules/Bookings/API/V1/BookingModel.cs
@@ -11,6 +11,9 @@ public record SearchBookingQuery(
   string? PassportNumber,
   string? PassengerName,
   int? StuckForMinutes,
+  // true = only Completed bookings without a ticket file reference — the
+  // ticket-repair worklist
+  bool? MissingTicket,
   string? SortBy,
   int? Limit,
   int? Skip
@@ -70,7 +73,9 @@ public record BookingPrincipalRes(
   string? TicketNo,
   string? BookingNo,
   string Status,
-  bool Priority
+  bool Priority,
+  // times this booking was recycled from Recovering back to Pending
+  int RecoveryRetries
 );
 
 public record BookingRes(BookingPrincipalRes Principal, UserPrincipalRes User);
@@ -83,6 +88,10 @@ public record SearchCountRes(int Total);
 // Position/Total null when the booking is no longer queued; Position is
 // 1-based (1 = next to be bought)
 public record BookingQueuePositionRes(string Status, int? Position, int? Total);
+
+// ticket reference health: HasRef = the booking carries a ticket key,
+// RefValid = that key resolves to a real object in block storage
+public record BookingTicketHealthRes(bool HasRef, bool RefValid);
 
 public record BookingStatRes(
   string DayOfWeek,

--- a/App/Modules/Bookings/API/V1/BookingValidator.cs
+++ b/App/Modules/Bookings/API/V1/BookingValidator.cs
@@ -65,6 +65,12 @@ public class BookingSearchQueryValidator : AbstractValidator<SearchBookingQuery>
       .GreaterThanOrEqualTo(1)
       .LessThanOrEqualTo(525600)
       .When(x => x.StuckForMinutes != null);
+    // MissingTicket implies Completed; any other explicit Status filter can
+    // only ever produce an empty page, so reject the contradiction upfront
+    this.RuleFor(x => x.Status)
+      .Must(x => x is null or "Completed")
+      .WithMessage("MissingTicket=true only applies to Completed bookings")
+      .When(x => x.MissingTicket == true);
     this.RuleFor(x => x.SortBy)
       .Must(x => x is "Timing" or "PassengerName" or "PassportNumber" or "BuyTime" or "FulfilTime")
       .WithMessage(

--- a/App/Modules/Bookings/Data/BookingData.cs
+++ b/App/Modules/Bookings/Data/BookingData.cs
@@ -42,6 +42,10 @@ public class BookingData
   [Precision(16, 8)]
   public decimal? PriorityFee { get; set; }
 
+  // how many times this booking was recycled from Recovering back to Pending
+  // for another purchase attempt (RecoverRevert); capped by Recovery:MaxRetries
+  public int RecoveryRetries { get; set; }
+
   // record
   public DateOnly Date { get; set; }
 

--- a/App/Modules/Bookings/Data/BookingMapper.cs
+++ b/App/Modules/Bookings/Data/BookingMapper.cs
@@ -55,6 +55,7 @@ public static class BookingMapper
       Complete = data.ToComplete(),
       Priority = data.Priority,
       PriorityFee = data.PriorityFee,
+      RecoveryRetries = data.RecoveryRetries,
     };
 
   public static Booking ToDomain(this BookingData data) =>

--- a/App/Modules/Bookings/Data/BookingRepository.cs
+++ b/App/Modules/Bookings/Data/BookingRepository.cs
@@ -62,6 +62,11 @@ public class BookingRepository(
     if (search.BuyingBefore != null)
       query = query.Where(x => x.LastBuyingAt != null && x.LastBuyingAt < search.BuyingBefore);
 
+    // ticket-repair worklist: Completed bookings that carry no ticket file
+    // reference. DB-level only — storage is deliberately never probed here
+    if (search.MissingTicket == true)
+      query = query.Where(x => x.Status == (byte)BookStatus.Completed && x.Ticket == null);
+
     return query;
   }
 
@@ -554,6 +559,26 @@ public class BookingRepository(
     catch (Exception e)
     {
       logger.LogError(e, "Failed to prioritize Booking '{Id}' under User '{UserId}'", id, userId);
+      return e;
+    }
+  }
+
+  public async Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id)
+  {
+    try
+    {
+      logger.LogInformation("Incrementing recovery retries for Booking '{Id}'", id);
+      var v1 = await db.Bookings.Where(x => x.Id == id).FirstOrDefaultAsync();
+      if (v1 == null)
+        return (BookingPrincipal?)null;
+
+      v1.RecoveryRetries += 1;
+      await db.SaveChangesAsync();
+      return v1.ToPrincipal();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to increment recovery retries for Booking '{Id}'", id);
       return e;
     }
   }

--- a/App/Modules/Bookings/Data/BookingStorage.cs
+++ b/App/Modules/Bookings/Data/BookingStorage.cs
@@ -17,4 +17,9 @@ public class BookingStorage(IFileRepository file) : IBookingStorage
   {
     return file.SignedLink(BlockStorages.Main, key, 60 * 60);
   }
+
+  public Task<Result<bool>> Exists(string key)
+  {
+    return file.Exists(BlockStorages.Main, key);
+  }
 }

--- a/App/Modules/Common/BaseController.cs
+++ b/App/Modules/Common/BaseController.cs
@@ -59,6 +59,10 @@ public class AtomiControllerBase(IAuthHelper h) : ControllerBase
         HttpStatusCode.Conflict,
         new BookingPriceChanged(bpce.Message, bpce.Expected, bpce.Actual)
       ),
+      RecoveryRetriesExhaustedException rree => this.Error(
+        HttpStatusCode.Conflict,
+        new RecoveryRetriesExhausted(rree.Message, rree.BookingId, rree.Retries, rree.MaxRetries)
+      ),
       InvalidWithdrawalOperationException iwoe => this.Error(
         HttpStatusCode.BadRequest,
         new InvalidWithdrawalOperation(iwoe.Message, iwoe.WithdrawStatus, iwoe.Operation)

--- a/App/Modules/Common/FileRepository.cs
+++ b/App/Modules/Common/FileRepository.cs
@@ -4,6 +4,7 @@ using CSharp_Result;
 using Flurl;
 using MimeDetective;
 using Minio.DataModel.Args;
+using Minio.Exceptions;
 
 namespace App.Modules.Common;
 
@@ -14,6 +15,10 @@ public interface IFileRepository
   Task<Result<string>> Save(string store, string dir, string name, Stream content, bool appendExt);
   Task<Result<string>> Link(string store, string key);
   Task<Result<string>> SignedLink(string store, string key, int seconds);
+
+  // true when the object behind the key exists in the store, false when it is
+  // missing (a dangling reference); other storage failures surface as errors
+  Task<Result<bool>> Exists(string store, string key);
 }
 
 public class FileRepository(IBlockStorageFactory factory, ContentInspector inspector)
@@ -125,5 +130,35 @@ public class FileRepository(IBlockStorageFactory factory, ContentInspector inspe
 
     var pgo = new PresignedGetObjectArgs().WithBucket(s.Bucket).WithObject(key).WithExpiry(expiry);
     return await s.ReadClient.PresignedGetObjectAsync(pgo);
+  }
+
+  // Same StatObject probe Save uses to verify persistence, exposed as a
+  // point query so callers (e.g. the booking ticket-health endpoint) can
+  // detect a dangling reference without downloading or serving the object.
+  // Only a definitive "object is not there" maps to false; any other failure
+  // (auth, network, bucket) is an error, so an outage can never masquerade
+  // as a missing ticket.
+  public async Task<Result<bool>> Exists(string store, string key)
+  {
+    var s = this.Store(store);
+    try
+    {
+      await s
+        .WriteClient.StatObjectAsync(new StatObjectArgs().WithBucket(s.Bucket).WithObject(key))
+        .ConfigureAwait(false);
+      return true;
+    }
+    catch (ObjectNotFoundException)
+    {
+      return false;
+    }
+    catch (BucketNotFoundException)
+    {
+      return false;
+    }
+    catch (Exception e)
+    {
+      return e;
+    }
   }
 }

--- a/App/StartUp/Database/MainDbContext.cs
+++ b/App/StartUp/Database/MainDbContext.cs
@@ -123,6 +123,14 @@ public class MainDbContext(
     booking.Property(x => x.CreatedAt).HasDefaultValueSql("NOW()");
     booking.Property(x => x.CompletedAt).HasDefaultValue(null);
     booking.Property(x => x.Status).HasDefaultValue(0);
+    // pre-existing rows have never been recovery-recycled — default 0 keeps
+    // the retry cap meaningful for them without a backfill
+    booking
+      .Property(x => x.RecoveryRetries)
+      .HasDefaultValue(0)
+      .HasComment(
+        "Times this booking was recycled from Recovering back to Pending (RecoverRevert); capped by Recovery:MaxRetries"
+      );
 
     // materialized view (created via raw SQL in a migration, refreshed on
     // read by BookingRepository) — ToView keeps it out of EF migrations

--- a/App/StartUp/Options/OptionsExtensions.cs
+++ b/App/StartUp/Options/OptionsExtensions.cs
@@ -144,6 +144,9 @@ public static class OptionsExtensions
     // Register Terminator Options
     services.RegisterOption<TerminatorOption>(TerminatorOption.Key);
 
+    // Register Recovery Options
+    services.RegisterOption<RecoveryOption>(RecoveryOption.Key);
+
     // Register SMTP Options
     services
       .RegisterOption<Dictionary<string, SmtpOption>>(SmtpOption.Key)

--- a/App/StartUp/Options/RecoveryOption.cs
+++ b/App/StartUp/Options/RecoveryOption.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace App.StartUp.Options;
+
+public class RecoveryOption
+{
+  public const string Key = "Recovery";
+
+  // maximum times a booking may be recycled from Recovering back to Pending
+  // (RecoverRevert) before the recycle is refused and a human must resolve it
+  [Required, Range(0, 1000)]
+  public int MaxRetries { get; set; } = 10;
+}

--- a/Domain/Booking/BookingOperations.cs
+++ b/Domain/Booking/BookingOperations.cs
@@ -22,6 +22,10 @@ public static class BookingOperations
 
   public const string Revert = "Revert";
 
+  public const string RecoverRevert = "RecoverRevert";
+
+  public const string AttachTicket = "AttachTicket";
+
   public const string CompleteNoCollect = "CompleteNoCollect";
 
   public const string Prioritize = "Prioritize";

--- a/Domain/Booking/IService.cs
+++ b/Domain/Booking/IService.cs
@@ -33,6 +33,25 @@ public interface IBookingService
 
   Task<Result<BookingPrincipal?>> Revert(Guid id, bool force);
 
+  // recycle a 'Recovering' booking back to 'Pending' for another purchase
+  // attempt, counting the attempt; refuses with
+  // RecoveryRetriesExhaustedException once maxRetries recycles happened
+  Task<Result<BookingPrincipal?>> RecoverRevert(Guid id, int maxRetries);
+
+  // repair the ticket artefacts of an already-Completed booking: replace the
+  // ticket file reference and backfill missing identifiers — no money moves,
+  // no status change
+  Task<Result<BookingPrincipal?>> AttachTicket(
+    Guid id,
+    string? bookingNo,
+    string? ticketNo,
+    Stream file
+  );
+
+  // cheap single-booking probe: does the booking carry a ticket reference,
+  // and does that reference resolve to a real stored object
+  Task<Result<BookingTicketHealth?>> TicketHealth(Guid id);
+
   Task<Result<BookingPrincipal?>> Complete(Guid id,
     string bookingNo,
     string ticketNo,

--- a/Domain/Booking/Model.cs
+++ b/Domain/Booking/Model.cs
@@ -72,6 +72,11 @@ public record BookingSearch
   // reverter cron list stuck-Buying bookings without racing live purchases
   public DateTime? BuyingBefore { get; init; }
 
+  // true = only Completed bookings with no ticket file reference (Ticket is
+  // NULL) — the ticket-repair worklist; DB-level filter only, storage is
+  // never probed per row
+  public bool? MissingTicket { get; init; }
+
   // null = travel-date descending (the historical default ordering)
   public BookingSort? Sort { get; init; }
 
@@ -110,6 +115,12 @@ public record BookingPrincipal
   // snapshot of the fee charged when the booking was prioritized; refunded
   // to Usable when the booking ends Refunded or Cancelled
   public decimal? PriorityFee { get; init; }
+
+  // how many times this booking was recycled from 'Recovering' back to
+  // 'Pending' for another purchase attempt; RecoverRevert stops at the
+  // configured cap so a permanently-conflicted booking cannot loop forever
+  // (default keeps pre-retry construction sites valid)
+  public int RecoveryRetries { get; init; }
 }
 
 public record BookingComplete
@@ -151,6 +162,16 @@ public record BookingCount
 
   public required TrainDirection Direction { get; init; }
   public required int TicketsNeeded { get; init; }
+}
+
+// Cheap single-booking probe of the ticket file reference: HasRef = the
+// booking carries a Ticket key; RefValid = that key resolves to a real object
+// in block storage (false when the reference dangles, e.g. a lost upload)
+public record BookingTicketHealth
+{
+  public required bool HasRef { get; init; }
+
+  public required bool RefValid { get; init; }
 }
 
 // A booking's place in its timeslot's purchase queue. Position/Total are null

--- a/Domain/Booking/Repository.cs
+++ b/Domain/Booking/Repository.cs
@@ -36,6 +36,11 @@ public interface IBookingRepository
   // charged; null when the booking does not exist (or is not visible to userId)
   Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal fee);
 
+  // bumps the recovery retry counter by one; null when the booking does not
+  // exist. Runs inside the caller's RecoverRevert transaction so the counter
+  // and the status transition always move together.
+  Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id);
+
   Task<Result<Unit?>> Delete(string? userId, Guid id);
 
   Task<Result<IEnumerable<BookingCount>>> Count(

--- a/Domain/Booking/Service.cs
+++ b/Domain/Booking/Service.cs
@@ -219,6 +219,66 @@ public class BookingService(
     );
   }
 
+  // RecoverRevert recycles a 'Recovering' booking back to 'Pending' so it
+  // re-enters the demand pool for another purchase attempt, counting the
+  // attempt in RecoveryRetries. Status-only: no money moves (both Recovering
+  // and Pending hold the amount in BookingReserve). The guard, the counter
+  // increment and the status write run in ONE transaction so a concurrent
+  // transition (or a concurrent RecoverRevert) can never lose an increment or
+  // clobber a booking that completed meanwhile. Once the counter reaches
+  // maxRetries the recycle is refused with RecoveryRetriesExhaustedException
+  // (a distinguishable failure, not a transition): the booking stays parked in
+  // 'Recovering' for a human to resolve via Duplicate/ManualIntervention.
+  public Task<Result<BookingPrincipal?>> RecoverRevert(Guid id, int maxRetries)
+  {
+    return transaction.Start(
+      () =>
+        repo.Get(null, id)
+          .NullToError(id.ToString())
+          .DoAwait(
+            DoType.MapErrors,
+            b =>
+            {
+              if (
+                b.Principal.Status.Status != BookStatus.Recovering
+                || b.Principal.Complete.BookingNumber != null
+              )
+              {
+                var r = new InvalidBookingOperationException(
+                  "Recover-revert requires an uncaptured booking in 'Recovering' Status",
+                  b.Principal.Status.Status,
+                  BookingOperations.RecoverRevert
+                );
+                return Task.FromResult((Result<int>)r);
+              }
+
+              if (b.Principal.RecoveryRetries >= maxRetries)
+              {
+                var r = new RecoveryRetriesExhaustedException(
+                  id.ToString(),
+                  b.Principal.RecoveryRetries,
+                  maxRetries
+                );
+                return Task.FromResult((Result<int>)r);
+              }
+
+              return Task.FromResult((Result<int>)0);
+            }
+          )
+          .ThenAwait(_ => repo.IncrementRecoveryRetries(id))
+          .NullToError(id.ToString())
+          .ThenAwait(_ =>
+            repo.Update(
+              null,
+              id,
+              new BookingStatus() { Status = BookStatus.Pending, CompletedAt = null },
+              null,
+              null
+            )
+          )
+    );
+  }
+
   // This parks a buying booking whose purchase hit a KTMB conflict (e.g.
   // duplicate passport) until the recoverer resolves it. Wrapped in a
   // transaction so the guard read cannot go stale against a concurrent
@@ -487,6 +547,117 @@ public class BookingService(
             }), Errors.MapNone)
       .Then(BookingPrincipal? (x) => x.Principal , Errors.MapNone);
       
+  }
+
+  // AttachTicket repairs the ticket artefacts of an already-Completed booking
+  // (e.g. the upload was lost and the stored Ticket key dangles, or the ticket
+  // was completed with the wrong file). Money moved when the booking completed,
+  // so this is strictly status-preserving: NO BookEnd, NO ledger row, NO status
+  // change — only the Completed row's ticket fields are touched.
+  //
+  // The file is saved (and its persistence verified by the storage layer)
+  // BEFORE the transaction opens, exactly like Complete, so a failed upload can
+  // never commit a dangling reference. Overwriting an existing non-null Ticket
+  // reference is allowed — that IS the dangling-ref repair. The KTMB
+  // identifiers are different: they are facts about the captured reservation,
+  // so a provided bookingNo/ticketNo may only backfill a missing (null) value;
+  // conflicting with an existing non-null value is refused rather than silently
+  // rewriting reservation identity.
+  public Task<Result<BookingPrincipal?>> AttachTicket(
+    Guid id,
+    string? bookingNo,
+    string? ticketNo,
+    Stream file
+  )
+  {
+    return fileRepo
+      .Save(file)
+      .ThenAwait(fileId => transaction.Start(
+          () =>
+            repo.Get(null, id)
+              .NullToError(id.ToString())
+              .DoAwait(
+                DoType.MapErrors,
+                b =>
+                {
+                  if (b.Principal.Status.Status != BookStatus.Completed)
+                  {
+                    var r = new InvalidBookingOperationException(
+                      "Attaching a ticket requires a booking in 'Completed' Status",
+                      b.Principal.Status.Status,
+                      BookingOperations.AttachTicket
+                    );
+                    return Task.FromResult((Result<int>)r);
+                  }
+
+                  var existing = b.Principal.Complete;
+                  var bookingNoConflicts =
+                    bookingNo != null
+                    && existing.BookingNumber != null
+                    && bookingNo != existing.BookingNumber;
+                  var ticketNoConflicts =
+                    ticketNo != null
+                    && existing.TicketNumber != null
+                    && ticketNo != existing.TicketNumber;
+                  if (bookingNoConflicts || ticketNoConflicts)
+                  {
+                    var r = new InvalidBookingOperationException(
+                      "Attaching a ticket may only backfill missing booking/ticket numbers; it cannot overwrite existing ones with different values",
+                      b.Principal.Status.Status,
+                      BookingOperations.AttachTicket
+                    );
+                    return Task.FromResult((Result<int>)r);
+                  }
+
+                  return Task.FromResult((Result<int>)0);
+                }
+              )
+              // no money movement and no status write: repair the ticket
+              // reference and backfill any missing identifiers only
+              .ThenAwait(b =>
+                repo.Update(
+                  null,
+                  id,
+                  null,
+                  null,
+                  new BookingComplete
+                  {
+                    Ticket = fileId,
+                    BookingNumber = b.Principal.Complete.BookingNumber ?? bookingNo,
+                    TicketNumber = b.Principal.Complete.TicketNumber ?? ticketNo,
+                  }
+                )
+              )
+        )
+      )
+      .DoAwait(DoType.Ignore, _ => cdcRepository.Add("update"));
+  }
+
+  // Cheap single-booking probe for the admin UI: does this booking carry a
+  // ticket reference at all, and does that reference resolve to a real stored
+  // object. Never serves the object — pairs with AttachTicket to find and fix
+  // dangling references.
+  public Task<Result<BookingTicketHealth?>> TicketHealth(Guid id)
+  {
+    return repo.Get(null, id)
+      .ThenAwait(b =>
+      {
+        if (b == null)
+          return Task.FromResult((Result<BookingTicketHealth?>)(BookingTicketHealth?)null);
+        var key = b.Principal.Complete.Ticket;
+        if (key == null)
+          return Task.FromResult(
+            (Result<BookingTicketHealth?>)
+              new BookingTicketHealth { HasRef = false, RefValid = false }
+          );
+        return fileRepo
+          .Exists(key)
+          .Then(
+            BookingTicketHealth? (exists) =>
+              new BookingTicketHealth { HasRef = true, RefValid = exists },
+            Errors.MapNone
+          );
+      });
   }
 
   // When user cancels the tickets before booking succeeded

--- a/Domain/Booking/Storage.cs
+++ b/Domain/Booking/Storage.cs
@@ -7,4 +7,8 @@ public interface IBookingStorage
   Task<Result<string>> Save(Stream stream);
 
   Task<Result<string>> Get(string key);
+
+  // whether the stored object behind this key actually exists — used by the
+  // ticket-health probe to surface dangling references without serving them
+  Task<Result<bool>> Exists(string key);
 }

--- a/Domain/Exceptions/RecoveryRetriesExhaustedException.cs
+++ b/Domain/Exceptions/RecoveryRetriesExhaustedException.cs
@@ -1,0 +1,18 @@
+namespace Domain.Exceptions;
+
+// A 'Recovering' booking has already been recycled back to 'Pending' the
+// configured maximum number of times; another automated retry is refused so a
+// permanently-conflicted booking cannot loop forever. The booking stays in
+// 'Recovering' — a human decides the terminal outcome (Duplicate or manual
+// intervention).
+public class RecoveryRetriesExhaustedException(string bookingId, int retries, int maxRetries)
+  : Exception(
+    $"Booking '{bookingId}' exhausted its recovery retries ({retries}/{maxRetries}); resolve it manually"
+  )
+{
+  public string BookingId { get; } = bookingId;
+
+  public int Retries { get; } = retries;
+
+  public int MaxRetries { get; } = maxRetries;
+}

--- a/UnitTest/Bookings/BookingSearchMissingTicketTests.cs
+++ b/UnitTest/Bookings/BookingSearchMissingTicketTests.cs
@@ -1,0 +1,71 @@
+using App.Modules.Bookings.API.V1;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// The MissingTicket search filter is the ticket-repair worklist: Completed
+// bookings whose Ticket file reference is NULL. The repo applies it DB-level;
+// here we pin the API contract — the flag threads into the domain query and
+// contradictory Status filters are rejected upfront.
+public class BookingSearchMissingTicketTests
+{
+  private readonly BookingSearchQueryValidator validator = new();
+
+  private static SearchBookingQuery Query(bool? missingTicket, string? status = null) =>
+    new(
+      Date: null,
+      Direction: null,
+      Status: status,
+      Time: null,
+      UserId: null,
+      PassportNumber: null,
+      PassengerName: null,
+      StuckForMinutes: null,
+      MissingTicket: missingTicket,
+      SortBy: null,
+      Limit: null,
+      Skip: null
+    );
+
+  [Theory]
+  [InlineData(null)]
+  [InlineData(true)]
+  [InlineData(false)]
+  public void MissingTicket_threads_into_the_domain_search(bool? missingTicket)
+  {
+    Query(missingTicket).ToDomain().MissingTicket.Should().Be(missingTicket);
+  }
+
+  [Fact]
+  public void MissingTicket_alone_is_valid()
+  {
+    validator.Validate(Query(true)).IsValid.Should().BeTrue();
+  }
+
+  [Fact]
+  public void MissingTicket_with_completed_status_is_valid()
+  {
+    validator.Validate(Query(true, "Completed")).IsValid.Should().BeTrue();
+  }
+
+  [Theory]
+  [InlineData("Pending")]
+  [InlineData("Buying")]
+  [InlineData("Recovering")]
+  [InlineData("Refunded")]
+  public void MissingTicket_with_non_completed_status_is_rejected(string status)
+  {
+    // MissingTicket implies Completed; any other status filter can only
+    // produce an empty page — reject the contradiction instead
+    var result = validator.Validate(Query(true, status));
+    result.IsValid.Should().BeFalse();
+    result.Errors.Should().Contain(e => e.PropertyName == "Status");
+  }
+
+  [Fact]
+  public void Non_completed_status_without_missing_ticket_stays_valid()
+  {
+    validator.Validate(Query(null, "Pending")).IsValid.Should().BeTrue();
+    validator.Validate(Query(false, "Pending")).IsValid.Should().BeTrue();
+  }
+}

--- a/UnitTest/Bookings/BookingServiceAttachTicketTests.cs
+++ b/UnitTest/Bookings/BookingServiceAttachTicketTests.cs
@@ -11,16 +11,15 @@ using FluentAssertions;
 
 namespace UnitTest.Bookings;
 
-// CompleteNoCollect is the admin bypass that finalises a RequireManualIntervention
-// booking WITHOUT moving money — it must never call the wallet or write a ledger
-// row. These tests pin that invariant by passing NULL walletRepo/transactionRepo:
-// if CompleteNoCollect ever touched them the test would NRE. They also prove the
-// guard (RequireManualIntervention only) and that the ticket + Completed status
-// are written.
-public class BookingServiceCompleteNoCollectTests
+// Guards on BookingService.AttachTicket(id, bookingNo, ticketNo, file). Attach
+// is a repair for ALREADY-Completed bookings (e.g. dangling ticket refs): it
+// must never move money (null wallet/transaction repos would NRE), never change
+// status, allow overwriting the ticket file reference, backfill only missing
+// KTMB identifiers, and refuse conflicting non-null identifiers.
+public class BookingServiceAttachTicketTests
 {
-  // walletRepo (arg 2) and transactionRepo (arg 3) are deliberately null — the
-  // reserve-untouched invariant means CompleteNoCollect must never invoke them.
+  // walletRepo/transactionRepo/transactionGenerator deliberately null: attach
+  // must never touch money.
   private static BookingService MakeService(FakeBookingRepository repo) =>
     new(
       repo,
@@ -32,13 +31,18 @@ public class BookingServiceCompleteNoCollectTests
       null!,
       null!,
       new FakeCdc(),
-      new FakeNotifier(),
+      null!,
       null!,
       null!,
       null!
     );
 
-  private static Booking BookingWith(BookStatus status, string? bookingNumber)
+  private static Booking BookingWith(
+    BookStatus status,
+    string? ticket,
+    string? bookingNumber,
+    string? ticketNumber
+  )
   {
     var id = Guid.NewGuid();
     return new Booking
@@ -61,12 +65,12 @@ public class BookingServiceCompleteNoCollectTests
             PassportNumber = "P1234567",
           },
         },
-        Status = new BookingStatus { Status = status, CompletedAt = null },
+        Status = new BookingStatus { Status = status, CompletedAt = DateTime.UtcNow },
         Complete = new BookingComplete
         {
-          Ticket = bookingNumber == null ? null : "ticket-file",
+          Ticket = ticket,
           BookingNumber = bookingNumber,
-          TicketNumber = bookingNumber == null ? null : "TN-old",
+          TicketNumber = ticketNumber,
         },
       },
       User = new UserPrincipal
@@ -98,42 +102,109 @@ public class BookingServiceCompleteNoCollectTests
   }
 
   [Fact]
-  public async Task CompleteNoCollect_from_manual_intervention_completes_saves_ticket_and_moves_no_money()
+  public async Task AttachTicket_overwrites_dangling_ticket_ref_without_status_write()
   {
-    var booking = BookingWith(BookStatus.RequireManualIntervention, bookingNumber: null);
+    // Ticket ref overwrite IS the repair — the old key may dangle in storage
+    var booking = BookingWith(BookStatus.Completed, "old-dangling-key", "BN-1", "TN-1");
     var repo = new FakeBookingRepository(booking);
 
     var result = await MakeService(repo)
-      .CompleteNoCollect(booking.Principal.Id, "BN-1", "TN-1", new MemoryStream([1, 2, 3]));
+      .AttachTicket(booking.Principal.Id, null, null, new MemoryStream([1, 2, 3]));
 
-    // reaching success at all proves no money path ran (null wallet/transaction repos)
-    result.IsSuccess().Should().BeTrue("an admin may finalise a RequireManualIntervention booking without collecting");
+    result.IsSuccess().Should().BeTrue("replacing a Completed booking's ticket file is the repair");
     repo.UpdateCalls.Should().Be(1);
-    repo.LastStatusWritten!.Status.Should().Be(BookStatus.Completed);
+    repo.LastStatusWritten.Should().BeNull("attach must never write status");
+    repo.LastCompleteWritten!.Ticket.Should().Be("file-id", "the new upload replaces the old ref");
+    repo.LastCompleteWritten!.BookingNumber.Should().Be("BN-1", "existing identifiers are kept");
+    repo.LastCompleteWritten!.TicketNumber.Should().Be("TN-1");
+  }
+
+  [Fact]
+  public async Task AttachTicket_backfills_missing_identifiers()
+  {
+    var booking = BookingWith(BookStatus.Completed, ticket: null, bookingNumber: null, ticketNumber: null);
+    var repo = new FakeBookingRepository(booking);
+
+    var result = await MakeService(repo)
+      .AttachTicket(booking.Principal.Id, "BN-2", "TN-2", new MemoryStream([1]));
+
+    result.IsSuccess().Should().BeTrue();
+    repo.LastCompleteWritten!.Ticket.Should().Be("file-id");
+    repo.LastCompleteWritten!.BookingNumber.Should().Be("BN-2", "a null identifier may be backfilled");
+    repo.LastCompleteWritten!.TicketNumber.Should().Be("TN-2");
+  }
+
+  [Fact]
+  public async Task AttachTicket_keeps_existing_identifiers_when_same_values_are_provided()
+  {
+    var booking = BookingWith(BookStatus.Completed, "key", "BN-1", "TN-1");
+    var repo = new FakeBookingRepository(booking);
+
+    var result = await MakeService(repo)
+      .AttachTicket(booking.Principal.Id, "BN-1", "TN-1", new MemoryStream([1]));
+
+    result.IsSuccess().Should().BeTrue("re-supplying the identical identifiers is not a conflict");
     repo.LastCompleteWritten!.BookingNumber.Should().Be("BN-1");
     repo.LastCompleteWritten!.TicketNumber.Should().Be("TN-1");
   }
 
   [Theory]
-  [InlineData(BookStatus.Pending)]
-  [InlineData(BookStatus.Buying)]
-  [InlineData(BookStatus.Recovering)]
-  [InlineData(BookStatus.Completed)]
-  [InlineData(BookStatus.Cancelled)]
-  [InlineData(BookStatus.Refunded)]
-  [InlineData(BookStatus.Terminated)]
-  [InlineData(BookStatus.Duplicate)]
-  public async Task CompleteNoCollect_from_non_manual_intervention_is_rejected(BookStatus status)
+  [InlineData("BN-DIFFERENT", "TN-1")]
+  [InlineData("BN-1", "TN-DIFFERENT")]
+  [InlineData("BN-DIFFERENT", "TN-DIFFERENT")]
+  public async Task AttachTicket_with_conflicting_identifiers_is_rejected_and_writes_nothing(
+    string bookingNo,
+    string ticketNo
+  )
   {
-    var booking = BookingWith(status, bookingNumber: null);
+    // identifiers are facts about the captured KTMB reservation: repair may
+    // backfill a missing one but never rewrite reservation identity
+    var booking = BookingWith(BookStatus.Completed, "key", "BN-1", "TN-1");
     var repo = new FakeBookingRepository(booking);
 
     var result = await MakeService(repo)
-      .CompleteNoCollect(booking.Principal.Id, "BN-1", "TN-1", new MemoryStream([1]));
+      .AttachTicket(booking.Principal.Id, bookingNo, ticketNo, new MemoryStream([1]));
 
-    result.IsSuccess().Should().BeFalse($"a '{status}' booking is not in the manual-intervention parking state");
+    result.IsSuccess().Should().BeFalse("a different non-null identifier is a conflict");
     result.FailureOrDefault().Should().BeOfType<InvalidBookingOperationException>();
-    repo.UpdateCalls.Should().Be(0, "no status write may happen when the guard fails");
+    repo.UpdateCalls.Should().Be(0, "no write may happen when the guard fails");
+  }
+
+  [Theory]
+  [InlineData(BookStatus.Pending)]
+  [InlineData(BookStatus.Buying)]
+  [InlineData(BookStatus.Cancelled)]
+  [InlineData(BookStatus.Refunded)]
+  [InlineData(BookStatus.Terminated)]
+  [InlineData(BookStatus.Recovering)]
+  [InlineData(BookStatus.Duplicate)]
+  [InlineData(BookStatus.RequireManualIntervention)]
+  public async Task AttachTicket_on_non_completed_booking_is_rejected_and_writes_nothing(
+    BookStatus status
+  )
+  {
+    // in-flight bookings go through Complete (which moves money); attach is
+    // strictly a post-completion repair
+    var booking = BookingWith(status, ticket: null, bookingNumber: null, ticketNumber: null);
+    var repo = new FakeBookingRepository(booking);
+
+    var result = await MakeService(repo)
+      .AttachTicket(booking.Principal.Id, "BN-1", "TN-1", new MemoryStream([1]));
+
+    result.IsSuccess().Should().BeFalse($"a '{status}' booking cannot have its ticket repaired");
+    result.FailureOrDefault().Should().BeOfType<InvalidBookingOperationException>();
+    repo.UpdateCalls.Should().Be(0);
+  }
+
+  [Fact]
+  public async Task AttachTicket_of_missing_booking_is_rejected()
+  {
+    var repo = new FakeBookingRepository(null);
+
+    var result = await MakeService(repo).AttachTicket(Guid.NewGuid(), null, null, new MemoryStream([1]));
+
+    result.IsSuccess().Should().BeFalse();
+    repo.UpdateCalls.Should().Be(0);
   }
 
   private sealed class PassThroughTransactionManager : ITransactionManager
@@ -151,16 +222,6 @@ public class BookingServiceCompleteNoCollectTests
   private sealed class FakeCdc : IBookingCdcRepository
   {
     public Task<Result<Unit>> Add(string action) => Task.FromResult((Result<Unit>)new Unit());
-  }
-
-  private sealed class FakeNotifier : IBookingNotificationService
-  {
-    public Task<Result<Unit>> NotifyBookingCompleted(Booking booking) => Task.FromResult((Result<Unit>)new Unit());
-    public Task<Result<Unit>> NotifyBookingCancelled(Booking booking) => throw new NotImplementedException();
-    public Task<Result<Unit>> NotifyBookingTerminated(Booking booking) => throw new NotImplementedException();
-    public Task<Result<Unit>> NotifyBookingRefunded(Booking booking) => throw new NotImplementedException();
-    public Task<Result<Unit>> NotifyBookingDuplicate(Booking booking) => throw new NotImplementedException();
-    public Task<Result<Unit>> NotifyBookingManualIntervention(Booking booking) => throw new NotImplementedException();
   }
 
   private sealed class FakeBookingRepository(Booking? booking) : IBookingRepository
@@ -183,9 +244,12 @@ public class BookingServiceCompleteNoCollectTests
       UpdateCalls++;
       LastStatusWritten = status;
       LastCompleteWritten = complete;
-      var principal = booking!.Principal with { Status = status! };
+      var principal = booking!.Principal with { Complete = complete! };
       return Task.FromResult((Result<BookingPrincipal?>)principal);
     }
+
+    public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>
+      throw new NotImplementedException();
 
     public Task<Result<IEnumerable<BookingPrincipal>>> Search(BookingSearch search) =>
       throw new NotImplementedException();
@@ -209,9 +273,6 @@ public class BookingServiceCompleteNoCollectTests
       throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal fee) =>
-      throw new NotImplementedException();
-
-    public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>
       throw new NotImplementedException();
 
     public Task<Result<Unit?>> Delete(string? userId, Guid id) =>

--- a/UnitTest/Bookings/BookingServiceBuyingGuardTests.cs
+++ b/UnitTest/Bookings/BookingServiceBuyingGuardTests.cs
@@ -216,6 +216,9 @@ public class BookingServiceBuyingGuardTests
     public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal fee) =>
       throw new NotImplementedException();
 
+    public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>
+      throw new NotImplementedException();
+
     public Task<Result<Unit?>> Delete(string? userId, Guid id) =>
       throw new NotImplementedException();
 

--- a/UnitTest/Bookings/BookingServicePrioritizeTests.cs
+++ b/UnitTest/Bookings/BookingServicePrioritizeTests.cs
@@ -514,6 +514,9 @@ public class BookingServicePrioritizeTests
       return Task.FromResult((Result<BookingPrincipal?>)Current()!.Principal);
     }
 
+    public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>
+      throw new NotImplementedException();
+
     public Task<Result<IEnumerable<BookingPrincipal>>> Search(BookingSearch search) =>
       throw new NotImplementedException();
 

--- a/UnitTest/Bookings/BookingServiceRecoverRevertTests.cs
+++ b/UnitTest/Bookings/BookingServiceRecoverRevertTests.cs
@@ -1,0 +1,301 @@
+using CSharp_Result;
+using Domain;
+using Domain.Booking;
+using Domain.Exceptions;
+using Domain.Passenger;
+using Domain.Timings;
+using Domain.Transaction;
+using Domain.User;
+using Domain.Wallet;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// Guards on BookingService.RecoverRevert(id, maxRetries). RecoverRevert recycles
+// a 'Recovering' booking back to 'Pending' for another purchase attempt while
+// counting the attempt in RecoveryRetries. It must only fire for an uncaptured
+// 'Recovering' booking, must refuse (with a distinguishable
+// RecoveryRetriesExhaustedException, writing NOTHING) once the counter reaches
+// the cap, and must never move money — the null wallet/transaction repos in the
+// service would NRE if it ever did.
+public class BookingServiceRecoverRevertTests
+{
+  private static BookingService MakeService(FakeBookingRepository repo) =>
+    new(
+      repo,
+      null!,
+      null!,
+      null!,
+      new PassThroughTransactionManager(),
+      null!,
+      null!,
+      null!,
+      null!,
+      null!,
+      null!,
+      null!,
+      null!
+    );
+
+  private static Booking BookingWith(BookStatus status, string? bookingNumber, int retries = 0)
+  {
+    var id = Guid.NewGuid();
+    return new Booking
+    {
+      Principal = new BookingPrincipal
+      {
+        Id = id,
+        UserId = "user-1",
+        CreatedAt = DateTime.UtcNow,
+        Record = new BookingRecord
+        {
+          Date = new DateOnly(2026, 7, 3),
+          Time = new TimeOnly(8, 0),
+          Direction = TrainDirection.WToJ,
+          Passenger = new PassengerRecord
+          {
+            FullName = "Test Passenger",
+            Gender = PassengerGender.M,
+            PassportExpiry = new DateOnly(2030, 1, 1),
+            PassportNumber = "P1234567",
+          },
+        },
+        Status = new BookingStatus { Status = status, CompletedAt = null },
+        Complete = new BookingComplete
+        {
+          Ticket = bookingNumber == null ? null : "ticket-file",
+          BookingNumber = bookingNumber,
+          TicketNumber = bookingNumber == null ? null : "TN-1",
+        },
+        RecoveryRetries = retries,
+      },
+      User = new UserPrincipal
+      {
+        Id = "user-1",
+        Record = new UserRecord { Username = "tester" },
+      },
+      Transaction = new TransactionPrincipal
+      {
+        Id = Guid.NewGuid(),
+        CreatedAt = DateTime.UtcNow,
+        Record = new TransactionRecord
+        {
+          Name = "BookingRequest",
+          Description = "reserve",
+          Type = TransactionType.BookingRequest,
+          Amount = 26.0m,
+          From = "Usable",
+          To = "BookingReserve",
+        },
+      },
+      Wallet = new WalletPrincipal
+      {
+        Id = Guid.NewGuid(),
+        UserId = "user-1",
+        Record = new WalletRecord { Usable = 100m, WithdrawReserve = 0m, BookingReserve = 26m },
+      },
+    };
+  }
+
+  [Fact]
+  public async Task RecoverRevert_from_recovering_increments_counter_and_reverts_to_pending()
+  {
+    var booking = BookingWith(BookStatus.Recovering, bookingNumber: null, retries: 0);
+    var repo = new FakeBookingRepository(booking);
+
+    var result = await MakeService(repo).RecoverRevert(booking.Principal.Id, maxRetries: 10);
+
+    result.IsSuccess().Should().BeTrue("an uncaptured 'Recovering' booking below the cap may recycle");
+    repo.IncrementCalls.Should().Be(1, "the attempt must be counted");
+    repo.Retries.Should().Be(1, "the counter increments 0 -> 1");
+    repo.UpdateCalls.Should().Be(1);
+    repo.LastStatusWritten!.Status.Should().Be(BookStatus.Pending);
+    repo.LastStatusWritten!.CompletedAt.Should().BeNull();
+  }
+
+  [Theory]
+  [InlineData(BookStatus.Pending)]
+  [InlineData(BookStatus.Buying)]
+  [InlineData(BookStatus.Completed)]
+  [InlineData(BookStatus.Cancelled)]
+  [InlineData(BookStatus.Refunded)]
+  [InlineData(BookStatus.Terminated)]
+  [InlineData(BookStatus.Duplicate)]
+  [InlineData(BookStatus.RequireManualIntervention)]
+  public async Task RecoverRevert_from_non_recovering_status_is_rejected_and_writes_nothing(
+    BookStatus status
+  )
+  {
+    var bookingNumber = status == BookStatus.Completed ? "BN-123" : null;
+    var booking = BookingWith(status, bookingNumber);
+    var repo = new FakeBookingRepository(booking);
+
+    var result = await MakeService(repo).RecoverRevert(booking.Principal.Id, maxRetries: 10);
+
+    result.IsSuccess().Should().BeFalse($"a '{status}' booking must not be recycled to 'Pending'");
+    result.FailureOrDefault().Should().BeOfType<InvalidBookingOperationException>();
+    repo.IncrementCalls.Should().Be(0, "a refused recycle must not consume a retry");
+    repo.UpdateCalls.Should().Be(0, "no status write may happen when the guard fails");
+  }
+
+  [Fact]
+  public async Task RecoverRevert_of_captured_recovering_booking_is_rejected()
+  {
+    // A booking that already captured a KTMB ticket must never re-enter the
+    // demand pool: re-buying it would double-purchase.
+    var booking = BookingWith(BookStatus.Recovering, bookingNumber: "BN-999");
+    var repo = new FakeBookingRepository(booking);
+
+    var result = await MakeService(repo).RecoverRevert(booking.Principal.Id, maxRetries: 10);
+
+    result.IsSuccess().Should().BeFalse();
+    result.FailureOrDefault().Should().BeOfType<InvalidBookingOperationException>();
+    repo.IncrementCalls.Should().Be(0);
+    repo.UpdateCalls.Should().Be(0);
+  }
+
+  [Fact]
+  public async Task RecoverRevert_at_cap_is_refused_with_exhausted_error_and_writes_nothing()
+  {
+    var booking = BookingWith(BookStatus.Recovering, bookingNumber: null, retries: 10);
+    var repo = new FakeBookingRepository(booking);
+
+    var result = await MakeService(repo).RecoverRevert(booking.Principal.Id, maxRetries: 10);
+
+    result.IsSuccess().Should().BeFalse("the cap is exhausted");
+    var e = result.FailureOrDefault().Should().BeOfType<RecoveryRetriesExhaustedException>().Subject;
+    e.BookingId.Should().Be(booking.Principal.Id.ToString());
+    e.Retries.Should().Be(10);
+    e.MaxRetries.Should().Be(10);
+    repo.IncrementCalls.Should().Be(0, "an exhausted booking must not keep counting");
+    repo.UpdateCalls.Should().Be(0, "an exhausted booking must stay parked in 'Recovering'");
+  }
+
+  [Fact]
+  public async Task RecoverRevert_last_allowed_retry_succeeds_then_next_is_exhausted()
+  {
+    // retries = 9 with cap 10: the 10th recycle is allowed (9 -> 10); once the
+    // booking lands back in 'Recovering' the 11th call must be refused as
+    // exhausted, not silently recycled again.
+    var booking = BookingWith(BookStatus.Recovering, bookingNumber: null, retries: 9);
+    var repo = new FakeBookingRepository(booking);
+    var service = MakeService(repo);
+
+    var tenth = await service.RecoverRevert(booking.Principal.Id, maxRetries: 10);
+    tenth.IsSuccess().Should().BeTrue("retry 9 -> 10 is the last allowed recycle");
+    repo.Retries.Should().Be(10);
+    repo.LastStatusWritten!.Status.Should().Be(BookStatus.Pending);
+
+    // the recoverer parks the booking in 'Recovering' again after another
+    // failed purchase attempt
+    repo.StatusOverride = BookStatus.Recovering;
+
+    var eleventh = await service.RecoverRevert(booking.Principal.Id, maxRetries: 10);
+    eleventh.IsSuccess().Should().BeFalse("the counter reached the cap");
+    eleventh.FailureOrDefault().Should().BeOfType<RecoveryRetriesExhaustedException>();
+    repo.IncrementCalls.Should().Be(1, "only the allowed recycle was counted");
+    repo.UpdateCalls.Should().Be(1, "the exhausted call wrote nothing");
+  }
+
+  [Fact]
+  public async Task RecoverRevert_of_missing_booking_is_rejected()
+  {
+    var repo = new FakeBookingRepository(null);
+
+    var result = await MakeService(repo).RecoverRevert(Guid.NewGuid(), maxRetries: 10);
+
+    result.IsSuccess().Should().BeFalse();
+    repo.IncrementCalls.Should().Be(0);
+    repo.UpdateCalls.Should().Be(0);
+  }
+
+  private sealed class PassThroughTransactionManager : ITransactionManager
+  {
+    public Task<Result<T>> Start<T>(Func<Task<Result<T>>> func) => func();
+  }
+
+  // Stateful fake: tracks the retry counter and lets a test park the booking
+  // back into 'Recovering' between calls (StatusOverride) to simulate the
+  // recoverer failing the recycled attempt again.
+  private sealed class FakeBookingRepository(Booking? booking) : IBookingRepository
+  {
+    public int UpdateCalls { get; private set; }
+    public int IncrementCalls { get; private set; }
+    public int Retries { get; private set; } = booking?.Principal.RecoveryRetries ?? 0;
+    public BookingStatus? LastStatusWritten { get; private set; }
+    public BookStatus? StatusOverride { get; set; }
+
+    private Booking? Current()
+    {
+      if (booking == null)
+        return null;
+      var status = StatusOverride ?? booking.Principal.Status.Status;
+      return booking with
+      {
+        Principal = booking.Principal with
+        {
+          Status = booking.Principal.Status with { Status = status },
+          RecoveryRetries = Retries,
+        },
+      };
+    }
+
+    public Task<Result<Booking?>> Get(string? userId, Guid id) =>
+      Task.FromResult((Result<Booking?>)Current());
+
+    public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id)
+    {
+      IncrementCalls++;
+      Retries++;
+      return Task.FromResult((Result<BookingPrincipal?>)Current()!.Principal);
+    }
+
+    public Task<Result<BookingPrincipal?>> Update(
+      string? userId,
+      Guid id,
+      BookingStatus? status,
+      BookingRecord? record,
+      BookingComplete? complete
+    )
+    {
+      UpdateCalls++;
+      LastStatusWritten = status;
+      StatusOverride = status!.Status;
+      return Task.FromResult((Result<BookingPrincipal?>)Current()!.Principal);
+    }
+
+    public Task<Result<IEnumerable<BookingPrincipal>>> Search(BookingSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<int>> SearchCount(BookingSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<BookingQueuePosition?>> QueuePosition(string? userId, Guid id) =>
+      throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingStatRow>>> Stats(BookingStatsQuery query) =>
+      throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingPrincipal>>> RefundList(DateOnly date, TimeOnly time) =>
+      throw new NotImplementedException();
+
+    public Task<Result<BookingPrincipal>> Create(string userId, Guid transactionId, BookingRecord record) =>
+      throw new NotImplementedException();
+
+    public Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly time) =>
+      throw new NotImplementedException();
+
+    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal fee) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Unit?>> Delete(string? userId, Guid id) =>
+      throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingCount>>> Count(
+      DateOnly date,
+      TimeOnly time,
+      DateOnly? filterDate,
+      TrainDirection? filterDirection
+    ) => throw new NotImplementedException();
+  }
+}

--- a/UnitTest/Bookings/BookingServiceRevertGuardTests.cs
+++ b/UnitTest/Bookings/BookingServiceRevertGuardTests.cs
@@ -349,6 +349,9 @@ public class BookingServiceRevertGuardTests
     public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal fee) =>
       throw new NotImplementedException();
 
+    public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>
+      throw new NotImplementedException();
+
     public Task<Result<Unit?>> Delete(string? userId, Guid id) =>
       throw new NotImplementedException();
 

--- a/UnitTest/Bookings/BookingServiceTerminateTests.cs
+++ b/UnitTest/Bookings/BookingServiceTerminateTests.cs
@@ -307,6 +307,9 @@ public class BookingServiceTerminateTests
     public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal fee) =>
       throw new NotImplementedException();
 
+    public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>
+      throw new NotImplementedException();
+
     public Task<Result<IEnumerable<BookingPrincipal>>> Search(BookingSearch search) =>
       throw new NotImplementedException();
 

--- a/UnitTest/Bookings/BookingServiceTicketHealthTests.cs
+++ b/UnitTest/Bookings/BookingServiceTicketHealthTests.cs
@@ -1,0 +1,216 @@
+using CSharp_Result;
+using Domain;
+using Domain.Booking;
+using Domain.Passenger;
+using Domain.Timings;
+using Domain.Transaction;
+using Domain.User;
+using Domain.Wallet;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// TicketHealth is the cheap dangling-ref probe: HasRef = the booking carries a
+// Ticket key, RefValid = the key resolves to a real stored object. It must
+// never touch storage when there is no key, and a missing booking is null
+// (404), not a health report.
+public class BookingServiceTicketHealthTests
+{
+  private static BookingService MakeService(FakeBookingRepository repo, FakeStorage storage) =>
+    new(
+      repo,
+      storage,
+      null!,
+      null!,
+      null!,
+      null!,
+      null!,
+      null!,
+      null!,
+      null!,
+      null!,
+      null!,
+      null!
+    );
+
+  private static Booking BookingWith(string? ticket)
+  {
+    var id = Guid.NewGuid();
+    return new Booking
+    {
+      Principal = new BookingPrincipal
+      {
+        Id = id,
+        UserId = "user-1",
+        CreatedAt = DateTime.UtcNow,
+        Record = new BookingRecord
+        {
+          Date = new DateOnly(2026, 7, 3),
+          Time = new TimeOnly(8, 0),
+          Direction = TrainDirection.WToJ,
+          Passenger = new PassengerRecord
+          {
+            FullName = "Test Passenger",
+            Gender = PassengerGender.M,
+            PassportExpiry = new DateOnly(2030, 1, 1),
+            PassportNumber = "P1234567",
+          },
+        },
+        Status = new BookingStatus { Status = BookStatus.Completed, CompletedAt = DateTime.UtcNow },
+        Complete = new BookingComplete
+        {
+          Ticket = ticket,
+          BookingNumber = "BN-1",
+          TicketNumber = "TN-1",
+        },
+      },
+      User = new UserPrincipal
+      {
+        Id = "user-1",
+        Record = new UserRecord { Username = "tester" },
+      },
+      Transaction = new TransactionPrincipal
+      {
+        Id = Guid.NewGuid(),
+        CreatedAt = DateTime.UtcNow,
+        Record = new TransactionRecord
+        {
+          Name = "BookingRequest",
+          Description = "reserve",
+          Type = TransactionType.BookingRequest,
+          Amount = 26.0m,
+          From = "Usable",
+          To = "BookingReserve",
+        },
+      },
+      Wallet = new WalletPrincipal
+      {
+        Id = Guid.NewGuid(),
+        UserId = "user-1",
+        Record = new WalletRecord { Usable = 100m, WithdrawReserve = 0m, BookingReserve = 26m },
+      },
+    };
+  }
+
+  [Fact]
+  public async Task TicketHealth_with_valid_ref_reports_valid()
+  {
+    var booking = BookingWith("ticket-key");
+    var storage = new FakeStorage(exists: true);
+    var result = await MakeService(new FakeBookingRepository(booking), storage)
+      .TicketHealth(booking.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    var h = result.Get()!;
+    h.HasRef.Should().BeTrue();
+    h.RefValid.Should().BeTrue();
+    storage.ProbedKeys.Should().Equal("ticket-key");
+  }
+
+  [Fact]
+  public async Task TicketHealth_with_dangling_ref_reports_invalid()
+  {
+    var booking = BookingWith("lost-key");
+    var storage = new FakeStorage(exists: false);
+    var result = await MakeService(new FakeBookingRepository(booking), storage)
+      .TicketHealth(booking.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    var h = result.Get()!;
+    h.HasRef.Should().BeTrue();
+    h.RefValid.Should().BeFalse("the reference dangles — no stored object behind the key");
+  }
+
+  [Fact]
+  public async Task TicketHealth_without_ref_skips_storage()
+  {
+    var booking = BookingWith(ticket: null);
+    var storage = new FakeStorage(exists: true);
+    var result = await MakeService(new FakeBookingRepository(booking), storage)
+      .TicketHealth(booking.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    var h = result.Get()!;
+    h.HasRef.Should().BeFalse();
+    h.RefValid.Should().BeFalse();
+    storage.ProbedKeys.Should().BeEmpty("no key means nothing to probe");
+  }
+
+  [Fact]
+  public async Task TicketHealth_of_missing_booking_is_null()
+  {
+    var storage = new FakeStorage(exists: true);
+    var result = await MakeService(new FakeBookingRepository(null), storage)
+      .TicketHealth(Guid.NewGuid());
+
+    result.IsSuccess().Should().BeTrue();
+    result.Get().Should().BeNull("a missing booking maps to 404, not a health report");
+    storage.ProbedKeys.Should().BeEmpty();
+  }
+
+  private sealed class FakeStorage(bool exists) : IBookingStorage
+  {
+    public List<string> ProbedKeys { get; } = [];
+
+    public Task<Result<string>> Save(Stream stream) => throw new NotImplementedException();
+
+    public Task<Result<string>> Get(string key) => throw new NotImplementedException();
+
+    public Task<Result<bool>> Exists(string key)
+    {
+      ProbedKeys.Add(key);
+      return Task.FromResult((Result<bool>)exists);
+    }
+  }
+
+  private sealed class FakeBookingRepository(Booking? booking) : IBookingRepository
+  {
+    public Task<Result<Booking?>> Get(string? userId, Guid id) =>
+      Task.FromResult((Result<Booking?>)booking);
+
+    public Task<Result<BookingPrincipal?>> Update(
+      string? userId,
+      Guid id,
+      BookingStatus? status,
+      BookingRecord? record,
+      BookingComplete? complete
+    ) => throw new NotImplementedException();
+
+    public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>
+      throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingPrincipal>>> Search(BookingSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<int>> SearchCount(BookingSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<BookingQueuePosition?>> QueuePosition(string? userId, Guid id) =>
+      throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingStatRow>>> Stats(BookingStatsQuery query) =>
+      throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingPrincipal>>> RefundList(DateOnly date, TimeOnly time) =>
+      throw new NotImplementedException();
+
+    public Task<Result<BookingPrincipal>> Create(string userId, Guid transactionId, BookingRecord record) =>
+      throw new NotImplementedException();
+
+    public Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly time) =>
+      throw new NotImplementedException();
+
+    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal fee) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Unit?>> Delete(string? userId, Guid id) =>
+      throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingCount>>> Count(
+      DateOnly date,
+      TimeOnly time,
+      DateOnly? filterDate,
+      TrainDirection? filterDirection
+    ) => throw new NotImplementedException();
+  }
+}

--- a/infra/api_chart/app/schema.json
+++ b/infra/api_chart/app/schema.json
@@ -52,6 +52,9 @@
     "Terminator": {
       "$ref": "#/definitions/Terminator"
     },
+    "Recovery": {
+      "$ref": "#/definitions/Recovery"
+    },
     "Smtp": {
       "$ref": "#/definitions/Smtp"
     }
@@ -1286,6 +1289,22 @@
           "type": "integer",
           "format": "int32",
           "maximum": 3600.0,
+          "minimum": 0.0
+        }
+      }
+    },
+    "Recovery": {
+      "title": "RecoveryOption",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "MaxRetries"
+      ],
+      "properties": {
+        "MaxRetries": {
+          "type": "integer",
+          "format": "int32",
+          "maximum": 1000.0,
           "minimum": 0.0
         }
       }

--- a/infra/api_chart/app/settings.yaml
+++ b/infra/api_chart/app/settings.yaml
@@ -188,6 +188,11 @@ Payment:
 Terminator:
   QueueName: terminator
 
+# recovery retry-before-duplicate: how many times a booking may be recycled
+# from Recovering back to Pending before requiring manual resolution
+Recovery:
+  MaxRetries: 10
+
 Smtp:
   TRANSACTIONAL:
     Host: smtp.larksuite.com

--- a/infra/migration_chart/app/schema.json
+++ b/infra/migration_chart/app/schema.json
@@ -52,6 +52,9 @@
     "Terminator": {
       "$ref": "#/definitions/Terminator"
     },
+    "Recovery": {
+      "$ref": "#/definitions/Recovery"
+    },
     "Smtp": {
       "$ref": "#/definitions/Smtp"
     }
@@ -1286,6 +1289,22 @@
           "type": "integer",
           "format": "int32",
           "maximum": 3600.0,
+          "minimum": 0.0
+        }
+      }
+    },
+    "Recovery": {
+      "title": "RecoveryOption",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "MaxRetries"
+      ],
+      "properties": {
+        "MaxRetries": {
+          "type": "integer",
+          "format": "int32",
+          "maximum": 1000.0,
           "minimum": 0.0
         }
       }

--- a/infra/migration_chart/app/settings.yaml
+++ b/infra/migration_chart/app/settings.yaml
@@ -188,6 +188,11 @@ Payment:
 Terminator:
   QueueName: terminator
 
+# recovery retry-before-duplicate: how many times a booking may be recycled
+# from Recovering back to Pending before requiring manual resolution
+Recovery:
+  MaxRetries: 10
+
 Smtp:
   TRANSACTIONAL:
     Host: smtp.larksuite.com


### PR DESCRIPTION
## What

Two admin/tin recovery features for bookings:

**A. Recovery retry-before-duplicate**
- New `Bookings.RecoveryRetries` column (int, non-null, default 0, with column comment) via migration `AddRecoveryRetriesAndTicketRepair`.
- `POST api/v1/Booking/recover-revert/{id}` (AdminOrTin): recycles an **uncaptured `Recovering`** booking back to `Pending` for another purchase attempt, incrementing `RecoveryRetries` in the same RepeatableRead transaction as the guard + status write. Status-only — no money moves (both states hold the amount in BookingReserve).
- Once `RecoveryRetries >= Recovery:MaxRetries` (new option, default 10, in settings.yaml + all three schema.json), the recycle is refused with a structured **409 `recovery_retries_exhausted`** problem (`{ detail, bookingId, retries, maxRetries }`) and *nothing is written* — the booking stays parked in `Recovering` for a human to resolve via `duplicate/` or `manual-intervention/`.
- `recoveryRetries` is exposed on the booking API response for the admin UI/tin.

**B. Ticket repair**
- `GET api/v1/Booking?MissingTicket=true` — ticket-repair worklist: Completed bookings whose `Ticket` file ref is NULL. DB-level filter only (no per-row storage probes); validator rejects a contradictory `Status` filter.
- `POST api/v1/Booking/ticket/{id}` (AdminOrTin, multipart `file` + optional `bookingNo`/`ticketNo`): repairs an **already-Completed** booking. Saves the file first (reusing the PR #28 StatObject persistence verification), then in one transaction: overwrites the ticket ref (dangling-ref repair is the point), backfills missing identifiers, and **rejects** a provided identifier that conflicts with an existing non-null one. No money movement, no status change.
- `GET api/v1/Booking/ticket-health/{id}` (AdminOrTin) → `{ hasRef, refValid }` via a new `IFileRepository.Exists` StatObject probe. Only a definitive missing object/bucket maps to `refValid: false`; storage outages surface as errors, never as "missing ticket".

## Why

- The recoverer currently has no bounded retry path: a transient KTMB conflict either loops forever or forces an immediate Duplicate refund. RecoverRevert gives automation N counted retries, then a structured stop.
- Lost/dangling ticket uploads (pre-PR #28) left Completed bookings with refs that 404; there was no way to re-attach a ticket without abusing money-moving flows.

## Validation

- Build clean; `dotnet format style --verify-no-changes` clean on changed files.
- Unit tests: **364 passed** (322 baseline + 42 new): RecoverRevert guard matrix (wrong status ×8, captured booking, missing booking, at-cap exhausted writes nothing, 0→1 increment, 9→10 then 11th exhausted), AttachTicket (non-Completed ×8, identifier conflicts ×3, same-value ok, backfill, dangling-ref overwrite, no status write, null wallet/txn repos prove no money path), TicketHealth (valid/dangling/no-ref/missing), MissingTicket validator + threading.
- New endpoints exercise the same Result-monad/controller/problem-mapping conventions as siblings (`InvalidBookingOperationException` → 400, new exhausted exception → 409).

## Rollout / backward compat

- Existing rows get `RecoveryRetries = 0` via column default; no backfill needed.
- No existing endpoint changes behavior; old tin never calls the new routes.
- `Recovery:MaxRetries` defaults to 10 in the base settings; no landscape overlays needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable recovery retries, allowing eligible bookings to return from Recovering to Pending before manual resolution.
  * Added administrative actions to revert recovering bookings and report when retry limits are exhausted.
  * Added ticket repair uploads and ticket-reference health checks.
  * Added a search filter for completed bookings missing ticket files.
* **Bug Fixes**
  * Improved handling and visibility of missing or invalid ticket references.
* **Configuration**
  * Added `Recovery.MaxRetries`, defaulting to 10 and supporting values from 0 to 1000.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->