### PR TITLE
feat(withdrawal): card-refund rail with fragmented oldest-first refunds

### DIFF
--- a/App/Config/schema.json
+++ b/App/Config/schema.json
@@ -57,6 +57,9 @@
     },
     "Smtp": {
       "$ref": "#/definitions/Smtp"
+    },
+    "Withdrawal": {
+      "$ref": "#/definitions/Withdrawal"
     }
   },
   "definitions": {
@@ -1366,6 +1369,22 @@
               "format": "int32"
             }
           }
+        }
+      }
+    },
+    "Withdrawal": {
+      "title": "WithdrawalOption",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "RefundWindowDays"
+      ],
+      "properties": {
+        "RefundWindowDays": {
+          "type": "integer",
+          "format": "int32",
+          "maximum": 3650.0,
+          "minimum": 1.0
         }
       }
     }

--- a/App/Config/settings.yaml
+++ b/App/Config/settings.yaml
@@ -193,6 +193,11 @@ Terminator:
 Recovery:
   MaxRetries: 10
 
+# card-refund withdrawals: how far back (days) a captured card payment still
+# counts toward the refundable pool
+Withdrawal:
+  RefundWindowDays: 180
+
 Smtp:
   TRANSACTIONAL:
     Host: smtp.larksuite.com

--- a/App/Error/V1/InsufficientRefundablePool.cs
+++ b/App/Error/V1/InsufficientRefundablePool.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace App.Error.V1;
+
+[Description(
+  "The user's refundable pool (captured card payments inside the refund window, minus refunds already issued) cannot cover the net amount of the card-refund withdrawal"
+)]
+public class InsufficientRefundablePool : IDomainProblem
+{
+  public InsufficientRefundablePool() { }
+
+  public InsufficientRefundablePool(string detail, decimal required, decimal available)
+  {
+    this.Detail = detail;
+    this.Required = required;
+    this.Available = available;
+  }
+
+  [JsonIgnore]
+  public string Id { get; } = "insufficient_refundable_pool";
+
+  [JsonIgnore]
+  public string Title { get; } = "Insufficient Refundable Pool";
+
+  [JsonIgnore]
+  public string Version { get; } = "v1";
+
+  public string Detail { get; } = string.Empty;
+
+  [Description("The net amount in SGD the card refunds must cover (gross minus fee)")]
+  public decimal Required { get; }
+
+  [Description("The amount in SGD the refundable pool can still cover")]
+  public decimal Available { get; }
+}

--- a/App/Migrations/20260711203552_AddWithdrawalMethodAndRefundFragments.Designer.cs
+++ b/App/Migrations/20260711203552_AddWithdrawalMethodAndRefundFragments.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using App.StartUp.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace App.Migrations
 {
     [DbContext(typeof(MainDbContext))]
-    partial class MainDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260711203552_AddWithdrawalMethodAndRefundFragments")]
+    partial class AddWithdrawalMethodAndRefundFragments
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/App/Migrations/20260711203552_AddWithdrawalMethodAndRefundFragments.cs
+++ b/App/Migrations/20260711203552_AddWithdrawalMethodAndRefundFragments.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace App.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWithdrawalMethodAndRefundFragments : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<byte>(
+                name: "Method",
+                table: "Withdrawals",
+                type: "smallint",
+                nullable: false,
+                defaultValue: (byte)0,
+                comment: "Payout rail: 0 = PayNow transfer, 1 = card refunds (Airwallex)");
+
+            migrationBuilder.CreateTable(
+                name: "WithdrawalRefunds",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Status = table.Column<byte>(type: "smallint", nullable: false),
+                    Amount = table.Column<decimal>(type: "numeric(16,8)", precision: 16, scale: 8, nullable: false),
+                    PaymentIntentId = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    AirwallexRefundId = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    RequestId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    SettledAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    WithdrawalId = table.Column<Guid>(type: "uuid", nullable: false),
+                    PaymentId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WithdrawalRefunds", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_WithdrawalRefunds_Payments_PaymentId",
+                        column: x => x.PaymentId,
+                        principalTable: "Payments",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_WithdrawalRefunds_Withdrawals_WithdrawalId",
+                        column: x => x.WithdrawalId,
+                        principalTable: "Withdrawals",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WithdrawalRefunds_PaymentId",
+                table: "WithdrawalRefunds",
+                column: "PaymentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WithdrawalRefunds_RequestId",
+                table: "WithdrawalRefunds",
+                column: "RequestId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WithdrawalRefunds_WithdrawalId",
+                table: "WithdrawalRefunds",
+                column: "WithdrawalId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "WithdrawalRefunds");
+
+            migrationBuilder.DropColumn(
+                name: "Method",
+                table: "Withdrawals");
+        }
+    }
+}

--- a/App/Modules/Common/BaseController.cs
+++ b/App/Modules/Common/BaseController.cs
@@ -67,6 +67,10 @@ public class AtomiControllerBase(IAuthHelper h) : ControllerBase
         HttpStatusCode.BadRequest,
         new InvalidWithdrawalOperation(iwoe.Message, iwoe.WithdrawStatus, iwoe.Operation)
       ),
+      InsufficientRefundablePoolException irpe => this.Error(
+        HttpStatusCode.Conflict,
+        new InsufficientRefundablePool(irpe.Message, irpe.Required, irpe.Available)
+      ),
       NotFoundException nfe => this.Error(
         HttpStatusCode.NotFound,
         new EntityNotFound(nfe.Message, nfe.Type, nfe.RequestIdentifier)

--- a/App/Modules/DomainServices.cs
+++ b/App/Modules/DomainServices.cs
@@ -116,6 +116,11 @@ public static class DomainServices
 
     s.AddScoped<IPayoutGateway, AirwallexPayoutGateway>().AutoTrace<IPayoutGateway>();
 
+    s.AddScoped<IWithdrawalRefundRepository, WithdrawalRefundRepository>()
+      .AutoTrace<IWithdrawalRefundRepository>();
+
+    s.AddScoped<IRefundGateway, AirwallexRefundGateway>().AutoTrace<IRefundGateway>();
+
     // Cost
     s.AddScoped<ICostCalculator, CostCalculator>().AutoTrace<ICostCalculator>();
 

--- a/App/Modules/Payments/Airwallex/AirwallexEventAdapter.cs
+++ b/App/Modules/Payments/Airwallex/AirwallexEventAdapter.cs
@@ -38,6 +38,42 @@ public class AirwallexEventAdapter
   public static bool IsTransferEvent(AirwallexEvent evt) =>
     evt.Name.StartsWith("transfer", StringComparison.OrdinalIgnoreCase);
 
+  // True for refund.* events (refund.received/accepted/settled/failed),
+  // which resolve a card-refund Withdrawal fragment
+  public static bool IsRefundEvent(AirwallexEvent evt) =>
+    evt.Name.StartsWith("refund.", StringComparison.OrdinalIgnoreCase);
+
+  // Refund request ids are "{withdrawalId}-{attempt}-{index}". WithdrawalId
+  // is null for ids not minted by us (e.g. a refund issued by hand on the
+  // Airwallex dashboard) — such events must be acknowledged and ignored.
+  public (
+    Guid? WithdrawalId,
+    string RequestId,
+    string RefundId,
+    int? Attempt,
+    TransferOutcome Outcome
+  ) ProcessRefundEvent(AirwallexEvent evt)
+  {
+    var requestId = evt.Data.Object.RequestId;
+    Guid? withdrawalId = null;
+    int? attempt = null;
+    var parts = requestId.Split('-');
+    // guid is 5 dash-separated groups; ours is guid + attempt + index = 7
+    if (parts.Length == 7 && Guid.TryParse(string.Join('-', parts[..5]), out var parsed))
+    {
+      withdrawalId = parsed;
+      if (int.TryParse(parts[5], out var n))
+        attempt = n;
+    }
+
+    var status = evt.Data.Object.Status.ToUpperInvariant();
+    var outcome = AirwallexRefundStatuses.Settled.Contains(status) ? TransferOutcome.Settled
+      : AirwallexRefundStatuses.Failed.Contains(status) ? TransferOutcome.Failed
+      : TransferOutcome.InFlight;
+
+    return (withdrawalId, requestId, evt.Data.Object.Id, attempt, outcome);
+  }
+
   // Transfer request ids are "{withdrawalId}-{attempt}"; the number after the
   // last dash is the attempt counter, everything before it the withdrawal id.
   // WithdrawalId is null for ids not minted by us (e.g. a transfer created by

--- a/App/Modules/Payments/Airwallex/AirwallexWebhookService.cs
+++ b/App/Modules/Payments/Airwallex/AirwallexWebhookService.cs
@@ -36,9 +36,9 @@ public class AirwallexWebhookService(
           ).ToException()
       )
       .ThenAwait(_ =>
-        AirwallexEventAdapter.IsTransferEvent(evt)
-          ? this.ProcessTransfer(evt)
-          : this.ProcessPayment(evt)
+        AirwallexEventAdapter.IsTransferEvent(evt) ? this.ProcessTransfer(evt)
+        : AirwallexEventAdapter.IsRefundEvent(evt) ? this.ProcessRefund(evt)
+        : this.ProcessPayment(evt)
       );
   }
 
@@ -101,6 +101,68 @@ public class AirwallexWebhookService(
     {
       logger.LogWarning(
         "Ignoring stale Airwallex transfer event '{Name}' for Withdrawal '{WithdrawalId}': {Reason}",
+        evt.Name,
+        withdrawalId,
+        stale.Message
+      );
+      return new Unit();
+    }
+    return result;
+  }
+
+  // Card refunds: refund.* events resolve a fragment of a card-refund
+  // Withdrawal (settled fragments may complete the withdrawal; a failed
+  // fragment parks it for a human)
+  private async Task<Result<Unit>> ProcessRefund(AirwallexEvent evt)
+  {
+    var (withdrawalId, requestId, refundId, attempt, outcome) = adapter.ProcessRefundEvent(evt);
+    logger.LogInformation(
+      "Airwallex refund event '{Name}' for Withdrawal '{WithdrawalId}' (refund '{RefundId}', request '{RequestId}', attempt {Attempt}): {Outcome}",
+      evt.Name,
+      withdrawalId,
+      refundId,
+      requestId,
+      attempt,
+      outcome
+    );
+
+    // a refund we did not mint (e.g. issued by hand on the Airwallex
+    // dashboard): acknowledge and ignore
+    if (withdrawalId == null)
+    {
+      logger.LogWarning(
+        "Ignoring Airwallex refund event '{Name}' with foreign request id '{RequestId}' (refund '{RefundId}')",
+        evt.Name,
+        requestId,
+        refundId
+      );
+      return new Unit();
+    }
+
+    var result = await (
+      outcome switch
+      {
+        TransferOutcome.Settled => withdrawalService
+          .SettleRefundFragment(withdrawalId.Value, requestId, refundId, attempt)
+          .Then(_ => new Unit(), Errors.MapNone),
+        TransferOutcome.Failed => withdrawalService
+          .FailRefundFragment(
+            withdrawalId.Value,
+            requestId,
+            refundId,
+            $"Airwallex refund '{refundId}' ended as '{evt.Name}'",
+            attempt
+          )
+          .Then(_ => new Unit(), Errors.MapNone),
+        // RECEIVED / ACCEPTED: acknowledge, settlement decides later
+        _ => Task.FromResult(new Unit().ToResult()),
+      }
+    );
+
+    if (result.IsFailure() && result.FailureOrDefault() is StalePayoutEventException stale)
+    {
+      logger.LogWarning(
+        "Ignoring stale Airwallex refund event '{Name}' for Withdrawal '{WithdrawalId}': {Reason}",
         evt.Name,
         withdrawalId,
         stale.Message

--- a/App/Modules/Payments/Airwallex/Client.cs
+++ b/App/Modules/Payments/Airwallex/Client.cs
@@ -98,6 +98,93 @@ public class AirWallexClient(
       });
   }
 
+  public Task<Result<AirwallexRefundRes>> CreateRefund(AirwallexCreateRefundReq req)
+  {
+    return authenticator
+      .GetToken()
+      .ThenAwait(async token =>
+      {
+        var request = new HttpRequestMessage
+        {
+          Method = HttpMethod.Post,
+          RequestUri = new Uri("api/v1/pa/refunds/create", UriKind.Relative),
+          Headers = { Authorization = new AuthenticationHeaderValue("Bearer", token) },
+          Content = JsonContent.Create(req),
+        };
+        // like CreateTransfer: every failure is a failed Result, never a
+        // throw — the approve flow's compensation logic must classify it.
+        // Unlike transfers, refunds are never bounced back to Pending on a
+        // 4xx: sibling fragments may already exist at the gateway, so ALL
+        // failures are treated as ambiguous by the caller.
+        try
+        {
+          using var response = await this.HttpClient.SendAsync(request);
+          var body = await response.Content.ReadAsStringAsync();
+          if (response.IsSuccessStatusCode)
+            return body.ToObj<AirwallexRefundRes>().ToResult();
+
+          logger.LogError(
+            "Failed to create refund with Airwallex, Status: {Status}, Response: {Body}",
+            (int)response.StatusCode,
+            body
+          );
+          return (Result<AirwallexRefundRes>)
+            new HttpRequestException(
+              $"Airwallex refund creation failed ({(int)response.StatusCode}): {body}"
+            );
+        }
+        catch (Exception e)
+        {
+          logger.LogError(e, "Failed to create refund with Airwallex (transport error)");
+          return (Result<AirwallexRefundRes>)e;
+        }
+      });
+  }
+
+  // Point-in-time refund lookup for reconciliation. Returns null (not an
+  // error) when the gateway definitively has no such refund.
+  public Task<Result<AirwallexRefundRes?>> GetRefund(string refundId)
+  {
+    return authenticator
+      .GetToken()
+      .ThenAwait(async token =>
+      {
+        var request = new HttpRequestMessage
+        {
+          Method = HttpMethod.Get,
+          RequestUri = new Uri($"api/v1/pa/refunds/{refundId}", UriKind.Relative),
+          Headers = { Authorization = new AuthenticationHeaderValue("Bearer", token) },
+        };
+        try
+        {
+          using var response = await this.HttpClient.SendAsync(request);
+          var body = await response.Content.ReadAsStringAsync();
+          if ((int)response.StatusCode == 404)
+            return (Result<AirwallexRefundRes?>)(AirwallexRefundRes?)null;
+          if (!response.IsSuccessStatusCode)
+          {
+            logger.LogError(
+              "Failed to look up Airwallex refund, Status: {Status}, Response: {Body}",
+              (int)response.StatusCode,
+              body
+            );
+            return (Result<AirwallexRefundRes?>)
+              new HttpRequestException(
+                $"Airwallex refund lookup failed ({(int)response.StatusCode}): {body}"
+              );
+          }
+          return body.ToObj<AirwallexRefundRes>()
+            .ToResult()
+            .Then(r => (AirwallexRefundRes?)r, Errors.MapNone);
+        }
+        catch (Exception e)
+        {
+          logger.LogError(e, "Failed to look up Airwallex refund (transport error)");
+          return (Result<AirwallexRefundRes?>)e;
+        }
+      });
+  }
+
   // Point-in-time lookup for reconciliation. Returns null (not an error) when
   // the gateway definitively has no such transfer.
   public Task<Result<AirwallexTransferRes?>> GetTransfer(string transferId)

--- a/App/Modules/Payments/Airwallex/EventModels.cs
+++ b/App/Modules/Payments/Airwallex/EventModels.cs
@@ -64,6 +64,10 @@ public record AirwallexEventDataObject
   [JsonPropertyName("merchant_order_id")]
   public Guid MerchantOrderId { get; set; }
 
+  // refund.* events: the intent the money returned to (absent elsewhere)
+  [JsonPropertyName("payment_intent_id")]
+  public string PaymentIntentId { get; set; } = string.Empty;
+
   // string, not Guid: payment intents use a bare Guid, but transfer (payout)
   // request ids are "{withdrawalId}-{attempt}" and would fail Guid parsing
   [JsonPropertyName("request_id")]

--- a/App/Modules/Payments/Airwallex/ReqModels.cs
+++ b/App/Modules/Payments/Airwallex/ReqModels.cs
@@ -47,6 +47,23 @@ public record AirwallexCreateTransferReq
   public AirwallexTransferBeneficiary Beneficiary { get; set; } = null!;
 }
 
+// Refunds API — returns money to the card behind a captured payment intent;
+// used by the card-refund withdrawal rail
+public record AirwallexCreateRefundReq
+{
+  [JsonPropertyName("request_id")]
+  public string RequestId { get; set; } = null!;
+
+  [JsonPropertyName("payment_intent_id")]
+  public string PaymentIntentId { get; set; } = null!;
+
+  [JsonPropertyName("amount")]
+  public decimal Amount { get; set; }
+
+  [JsonPropertyName("reason")]
+  public string Reason { get; set; } = null!;
+}
+
 public record AirwallexTransferBeneficiary
 {
   [JsonPropertyName("entity_type")]

--- a/App/Modules/Payments/Airwallex/ResModel.cs
+++ b/App/Modules/Payments/Airwallex/ResModel.cs
@@ -85,3 +85,32 @@ public static class AirwallexTransferStatuses
 
   public static readonly string[] Failed = ["FAILED", "CANCELLED", "REJECTED", "RETURNED"];
 }
+
+public record AirwallexRefundRes
+{
+  [JsonPropertyName("id")]
+  public string Id { get; set; } = null!;
+
+  [JsonPropertyName("request_id")]
+  public string RequestId { get; set; } = null!;
+
+  [JsonPropertyName("payment_intent_id")]
+  public string PaymentIntentId { get; set; } = null!;
+
+  [JsonPropertyName("amount")]
+  public decimal Amount { get; set; }
+
+  [JsonPropertyName("status")]
+  public string Status { get; set; } = null!;
+}
+
+// Shared status classification for refund objects (webhook adapter and
+// reconciliation lookup). Refund events are refund.received / accepted /
+// settled / failed — SETTLED is the only terminal success, FAILED the only
+// terminal failure; RECEIVED / ACCEPTED are in flight.
+public static class AirwallexRefundStatuses
+{
+  public static readonly string[] Settled = ["SETTLED", "SUCCEEDED"];
+
+  public static readonly string[] Failed = ["FAILED", "CANCELLED"];
+}

--- a/App/Modules/Withdrawals/API/V1/WithdrawalController.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalController.cs
@@ -1,6 +1,7 @@
 using System.Net.Mime;
 using App.Error.V1;
 using App.Modules.Common;
+using App.StartUp.Options;
 using App.StartUp.Registry;
 using App.StartUp.Services.Auth;
 using App.Utility;
@@ -11,6 +12,7 @@ using Domain.Wallet;
 using Domain.Withdrawal;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 namespace App.Modules.Withdrawals.API.V1;
 
@@ -26,9 +28,12 @@ public class WithdrawalController(
   SearchWithdrawalQueryValidator searchWithdrawalQueryValidator,
   IWithdrawalImageEnricher enrich,
   IFeeCalculator feeCalculator,
+  IOptionsSnapshot<WithdrawalOption> withdrawalOptions,
   IAuthHelper h
 ) : AtomiControllerBase(h)
 {
+  private int RefundWindowDays => withdrawalOptions.Value.RefundWindowDays;
+
   // DEPRECATED: kept only so already-deployed frontends keep working during
   // rollout — use GET Fee/{type} instead, which also carries the flat
   // component. Returns the percentage as a rate, e.g. 0.04 = 4%.
@@ -81,7 +86,7 @@ public class WithdrawalController(
       .ThenAwait(_ =>
         createWithdrawalReqValidator.ValidateAsyncResult(req, "Invalid CreateWithdrawalReq")
       )
-      .ThenAwait(r => service.Create(userId, r.ToDomain()))
+      .ThenAwait(r => service.Create(userId, r.ToDomain(), this.RefundWindowDays))
       .Then(x => x.ToRes(), Errors.MapNone)
       .ThenAwait(x => enrich.Enrich(x));
 
@@ -124,12 +129,31 @@ public class WithdrawalController(
   }
 
   // Initiates the automated Airwallex payout: Pending -> Processing; the
-  // transfer webhook completes (or fails) the withdrawal. Callable by admins
-  // (argon Approve button) and by tin's nightly withdrawer sweep.
+  // gateway webhooks complete (or fail/park) the withdrawal. PayNow creates
+  // a transfer; CardRefund creates refunds against the payments that funded
+  // the wallet. Callable by admins (argon Approve button) and by tin's
+  // withdrawer sweep — no caller is assumed, the flow is fully interactive-
+  // safe (the tin nightly sweep is being disabled by config; approve then
+  // happens on an admin click and behaves identically).
   [Authorize(Policy = AuthPolicies.AdminOrTin), HttpPost("{id:guid}/approve")]
   public async Task<ActionResult<WithdrawalPrincipalRes>> Approve(Guid id)
   {
-    var x = await service.Approve(id).Then(w => w.ToRes(), Errors.MapNone).ThenAwait(enrich.Enrich);
+    var x = await service
+      .Approve(id, this.RefundWindowDays)
+      .Then(w => w.ToRes(), Errors.MapNone)
+      .ThenAwait(enrich.Enrich);
+    return this.ReturnResult(x);
+  }
+
+  // How much the user could withdraw via card refunds right now: captured
+  // card payments inside the refund window, minus refunds already issued
+  // against them. Owner-or-staff visibility, same as the withdrawal listing.
+  [Authorize, HttpGet("refundable/{userId}")]
+  public async Task<ActionResult<RefundablePoolRes>> Refundable(string userId)
+  {
+    var x = await this.GuardOrAllAsync(userId, AuthRoles.Field, AuthRoles.Admin)
+      .ThenAwait(_ => service.RefundablePool(userId, this.RefundWindowDays))
+      .Then(pool => new RefundablePoolRes(pool, this.RefundWindowDays), Errors.MapNone);
     return this.ReturnResult(x);
   }
 

--- a/App/Modules/Withdrawals/API/V1/WithdrawalMapper.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalMapper.cs
@@ -26,8 +26,35 @@ public static class WithdrawalMapper
   public static WithdrawalCompleteRes ToRes(this WithdrawalComplete complete) =>
     new(complete.CompletedAt, complete.Note, complete.Receipt);
 
+  public static string ToRes(this WithdrawalMethod method) =>
+    method switch
+    {
+      WithdrawalMethod.PayNow => "PayNow",
+      WithdrawalMethod.CardRefund => "CardRefund",
+      _ => throw new ArgumentOutOfRangeException(nameof(method), method, null),
+    };
+
+  public static string ToRes(this RefundFragmentStatus status) =>
+    status switch
+    {
+      RefundFragmentStatus.Created => "Created",
+      RefundFragmentStatus.Settled => "Settled",
+      RefundFragmentStatus.Failed => "Failed",
+      _ => throw new ArgumentOutOfRangeException(nameof(status), status, null),
+    };
+
   public static WithdrawalRecordRes ToRes(this WithdrawalRecord record) =>
-    new(record.Amount, record.PayNowNumber);
+    new(record.Amount, record.PayNowNumber, record.Method.ToRes());
+
+  public static WithdrawalRefundRes ToRes(this WithdrawalRefundFragment fragment) =>
+    new(
+      fragment.PaymentIntentId,
+      fragment.AirwallexRefundId,
+      fragment.Amount,
+      fragment.Status.ToRes(),
+      fragment.CreatedAt,
+      fragment.SettledAt
+    );
 
   public static WithdrawalPayoutRes ToRes(this WithdrawalPayout payout) =>
     new(payout.ConfirmationNumber, payout.Fee, payout.ReconcileAttempts);
@@ -43,9 +70,23 @@ public static class WithdrawalMapper
     );
 
   public static WithdrawalRes ToRes(this Withdrawal w) =>
-    new(w.Principal.ToRes(), w.User.ToRes(), w.Completer?.ToRes(), w.Wallet.ToRes());
+    new(
+      w.Principal.ToRes(),
+      w.User.ToRes(),
+      w.Completer?.ToRes(),
+      w.Wallet.ToRes(),
+      w.Refunds.Select(x => x.ToRes())
+    );
 
   // REQ -> Domain
+  public static WithdrawalMethod ToWithdrawalMethod(this string? method) =>
+    method switch
+    {
+      // absent = PayNow: already-deployed frontends predate the method field
+      null or "" or "PayNow" => WithdrawalMethod.PayNow,
+      "CardRefund" => WithdrawalMethod.CardRefund,
+      _ => throw new ArgumentOutOfRangeException(nameof(method), method, null),
+    };
   public static WithdrawStatus ToWithdrawStatus(this string status) =>
     status switch
     {
@@ -58,8 +99,17 @@ public static class WithdrawalMapper
       _ => throw new ArgumentOutOfRangeException(nameof(status), status, null),
     };
 
-  public static WithdrawalRecord ToDomain(this CreateWithdrawalReq record) =>
-    new() { Amount = record.Amount, PayNowNumber = record.PayNowNumber };
+  public static WithdrawalRecord ToDomain(this CreateWithdrawalReq record)
+  {
+    var method = record.Method.ToWithdrawalMethod();
+    return new WithdrawalRecord
+    {
+      Amount = record.Amount,
+      Method = method,
+      // card refunds carry no PayNow id even if one slipped into the request
+      PayNowNumber = method == WithdrawalMethod.CardRefund ? null : record.PayNowNumber,
+    };
+  }
 
   public static WithdrawalSearch ToDomain(this SearchWithdrawalQuery query) =>
     new()

--- a/App/Modules/Withdrawals/API/V1/WithdrawalModel.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalModel.cs
@@ -16,7 +16,9 @@ public record SearchWithdrawalQuery(
   int? Skip
 );
 
-public record CreateWithdrawalReq(decimal Amount, string PayNowNumber);
+// Method: "PayNow" (default when omitted, rollout compat) or "CardRefund".
+// PayNowNumber is required for PayNow and must be null/absent for CardRefund.
+public record CreateWithdrawalReq(decimal Amount, string? PayNowNumber, string? Method);
 
 public record CancelWithdrawalReq(string Note);
 
@@ -27,9 +29,20 @@ public record WithdrawalStatusRes(string Status);
 
 public record WithdrawalCompleteRes(DateTime CompletedAt, string Note, string? Receipt);
 
-public record WithdrawalRecordRes(decimal Amount, string PayNowNumber);
+public record WithdrawalRecordRes(decimal Amount, string? PayNowNumber, string Method);
 
 public record WithdrawalPayoutRes(string? ConfirmationNumber, decimal Fee, int ReconcileAttempts);
+
+// Card-refund evidence: one row per refund created against a funding payment
+// intent, so the user can see exactly where each slice of the money went
+public record WithdrawalRefundRes(
+  string PaymentIntentId,
+  string? AirwallexRefundId,
+  decimal Amount,
+  string Status,
+  DateTime CreatedAt,
+  DateTime? SettledAt
+);
 
 public record WithdrawalPrincipalRes(
   Guid Id,
@@ -48,5 +61,10 @@ public record WithdrawalRes(
   WithdrawalPrincipalRes Principal,
   UserPrincipalRes User,
   UserPrincipalRes? Completer,
-  WalletPrincipalRes Wallet
+  WalletPrincipalRes Wallet,
+  IEnumerable<WithdrawalRefundRes> Refunds
 );
+
+// GET Withdrawal/refundable/{userId}: how much the user could withdraw via
+// card refunds right now, and the window that pool was computed over
+public record RefundablePoolRes(decimal Pool, int WindowDays);

--- a/App/Modules/Withdrawals/API/V1/WithdrawalValidator.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalValidator.cs
@@ -20,12 +20,32 @@ public class SearchWithdrawalQueryValidator : AbstractValidator<SearchWithdrawal
 
 public class CreateWithdrawalReqValidator : AbstractValidator<CreateWithdrawalReq>
 {
+  private static readonly string[] Methods = ["PayNow", "CardRefund"];
+
   public CreateWithdrawalReqValidator()
   {
     this.RuleFor(x => x.Amount).GreaterThan(0);
-    // exactly 8 digits: an SG PayNow mobile number, matching the UI rule and
-    // the +65 normalization the payout gateway applies
-    this.RuleFor(x => x.PayNowNumber).NotEmpty().Matches("^[0-9]{8}$");
+
+    // absent = PayNow (rollout compat for already-deployed frontends)
+    this.RuleFor(x => x.Method)
+      .Must(m => string.IsNullOrEmpty(m) || Methods.Contains(m))
+      .WithMessage("Method must be 'PayNow' or 'CardRefund'");
+
+    // PayNow needs a destination account: exactly 8 digits, an SG PayNow
+    // mobile number, matching the UI rule and the +65 normalization the
+    // payout gateway applies. CardRefund has no PayNow id — the money
+    // returns to the cards that funded the wallet.
+    this.When(
+      x => x.Method != "CardRefund",
+      () => this.RuleFor(x => x.PayNowNumber).NotEmpty().Matches("^[0-9]{8}$")
+    );
+    this.When(
+      x => x.Method == "CardRefund",
+      () =>
+        this.RuleFor(x => x.PayNowNumber)
+          .Empty()
+          .WithMessage("A card-refund withdrawal must not carry a PayNow number")
+    );
   }
 }
 

--- a/App/Modules/Withdrawals/Data/AirwallexRefundGateway.cs
+++ b/App/Modules/Withdrawals/Data/AirwallexRefundGateway.cs
@@ -1,0 +1,43 @@
+using App.Modules.Payments.Airwallex;
+using CSharp_Result;
+using Domain.Withdrawal;
+
+namespace App.Modules.Withdrawals.Data;
+
+// Card-refund rail: returns withdrawal money to the cards behind the
+// payment intents that funded the wallet, via the Airwallex Refunds API
+public class AirwallexRefundGateway(AirWallexClient client) : IRefundGateway
+{
+  public Task<Result<RefundConfirmation>> CreateRefund(RefundRequest request)
+  {
+    var req = new AirwallexCreateRefundReq
+    {
+      RequestId = request.RequestId,
+      PaymentIntentId = request.PaymentIntentId,
+      Amount = request.Amount,
+      Reason = "BunnyBooker Withdrawal",
+    };
+    return client
+      .CreateRefund(req)
+      .Then(res => new RefundConfirmation { Id = res.Id }, Errors.MapNone);
+  }
+
+  public Task<Result<PayoutStatus>> GetRefundStatus(string refundId)
+  {
+    return client
+      .GetRefund(refundId)
+      .Then(
+        refund =>
+        {
+          if (refund == null)
+            return new PayoutStatus { Outcome = PayoutOutcome.NotFound, ConfirmationNumber = null };
+          var status = refund.Status.ToUpperInvariant();
+          var outcome = AirwallexRefundStatuses.Settled.Contains(status) ? PayoutOutcome.Settled
+            : AirwallexRefundStatuses.Failed.Contains(status) ? PayoutOutcome.Failed
+            : PayoutOutcome.InFlight;
+          return new PayoutStatus { Outcome = outcome, ConfirmationNumber = refund.Id };
+        },
+        Errors.MapNone
+      );
+  }
+}

--- a/App/Modules/Withdrawals/Data/WithdrawalData.cs
+++ b/App/Modules/Withdrawals/Data/WithdrawalData.cs
@@ -18,6 +18,12 @@ public class WithdrawalData
   [Precision(16, 8)]
   public decimal Amount { get; set; }
 
+  // 0 = PayNow (transfer to the user's mobile), 1 = CardRefund (refunds
+  // against the card payments that funded the wallet)
+  public byte Method { get; set; }
+
+  // empty for CardRefund withdrawals — no PayNow id is involved (kept
+  // non-null to match the pre-method column shape)
   [MaxLength(64)]
   public string PayNowNumber { get; set; } = string.Empty;
 
@@ -47,4 +53,7 @@ public class WithdrawalData
 
   public Guid WalletId { get; set; }
   public WalletData Wallet { get; set; } = null!;
+
+  // card-refund evidence rows; empty for PayNow withdrawals
+  public List<WithdrawalRefundData> Refunds { get; set; } = [];
 }

--- a/App/Modules/Withdrawals/Data/WithdrawalMapper.cs
+++ b/App/Modules/Withdrawals/Data/WithdrawalMapper.cs
@@ -8,7 +8,13 @@ public static class WithdrawalMapper
 {
   // Data -> Domain
   public static WithdrawalRecord ToRecord(this WithdrawalData data) =>
-    new() { Amount = data.Amount, PayNowNumber = data.PayNowNumber };
+    new()
+    {
+      Amount = data.Amount,
+      Method = (WithdrawalMethod)data.Method,
+      // card refunds carry no PayNow id; the column stores empty string
+      PayNowNumber = string.IsNullOrEmpty(data.PayNowNumber) ? null : data.PayNowNumber,
+    };
 
   public static WithdrawalStatus ToStatus(this WithdrawalData data) =>
     new() { Status = (WithdrawStatus)data.Status };
@@ -57,15 +63,51 @@ public static class WithdrawalMapper
       Wallet = data.Wallet.ToPrincipal(),
       User = data.Wallet.User.ToPrincipal(),
       Completer = data.Completer?.ToPrincipal(),
+      Refunds = data
+        .Refunds.OrderBy(x => x.RequestId, StringComparer.Ordinal)
+        .Select(x => x.ToDomain())
+        .ToList(),
     };
 
   // Domain -> Data
   public static WithdrawalData Update(this WithdrawalData data, WithdrawalRecord record)
   {
     data.Amount = record.Amount;
-    data.PayNowNumber = record.PayNowNumber;
+    data.Method = (byte)record.Method;
+    data.PayNowNumber = record.PayNowNumber ?? string.Empty;
     return data;
   }
+
+  // Refund fragments (evidence rows)
+  public static WithdrawalRefundFragment ToDomain(this WithdrawalRefundData data) =>
+    new()
+    {
+      Id = data.Id,
+      WithdrawalId = data.WithdrawalId,
+      PaymentId = data.PaymentId,
+      PaymentIntentId = data.PaymentIntentId,
+      AirwallexRefundId = data.AirwallexRefundId,
+      RequestId = data.RequestId,
+      Amount = data.Amount,
+      Status = (RefundFragmentStatus)data.Status,
+      CreatedAt = data.CreatedAt,
+      SettledAt = data.SettledAt,
+    };
+
+  public static WithdrawalRefundData ToData(this WithdrawalRefundFragment fragment) =>
+    new()
+    {
+      Id = fragment.Id,
+      WithdrawalId = fragment.WithdrawalId,
+      PaymentId = fragment.PaymentId,
+      PaymentIntentId = fragment.PaymentIntentId,
+      AirwallexRefundId = fragment.AirwallexRefundId,
+      RequestId = fragment.RequestId,
+      Amount = fragment.Amount,
+      Status = (byte)fragment.Status,
+      CreatedAt = fragment.CreatedAt,
+      SettledAt = fragment.SettledAt,
+    };
 
   public static WithdrawalData Update(this WithdrawalData data, WithdrawalStatus record)
   {

--- a/App/Modules/Withdrawals/Data/WithdrawalRefundData.cs
+++ b/App/Modules/Withdrawals/Data/WithdrawalRefundData.cs
@@ -1,0 +1,42 @@
+using System.ComponentModel.DataAnnotations;
+using App.Modules.Payments.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace App.Modules.Withdrawals.Data;
+
+// One card refund created (or planned) against a specific funding payment —
+// the user-visible evidence of where a card withdrawal's money went, and the
+// per-intent refunded-total ledger the refundable pool subtracts.
+public class WithdrawalRefundData
+{
+  public Guid Id { get; set; }
+
+  public DateTime CreatedAt { get; set; }
+
+  // fragment lifecycle: 0 Created, 1 Settled, 2 Failed
+  public byte Status { get; set; }
+
+  [Precision(16, 8)]
+  public decimal Amount { get; set; }
+
+  // denormalized Airwallex payment intent id (PaymentData.ExternalReference)
+  [MaxLength(256)]
+  public string PaymentIntentId { get; set; } = string.Empty;
+
+  // gateway refund id, once the create call returned
+  [MaxLength(64)]
+  public string? AirwallexRefundId { get; set; }
+
+  // deterministic gateway idempotency key: "{withdrawalId}-{attempt}-{index}"
+  [MaxLength(128)]
+  public string RequestId { get; set; } = string.Empty;
+
+  public DateTime? SettledAt { get; set; }
+
+  // References
+  public Guid WithdrawalId { get; set; }
+  public WithdrawalData Withdrawal { get; set; } = null!;
+
+  public Guid PaymentId { get; set; }
+  public PaymentData Payment { get; set; } = null!;
+}

--- a/App/Modules/Withdrawals/Data/WithdrawalRefundRepository.cs
+++ b/App/Modules/Withdrawals/Data/WithdrawalRefundRepository.cs
@@ -1,0 +1,180 @@
+using App.StartUp.Database;
+using CSharp_Result;
+using Domain.Withdrawal;
+using Microsoft.EntityFrameworkCore;
+
+namespace App.Modules.Withdrawals.Data;
+
+public class WithdrawalRefundRepository(
+  MainDbContext db,
+  ILogger<WithdrawalRefundRepository> logger
+) : IWithdrawalRefundRepository
+{
+  private const string Gateway = "Airwallex";
+
+  // a captured Airwallex payment intent: the only status under which money
+  // actually arrived and may be refunded
+  private const string CapturedStatus = "SUCCEEDED";
+
+  public async Task<Result<List<FundingPayment>>> ListFundingPayments(
+    Guid walletId,
+    DateTime since
+  )
+  {
+    try
+    {
+      logger.LogInformation(
+        "Listing funding payments for Wallet '{WalletId}' since {Since}",
+        walletId,
+        since
+      );
+      var payments = await db
+        .Payments.Where(x =>
+          x.WalletId == walletId
+          && x.Gateway == Gateway
+          && x.Status == CapturedStatus
+          && x.CreatedAt >= since
+          && x.CapturedAmount > 0
+        )
+        .OrderBy(x => x.CreatedAt)
+        .Select(x => new
+        {
+          x.Id,
+          x.ExternalReference,
+          x.CreatedAt,
+          x.CapturedAmount,
+        })
+        .ToArrayAsync();
+      return payments
+        .Select(x => new FundingPayment
+        {
+          PaymentId = x.Id,
+          PaymentIntentId = x.ExternalReference,
+          CreatedAt = x.CreatedAt,
+          CapturedAmount = x.CapturedAmount,
+        })
+        .ToList();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed listing funding payments for Wallet '{WalletId}'", walletId);
+      throw;
+    }
+  }
+
+  public async Task<Result<Dictionary<Guid, decimal>>> SumActiveRefundsByPayment(
+    IEnumerable<Guid> paymentIds
+  )
+  {
+    try
+    {
+      var ids = paymentIds.ToArray();
+      var sums = await db
+        .WithdrawalRefunds.Where(x =>
+          ids.Contains(x.PaymentId) && x.Status != (byte)RefundFragmentStatus.Failed
+        )
+        .GroupBy(x => x.PaymentId)
+        .Select(g => new { PaymentId = g.Key, Total = g.Sum(x => x.Amount) })
+        .ToArrayAsync();
+      return sums.ToDictionary(x => x.PaymentId, x => x.Total);
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed summing active refunds by payment");
+      throw;
+    }
+  }
+
+  public async Task<Result<List<WithdrawalRefundFragment>>> ListByWithdrawal(Guid withdrawalId)
+  {
+    try
+    {
+      var rows = await db
+        .WithdrawalRefunds.Where(x => x.WithdrawalId == withdrawalId)
+        .OrderBy(x => x.RequestId)
+        .ToArrayAsync();
+      return rows.Select(x => x.ToDomain()).ToList();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed listing refund fragments for Withdrawal '{Id}'", withdrawalId);
+      throw;
+    }
+  }
+
+  public async Task<Result<WithdrawalRefundFragment?>> GetByRequestId(string requestId)
+  {
+    try
+    {
+      var row = await db
+        .WithdrawalRefunds.Where(x => x.RequestId == requestId)
+        .FirstOrDefaultAsync();
+      return row?.ToDomain();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed getting refund fragment by request id '{RequestId}'", requestId);
+      throw;
+    }
+  }
+
+  public async Task<Result<List<WithdrawalRefundFragment>>> CreateMany(
+    IEnumerable<WithdrawalRefundFragment> fragments
+  )
+  {
+    try
+    {
+      var rows = fragments.Select(x => x.ToData()).ToList();
+      logger.LogInformation(
+        "Creating {Count} refund fragments for Withdrawal '{WithdrawalId}'",
+        rows.Count,
+        rows.FirstOrDefault()?.WithdrawalId
+      );
+      db.WithdrawalRefunds.AddRange(rows);
+      await db.SaveChangesAsync();
+      return rows.Select(x => x.ToDomain()).ToList();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed creating refund fragments");
+      return e;
+    }
+  }
+
+  public async Task<Result<WithdrawalRefundFragment?>> Update(
+    Guid id,
+    RefundFragmentStatus? status,
+    string? airwallexRefundId,
+    DateTime? settledAt
+  )
+  {
+    try
+    {
+      logger.LogInformation(
+        "Updating refund fragment '{Id}' with status {Status}, refund id '{RefundId}'",
+        id,
+        status,
+        airwallexRefundId
+      );
+      var row = await db.WithdrawalRefunds.Where(x => x.Id == id).FirstOrDefaultAsync();
+      if (row == null)
+        return (WithdrawalRefundFragment?)null;
+
+      if (status != null)
+        row.Status = (byte)status;
+      if (airwallexRefundId != null)
+        row.AirwallexRefundId = airwallexRefundId;
+      if (settledAt != null)
+        row.SettledAt = settledAt;
+
+      var updated = db.WithdrawalRefunds.Update(row);
+      await db.SaveChangesAsync();
+      return updated.Entity.ToDomain();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed updating refund fragment '{Id}'", id);
+      return e;
+    }
+  }
+}

--- a/App/Modules/Withdrawals/Data/WithdrawalRepository.cs
+++ b/App/Modules/Withdrawals/Data/WithdrawalRepository.cs
@@ -71,6 +71,7 @@ public class WithdrawalRepository(MainDbContext db, ILogger<WithdrawalRepository
         .Withdrawals.Include(x => x.Wallet)
         .ThenInclude(x => x.User)
         .Include(x => x.Completer)
+        .Include(x => x.Refunds)
         .Where(x => x.Id == id && (userId == null || userId == x.Wallet.UserId))
         .FirstOrDefaultAsync();
       return wallet?.ToDomain();

--- a/App/StartUp/Database/MainDbContext.cs
+++ b/App/StartUp/Database/MainDbContext.cs
@@ -38,6 +38,8 @@ public class MainDbContext(
 
   public DbSet<WithdrawalData> Withdrawals { get; set; }
 
+  public DbSet<WithdrawalRefundData> WithdrawalRefunds { get; set; }
+
   public DbSet<FeeData> Fees { get; set; }
 
   public DbSet<TransactionData> Transactions { get; set; }
@@ -180,6 +182,20 @@ public class MainDbContext(
         d.OwnsMany(dt => dt.Matches);
       }
     );
+
+    var withdrawal = modelBuilder.Entity<WithdrawalData>();
+    // existing rows predate the method column and are all PayNow transfers
+    withdrawal
+      .Property(x => x.Method)
+      .HasDefaultValue((byte)0)
+      .HasComment("Payout rail: 0 = PayNow transfer, 1 = card refunds (Airwallex)");
+
+    var withdrawalRefund = modelBuilder.Entity<WithdrawalRefundData>();
+    withdrawalRefund.HasIndex(x => x.WithdrawalId);
+    withdrawalRefund.HasIndex(x => x.PaymentId);
+    // the gateway idempotency key is unique by construction; the index makes
+    // webhook routing by request id an O(1) lookup and enforces the invariant
+    withdrawalRefund.HasIndex(x => x.RequestId).IsUnique();
 
     var payments = modelBuilder.Entity<PaymentData>();
     payments.HasIndex(x => x.ExternalReference);

--- a/App/StartUp/Options/OptionsExtensions.cs
+++ b/App/StartUp/Options/OptionsExtensions.cs
@@ -147,6 +147,9 @@ public static class OptionsExtensions
     // Register Recovery Options
     services.RegisterOption<RecoveryOption>(RecoveryOption.Key);
 
+    // Register Withdrawal Options
+    services.RegisterOption<WithdrawalOption>(WithdrawalOption.Key);
+
     // Register SMTP Options
     services
       .RegisterOption<Dictionary<string, SmtpOption>>(SmtpOption.Key)

--- a/App/StartUp/Options/WithdrawalOption.cs
+++ b/App/StartUp/Options/WithdrawalOption.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace App.StartUp.Options;
+
+public class WithdrawalOption
+{
+  public const string Key = "Withdrawal";
+
+  // How far back (days) a captured card payment still counts toward the
+  // refundable pool for card-refund withdrawals — mirrors the card networks'
+  // refund window
+  [Required, Range(1, 3650)]
+  public int RefundWindowDays { get; set; } = 180;
+}

--- a/Domain/Exceptions/InsufficientRefundablePoolException.cs
+++ b/Domain/Exceptions/InsufficientRefundablePoolException.cs
@@ -1,0 +1,19 @@
+namespace Domain.Exceptions;
+
+// A card-refund withdrawal needs the user's refundable pool (captured card
+// payments inside the refund window, minus refunds already issued against
+// them) to cover the net payout. Raised at creation (pool checked before the
+// reserve moves) and at approval (the pool may have shrunk in between —
+// the claim is reverted to Pending and no refund is created).
+public class InsufficientRefundablePoolException(
+  string? message,
+  decimal required,
+  decimal available
+) : Exception(message)
+{
+  // net amount (gross minus fee) the refunds must cover
+  public decimal Required { get; } = required;
+
+  // what the refundable pool can still cover
+  public decimal Available { get; } = available;
+}

--- a/Domain/Transaction/Generator.cs
+++ b/Domain/Transaction/Generator.cs
@@ -193,6 +193,13 @@ public class TransactionGenerator : ITransactionGenerator
     };
   }
 
+  // Human-readable payout destination: the PayNow account, or (card refunds)
+  // the cards that funded the wallet
+  private static string Destination(WithdrawalRecord record) =>
+    record.Method == WithdrawalMethod.CardRefund
+      ? "card(s) used to fund your wallet"
+      : $"PayNow account {record.PayNowNumber}";
+
   public TransactionRecord CreateWithdrawalRequest(WithdrawalRecord record)
   {
     var amount = record.Amount;
@@ -200,8 +207,8 @@ public class TransactionGenerator : ITransactionGenerator
     {
       Name = "Withdrawal Request",
       Description =
-        $"A withdrawal request of SGD {amount:0.00} has been made to the PayNow "
-        + $"account {record.PayNowNumber}. SGD {amount:0.00} has been moved from your Usable account "
+        $"A withdrawal request of SGD {amount:0.00} has been made to the "
+        + $"{Destination(record)}. SGD {amount:0.00} has been moved from your Usable account "
         + $" to your Withdrawal Reserve account.",
       Amount = amount,
       Type = TransactionType.WithdrawRequest,
@@ -218,8 +225,8 @@ public class TransactionGenerator : ITransactionGenerator
     {
       Name = "Withdrawal Completed",
       Description =
-        $"BunnyBooker has completed your withdrawal request of SGD {amount:0.00} to the PayNow "
-        + $"account {record.PayNowNumber}. SGD {net:0.00} has been paid out to you and, together "
+        $"BunnyBooker has completed your withdrawal request of SGD {amount:0.00} to the "
+        + $"{Destination(record)}. SGD {net:0.00} has been paid out to you and, together "
         + $"with the SGD {fee:0.00} withdrawal fee, SGD {amount:0.00} has been collected from your "
         + $"Withdrawal Reserve Account.",
       Amount = net,
@@ -237,7 +244,7 @@ public class TransactionGenerator : ITransactionGenerator
       Name = "Withdrawal Fee",
       Description =
         $"A withdrawal fee of SGD {fee:0.00} has been charged on your withdrawal request of "
-        + $"SGD {amount:0.00} to the PayNow account {record.PayNowNumber}. The fee has been "
+        + $"SGD {amount:0.00} to the {Destination(record)}. The fee has been "
         + $"collected from your Withdrawal Reserve Account.",
       Amount = fee,
       Type = TransactionType.WithdrawFee,
@@ -253,8 +260,8 @@ public class TransactionGenerator : ITransactionGenerator
     {
       Name = "Withdrawal Cancelled",
       Description =
-        $"The Withdrawal Request of SGD {amount:0.00} to the PayNow "
-        + $"account {record.PayNowNumber} has been cancelled. SGD {amount:0.00} has been moved to your "
+        $"The Withdrawal Request of SGD {amount:0.00} to the "
+        + $"{Destination(record)} has been cancelled. SGD {amount:0.00} has been moved to your "
         + $"Usable Account from your Withdraw Reserve Account.",
       Amount = amount,
       Type = TransactionType.WithdrawCancelled,
@@ -270,8 +277,8 @@ public class TransactionGenerator : ITransactionGenerator
     {
       Name = "Withdrawal Rejected",
       Description =
-        $"The Withdrawal Request of SGD {amount:0.00} to the PayNow "
-        + $"account {record.PayNowNumber} has been rejected. "
+        $"The Withdrawal Request of SGD {amount:0.00} to the "
+        + $"{Destination(record)} has been rejected. "
         + $"SGD {amount:0.00} has been moved to your "
         + $"Usable Account from your Withdraw Reserve Account.",
       Amount = amount,

--- a/Domain/Withdrawal/IRefundGateway.cs
+++ b/Domain/Withdrawal/IRefundGateway.cs
@@ -1,0 +1,31 @@
+using CSharp_Result;
+
+namespace Domain.Withdrawal;
+
+public record RefundRequest
+{
+  // Unique per fragment and attempt ("{withdrawalId}-{attempt}-{index}"); the
+  // gateway deduplicates on this, so a re-sent fragment can never create a
+  // second refund
+  public required string RequestId { get; init; }
+
+  // the gateway payment intent the money returns to
+  public required string PaymentIntentId { get; init; }
+
+  public required decimal Amount { get; init; }
+}
+
+// Confirmation of a created refund; Id is the gateway's refund identifier
+public record RefundConfirmation
+{
+  public required string Id { get; init; }
+}
+
+public interface IRefundGateway
+{
+  Task<Result<RefundConfirmation>> CreateRefund(RefundRequest request);
+
+  // Point-in-time gateway view of a refund, used by the reconciliation sweep
+  // (refunds are only addressable by their gateway id)
+  Task<Result<PayoutStatus>> GetRefundStatus(string refundId);
+}

--- a/Domain/Withdrawal/IService.cs
+++ b/Domain/Withdrawal/IService.cs
@@ -4,11 +4,29 @@ namespace Domain.Withdrawal;
 
 public interface IWithdrawalService
 {
+  // How far back captured card payments still count toward the refundable
+  // pool, unless configured otherwise (Withdrawal:RefundWindowDays)
+  const int DefaultRefundWindowDays = 180;
+
   Task<Result<IEnumerable<WithdrawalPrincipal>>> Search(WithdrawalSearch search);
 
   Task<Result<Withdrawal?>> Get(Guid id, string? userId);
 
-  Task<Result<WithdrawalPrincipal>> Create(string userId, WithdrawalRecord record);
+  // refundWindowDays: how far back captured card payments still count toward
+  // the refundable pool (config Withdrawal:RefundWindowDays); a CardRefund
+  // creation is refused when the pool cannot cover the net amount
+  Task<Result<WithdrawalPrincipal>> Create(
+    string userId,
+    WithdrawalRecord record,
+    int refundWindowDays = DefaultRefundWindowDays
+  );
+
+  // The user's refundable pool: captured gateway card payments inside the
+  // window, minus refunds already issued against them (any withdrawal)
+  Task<Result<decimal>> RefundablePool(
+    string userId,
+    int refundWindowDays = DefaultRefundWindowDays
+  );
 
   // User initiated
   Task<Result<WithdrawalPrincipal>> Cancel(Guid id, string userId, string note);
@@ -23,9 +41,39 @@ public interface IWithdrawalService
     Stream receipt
   );
 
-  // Admin or automation initiated: creates a payout at the gateway and moves
-  // the withdrawal to Processing; the gateway webhook completes or fails it
-  Task<Result<WithdrawalPrincipal>> Approve(Guid id);
+  // Admin or automation initiated: moves the withdrawal to Processing and
+  // creates the payout at the gateway — a PayNow transfer, or (CardRefund)
+  // one refund per funding payment, planned oldest-first from the refundable
+  // pool. The gateway webhook completes or fails it. A CardRefund whose pool
+  // no longer covers the net amount is returned to Pending with a
+  // distinguishable error before any refund is created.
+  Task<Result<WithdrawalPrincipal>> Approve(
+    Guid id,
+    int refundWindowDays = DefaultRefundWindowDays
+  );
+
+  // Gateway webhook: a refund fragment settled. Records the evidence
+  // idempotently, and when ALL fragments of the current attempt are settled,
+  // collects the reserve and completes the withdrawal (identical ledger to
+  // the PayNow rail).
+  Task<Result<WithdrawalPrincipal>> SettleRefundFragment(
+    Guid id,
+    string requestId,
+    string refundId,
+    int? attempt
+  );
+
+  // Gateway webhook: a refund fragment terminally failed. Sibling fragments
+  // may already be settled — money has partially left — so the withdrawal is
+  // parked RequireManualIntervention with the evidence visible, never
+  // returned to Pending.
+  Task<Result<WithdrawalPrincipal>> FailRefundFragment(
+    Guid id,
+    string requestId,
+    string refundId,
+    string reason,
+    int? attempt
+  );
 
   // Gateway webhook: payout settled, collect the reserve and finalize.
   // attempt (parsed from the gateway request id) fences off events from

--- a/Domain/Withdrawal/Model.cs
+++ b/Domain/Withdrawal/Model.cs
@@ -43,12 +43,25 @@ public enum WithdrawStatus
   RequireManualIntervention = 5,
 }
 
+// How the money leaves BunnyBooker: a PayNow transfer to the user's mobile
+// number, or refunds against the card payments that funded the wallet
+public enum WithdrawalMethod
+{
+  PayNow = 0,
+  CardRefund = 1,
+}
+
 public record Withdrawal
 {
   public required WithdrawalPrincipal Principal { get; init; }
   public required WalletPrincipal Wallet { get; init; }
   public required UserPrincipal User { get; init; }
   public required UserPrincipal? Completer { get; init; }
+
+  // Card-refund evidence: one fragment per refund created at the gateway.
+  // Empty for PayNow withdrawals (defaulted so pre-card-refund call sites and
+  // fakes need no change)
+  public IReadOnlyList<WithdrawalRefundFragment> Refunds { get; init; } = [];
 }
 
 public record WithdrawalPrincipal
@@ -108,5 +121,75 @@ public record WithdrawalRecord
 {
   public required decimal Amount { get; init; }
 
-  public required string PayNowNumber { get; init; }
+  public required WithdrawalMethod Method { get; init; }
+
+  // required for PayNow (validated at the API); null for CardRefund — the
+  // money returns to the cards that funded the wallet, no PayNow id exists
+  public required string? PayNowNumber { get; init; }
+}
+
+// Lifecycle of a single refund fragment at the gateway
+public enum RefundFragmentStatus
+{
+  // created at the gateway (or planned), awaiting settlement
+  Created = 0,
+  Settled = 1,
+  Failed = 2,
+}
+
+// One card refund created (or planned) against a specific funding payment.
+// A card withdrawal's net amount is covered by one or more fragments, walked
+// oldest-payment-first; the rows double as the user-visible EVIDENCE of where
+// the money went and as the per-intent refunded-total ledger.
+public record WithdrawalRefundFragment
+{
+  public required Guid Id { get; init; }
+
+  public required Guid WithdrawalId { get; init; }
+
+  // the PaymentData row that funded this fragment
+  public required Guid PaymentId { get; init; }
+
+  // denormalized Airwallex payment intent id (PaymentData.ExternalReference)
+  public required string PaymentIntentId { get; init; }
+
+  // gateway refund id, once the create call returned
+  public required string? AirwallexRefundId { get; init; }
+
+  // deterministic gateway idempotency key: "{withdrawalId}-{attempt}-{index}"
+  public required string RequestId { get; init; }
+
+  public required decimal Amount { get; init; }
+
+  public required RefundFragmentStatus Status { get; init; }
+
+  public required DateTime CreatedAt { get; init; }
+
+  public required DateTime? SettledAt { get; init; }
+}
+
+// A captured card payment that funded the wallet — the raw input to the
+// refundable-pool computation
+public record FundingPayment
+{
+  public required Guid PaymentId { get; init; }
+
+  public required string PaymentIntentId { get; init; }
+
+  public required DateTime CreatedAt { get; init; }
+
+  public required decimal CapturedAmount { get; init; }
+}
+
+// A funding payment still inside the refund window, and how much of its
+// captured amount remains refundable (captured minus non-failed fragments)
+public record RefundablePayment
+{
+  public required Guid PaymentId { get; init; }
+
+  public required string PaymentIntentId { get; init; }
+
+  public required DateTime CreatedAt { get; init; }
+
+  public required decimal Refundable { get; init; }
 }

--- a/Domain/Withdrawal/RefundPlanner.cs
+++ b/Domain/Withdrawal/RefundPlanner.cs
@@ -1,0 +1,38 @@
+using CSharp_Result;
+using Domain.Exceptions;
+
+namespace Domain.Withdrawal;
+
+// Pure fragment planner for card-refund withdrawals: walks the refundable
+// pool oldest-payment-first and carves the net amount into per-payment
+// fragments. Deterministic — the same pool and net always produce the same
+// plan, which the approve flow relies on for idempotent request ids.
+public static class RefundPlanner
+{
+  public static Result<List<(RefundablePayment Payment, decimal Amount)>> Plan(
+    decimal net,
+    IReadOnlyList<RefundablePayment> pool
+  )
+  {
+    var plan = new List<(RefundablePayment, decimal)>();
+    var remaining = net;
+    foreach (var payment in pool.OrderBy(x => x.CreatedAt))
+    {
+      if (remaining <= 0)
+        break;
+      if (payment.Refundable <= 0)
+        continue;
+      var take = Math.Min(remaining, payment.Refundable);
+      plan.Add((payment, take));
+      remaining -= take;
+    }
+
+    if (remaining > 0)
+      return new InsufficientRefundablePoolException(
+        $"The refundable pool (SGD {net - remaining:0.00}) does not cover the net withdrawal amount (SGD {net:0.00})",
+        net,
+        net - remaining
+      );
+    return plan;
+  }
+}

--- a/Domain/Withdrawal/RefundRepository.cs
+++ b/Domain/Withdrawal/RefundRepository.cs
@@ -1,0 +1,35 @@
+using CSharp_Result;
+
+namespace Domain.Withdrawal;
+
+// Persistence port for the card-refund rail: the funding payments a wallet
+// may be refunded against, and the refund fragments (evidence rows) created
+// against them
+public interface IWithdrawalRefundRepository
+{
+  // Captured gateway card payments of the wallet created at or after `since`,
+  // oldest first — the raw refundable pool before subtracting prior refunds
+  Task<Result<List<FundingPayment>>> ListFundingPayments(Guid walletId, DateTime since);
+
+  // Sum of non-Failed fragment amounts per payment id, across ALL
+  // withdrawals (absent key = nothing refunded against that payment yet)
+  Task<Result<Dictionary<Guid, decimal>>> SumActiveRefundsByPayment(IEnumerable<Guid> paymentIds);
+
+  // All fragments of a withdrawal (every attempt), oldest first
+  Task<Result<List<WithdrawalRefundFragment>>> ListByWithdrawal(Guid withdrawalId);
+
+  Task<Result<WithdrawalRefundFragment?>> GetByRequestId(string requestId);
+
+  Task<Result<List<WithdrawalRefundFragment>>> CreateMany(
+    IEnumerable<WithdrawalRefundFragment> fragments
+  );
+
+  // Partial update: null leaves the field untouched (SettledAt is only
+  // written together with a Settled status)
+  Task<Result<WithdrawalRefundFragment?>> Update(
+    Guid id,
+    RefundFragmentStatus? status,
+    string? airwallexRefundId,
+    DateTime? settledAt
+  );
+}

--- a/Domain/Withdrawal/Service.cs
+++ b/Domain/Withdrawal/Service.cs
@@ -2,6 +2,7 @@ using CSharp_Result;
 using Domain.Exceptions;
 using Domain.Transaction;
 using Domain.Wallet;
+using WalletAggregate = Domain.Wallet.Wallet;
 
 namespace Domain.Withdrawal;
 
@@ -13,9 +14,13 @@ public class WithdrawalService(
   IWithdrawalStorage withdrawalStorage,
   ITransactionManager transactionManager,
   IFeeCalculator feeCalculator,
-  IPayoutGateway payoutGateway
+  IPayoutGateway payoutGateway,
+  IWithdrawalRefundRepository refundRepo,
+  IRefundGateway refundGateway
 ) : IWithdrawalService
 {
+  private const int DefaultRefundWindowDays = IWithdrawalService.DefaultRefundWindowDays;
+
   public Task<Result<IEnumerable<WithdrawalPrincipal>>> Search(WithdrawalSearch search)
   {
     return repo.Search(search);
@@ -26,13 +31,54 @@ public class WithdrawalService(
     return repo.Get(id, userId);
   }
 
-  public Task<Result<WithdrawalPrincipal>> Create(string userId, WithdrawalRecord record)
+  public Task<Result<decimal>> RefundablePool(
+    string userId,
+    int refundWindowDays = DefaultRefundWindowDays
+  )
+  {
+    return walletRepo
+      .GetByUserId(userId)
+      .NullToError(userId)
+      .ThenAwait(w => this.ComputePool(w.Principal.Id, refundWindowDays))
+      .Then(pool => pool.Sum(x => x.Refundable), Errors.MapNone);
+  }
+
+  public Task<Result<WithdrawalPrincipal>> Create(
+    string userId,
+    WithdrawalRecord record,
+    int refundWindowDays = DefaultRefundWindowDays
+  )
   {
     return transactionManager.Start(
       () =>
         walletRepo
           .GetByUserId(userId)
           .NullToError(userId)
+          // a card-refund withdrawal is only accepted when the refundable
+          // pool covers the net amount — checked BEFORE the reserve moves so
+          // a hopeless request never locks the user's funds. The pool is
+          // re-checked at approval; this uses the fee rate current now.
+          .ThenAwait(async w =>
+          {
+            if (record.Method != WithdrawalMethod.CardRefund)
+              return (Result<WalletAggregate>)w;
+            var feeR = await feeCalculator.Compute(FeeType.Withdrawal, record.Amount);
+            if (feeR.IsFailure())
+              return (Result<WalletAggregate>)feeR.FailureOrDefault();
+            var net = record.Amount - feeR.SuccessOrDefault();
+            var poolR = await this.ComputePool(w.Principal.Id, refundWindowDays);
+            if (poolR.IsFailure())
+              return (Result<WalletAggregate>)poolR.FailureOrDefault();
+            var pool = poolR.SuccessOrDefault().Sum(x => x.Refundable);
+            if (pool < net)
+              return (Result<WalletAggregate>)
+                new InsufficientRefundablePoolException(
+                  $"The refundable pool (SGD {pool:0.00}) does not cover the net withdrawal amount (SGD {net:0.00})",
+                  net,
+                  pool
+                );
+            return (Result<WalletAggregate>)w;
+          })
           .DoAwait(DoType.MapErrors, w => walletRepo.PrepareWithdraw(w.Principal.Id, record.Amount))
           .DoAwait(
             DoType.MapErrors,
@@ -44,6 +90,36 @@ public class WithdrawalService(
           )
           .ThenAwait(w => repo.Create(w.Principal.Id, record))
     );
+  }
+
+  // The wallet's refundable pool: captured Airwallex card payments inside the
+  // window, oldest first, each minus the refunds already issued against it
+  // (any withdrawal, Created or Settled — only Failed fragments release
+  // their claim on the intent)
+  private Task<Result<List<RefundablePayment>>> ComputePool(Guid walletId, int refundWindowDays)
+  {
+    var since = DateTime.UtcNow.AddDays(-refundWindowDays);
+    return refundRepo
+      .ListFundingPayments(walletId, since)
+      .ThenAwait(payments =>
+        refundRepo
+          .SumActiveRefundsByPayment(payments.Select(p => p.PaymentId))
+          .Then(
+            refunded =>
+              payments
+                .Select(p => new RefundablePayment
+                {
+                  PaymentId = p.PaymentId,
+                  PaymentIntentId = p.PaymentIntentId,
+                  CreatedAt = p.CreatedAt,
+                  Refundable = p.CapturedAmount - refunded.GetValueOrDefault(p.PaymentId),
+                })
+                .Where(p => p.Refundable > 0)
+                .OrderBy(p => p.CreatedAt)
+                .ToList(),
+            Errors.MapNone
+          )
+      );
   }
 
   public Task<Result<WithdrawalPrincipal>> Cancel(Guid id, string userId, string note)
@@ -206,7 +282,10 @@ public class WithdrawalService(
     );
   }
 
-  public async Task<Result<WithdrawalPrincipal>> Approve(Guid id)
+  public async Task<Result<WithdrawalPrincipal>> Approve(
+    Guid id,
+    int refundWindowDays = DefaultRefundWindowDays
+  )
   {
     // Phase 1 (claim): Pending -> Processing with a fresh attempt number, in
     // ONE transaction so two concurrent approves can never both claim the
@@ -280,7 +359,13 @@ public class WithdrawalService(
 
     var (withdrawal, claimed, redrive) = claim.SuccessOrDefault();
 
-    // Phase 2: create the payout at the gateway, outside any DB transaction.
+    // Phase 2 branches on the withdrawal method: PayNow creates a single
+    // transfer, CardRefund fans out into refund fragments against the
+    // payments that funded the wallet
+    if (withdrawal.Principal.Record.Method == WithdrawalMethod.CardRefund)
+      return await this.ApproveCardRefund(id, withdrawal, claimed, refundWindowDays);
+
+    // PayNow: create the payout at the gateway, outside any DB transaction.
     // The request id is deterministic per attempt, so a re-send of the same
     // attempt can never create a second payout.
     var created = await payoutGateway.CreatePayout(
@@ -288,7 +373,10 @@ public class WithdrawalService(
       {
         RequestId = $"{id}-{claimed.Attempt}",
         Amount = withdrawal.Principal.Record.Amount - claimed.Fee,
-        PayNowNumber = withdrawal.Principal.Record.PayNowNumber,
+        PayNowNumber = withdrawal.Principal.Record.PayNowNumber
+          ?? throw new InvalidOperationException(
+            $"PayNow withdrawal '{id}' has no PayNow number — inconsistent state"
+          ),
       }
     );
 
@@ -355,6 +443,372 @@ public class WithdrawalService(
                 {
                   ConfirmationNumber = created.SuccessOrDefault().Id,
                 }
+              )
+              .NullToError(id.ToString());
+          })
+    );
+  }
+
+  // Card-refund phase 2: plan the net amount into refund fragments against
+  // the wallet's funding payments (oldest first), persist the evidence rows,
+  // then create one gateway refund per fragment. Request ids are
+  // deterministic ("{id}-{attempt}-{index}"), so a partial failure leaves the
+  // withdrawal Processing and a re-drive re-sends the SAME ids — the
+  // gateway's idempotency collapses them into the original refunds.
+  // (No redrive flag needed here, unlike the PayNow rail: the fragment rows
+  // themselves distinguish a first send from a re-drive.)
+  private async Task<Result<WithdrawalPrincipal>> ApproveCardRefund(
+    Guid id,
+    Withdrawal withdrawal,
+    WithdrawalPayout claimed,
+    int refundWindowDays
+  )
+  {
+    var prefix = $"{id}-{claimed.Attempt}-";
+
+    // A re-drive may already own fragment rows for this attempt — reuse them
+    // verbatim. Re-planning would double-subtract them from the pool, and the
+    // rows are the source of truth for the request ids already (possibly)
+    // sent to the gateway: rows are committed BEFORE any gateway call, so
+    // no rows means no refunds exist for this attempt.
+    var existingR = await refundRepo.ListByWithdrawal(id);
+    if (existingR.IsFailure())
+      return existingR.FailureOrDefault();
+    var fragments = existingR
+      .SuccessOrDefault()
+      .Where(f => f.RequestId.StartsWith(prefix, StringComparison.Ordinal))
+      .OrderBy(f => f.RequestId, StringComparer.Ordinal)
+      .ToList();
+
+    if (fragments.Count == 0)
+    {
+      // plan fresh: the pool may have shrunk since creation (other card
+      // withdrawals settled against the same payments), so re-check before
+      // any money-adjacent action
+      var net = withdrawal.Principal.Record.Amount - claimed.Fee;
+      var poolR = await this.ComputePool(withdrawal.Wallet.Id, refundWindowDays);
+      if (poolR.IsFailure())
+        return poolR.FailureOrDefault();
+      var planR = RefundPlanner.Plan(net, poolR.SuccessOrDefault());
+      if (planR.IsFailure())
+      {
+        // Insufficient pool: no refund was created (rows precede gateway
+        // calls), so releasing the claim back to Pending is safe — mirrors
+        // the PayoutRejectedException bounce. The distinguishable error
+        // carries the shortfall for the admin; a sweep sees a failure and
+        // moves on instead of hot-looping.
+        var release = await transactionManager.Start(
+          () =>
+            repo.Update(
+                null,
+                id,
+                null,
+                new WithdrawalStatus { Status = WithdrawStatus.Pending },
+                null,
+                null
+              )
+              .NullToError(id.ToString())
+        );
+        if (release.IsFailure())
+          return release.FailureOrDefault();
+        return planR.FailureOrDefault();
+      }
+
+      var now = DateTime.UtcNow;
+      var planned = planR
+        .SuccessOrDefault()
+        .Select(
+          (x, idx) =>
+            new WithdrawalRefundFragment
+            {
+              Id = Guid.NewGuid(),
+              WithdrawalId = id,
+              PaymentId = x.Payment.PaymentId,
+              PaymentIntentId = x.Payment.PaymentIntentId,
+              AirwallexRefundId = null,
+              RequestId = $"{prefix}{idx}",
+              Amount = x.Amount,
+              Status = RefundFragmentStatus.Created,
+              CreatedAt = now,
+              SettledAt = null,
+            }
+        )
+        .ToList();
+      var createdR = await transactionManager.Start(() => refundRepo.CreateMany(planned));
+      if (createdR.IsFailure())
+        return createdR.FailureOrDefault();
+      fragments = createdR.SuccessOrDefault();
+    }
+
+    // create the refunds at the gateway, outside any DB transaction; refunds
+    // already created (re-drive) are skipped by their stored refund id
+    foreach (var fragment in fragments)
+    {
+      if (fragment.AirwallexRefundId != null || fragment.Status == RefundFragmentStatus.Failed)
+        continue;
+      var created = await refundGateway.CreateRefund(
+        new RefundRequest
+        {
+          RequestId = fragment.RequestId,
+          PaymentIntentId = fragment.PaymentIntentId,
+          Amount = fragment.Amount,
+        }
+      );
+      if (created.IsFailure())
+        // ANY failure mid-fragmenting is treated as ambiguous: fragments
+        // already created at the gateway stand, so the withdrawal must stay
+        // Processing and be re-driven with the same request ids (or resolved
+        // by webhooks/reconciliation) — never bounced to Pending, which
+        // would mint a fresh attempt and double-refund
+        return created.FailureOrDefault();
+      var stored = await refundRepo.Update(
+        fragment.Id,
+        null,
+        created.SuccessOrDefault().Id,
+        null
+      );
+      if (stored.IsFailure())
+        return stored.FailureOrDefault();
+    }
+
+    // Phase 3 (conditional, like the PayNow rail): the confirmation number of
+    // a card withdrawal is the FIRST fragment's gateway refund id — the
+    // remaining ids live on the fragment evidence rows. Written only once all
+    // fragments hold a refund id, so Approve's re-drive (which keys on a null
+    // confirmation) stays available until fragmenting genuinely finished.
+    var confirmationsR = await refundRepo.ListByWithdrawal(id);
+    if (confirmationsR.IsFailure())
+      return confirmationsR.FailureOrDefault();
+    var confirmed = confirmationsR
+      .SuccessOrDefault()
+      .Where(f => f.RequestId.StartsWith(prefix, StringComparison.Ordinal))
+      .OrderBy(f => f.RequestId, StringComparer.Ordinal)
+      .ToList();
+    if (confirmed.Count == 0 || confirmed.Any(f => f.AirwallexRefundId == null))
+      return await repo.Get(id, null).NullToError(id.ToString()).Then(w => w.Principal, Errors.MapNone);
+    var confirmation = confirmed[0].AirwallexRefundId!;
+
+    return await transactionManager.Start(
+      () =>
+        repo.Get(id, null)
+          .NullToError(id.ToString())
+          .ThenAwait(w =>
+          {
+            var payout = w.Principal.Payout;
+            if (
+              w.Principal.Status.Status != WithdrawStatus.Processing
+              || payout == null
+              || payout.Attempt != claimed.Attempt
+              || payout.ConfirmationNumber != null
+            )
+              return Task.FromResult((Result<WithdrawalPrincipal>)w.Principal);
+            return repo.Update(
+                null,
+                id,
+                null,
+                null,
+                null,
+                payout with
+                {
+                  ConfirmationNumber = confirmation,
+                }
+              )
+              .NullToError(id.ToString());
+          })
+    );
+  }
+
+  public async Task<Result<WithdrawalPrincipal>> SettleRefundFragment(
+    Guid id,
+    string requestId,
+    string refundId,
+    int? attempt
+  )
+  {
+    // Step 1 (own transaction): record the evidence. The settlement is real
+    // money regardless of any staleness fencing below — committing it first
+    // means a stale event's rollback can never erase what actually happened,
+    // and the fragment keeps counting against the refundable pool.
+    var recorded = await transactionManager.Start(
+      () =>
+        refundRepo
+          .GetByRequestId(requestId)
+          .ThenAwait(fragment =>
+          {
+            if (fragment == null)
+              return Task.FromResult(
+                (Result<WithdrawalRefundFragment?>)(WithdrawalRefundFragment?)null
+              );
+            if (fragment.Status == RefundFragmentStatus.Settled)
+              return Task.FromResult((Result<WithdrawalRefundFragment?>)fragment);
+            return refundRepo.Update(
+              fragment.Id,
+              RefundFragmentStatus.Settled,
+              refundId,
+              DateTime.UtcNow
+            );
+          })
+    );
+    if (recorded.IsFailure())
+      return recorded.FailureOrDefault();
+    if (recorded.SuccessOrDefault() == null)
+      return new StalePayoutEventException(
+        $"settled event for unknown refund fragment '{requestId}' of withdrawal '{id}'"
+      );
+
+    // Step 2 (guarded transition): when ALL fragments of the current attempt
+    // are settled, collect the reserve exactly once and complete — identical
+    // ledger to the PayNow rail. Concurrent last-fragment webhooks are safe:
+    // both may see all-settled, but the RepeatableRead write on the
+    // withdrawal row aborts one of them.
+    return await transactionManager.Start(
+      () =>
+        repo.Get(id, null)
+          .NullToError(id.ToString())
+          .ThenAwait(async w =>
+          {
+            var status = w.Principal.Status.Status;
+            var payout = w.Principal.Payout;
+
+            // idempotent redelivery: the withdrawal already completed
+            if (status == WithdrawStatus.Completed)
+              return (Result<WithdrawalPrincipal>)w.Principal;
+
+            if (status != WithdrawStatus.Processing)
+              return await Stale(
+                $"settled refund event for fragment '{requestId}' but withdrawal '{id}' is '{status}'"
+              );
+
+            if (payout == null)
+              return (Result<WithdrawalPrincipal>)
+                new InvalidWithdrawalOperationException(
+                  "Refund settlement requires an approved withdrawal with payout bookkeeping",
+                  status,
+                  WithdrawalOperations.SettleRefund
+                );
+
+            // an event for a superseded attempt must never settle the
+            // current one — its refunds are not the money in flight now (the
+            // evidence recorded above stands either way)
+            if (attempt != null && attempt != payout.Attempt)
+              return await Stale(
+                $"settled refund event for attempt {attempt} of withdrawal '{id}', current attempt is {payout.Attempt}"
+              );
+
+            var allR = await refundRepo.ListByWithdrawal(id);
+            if (allR.IsFailure())
+              return (Result<WithdrawalPrincipal>)allR.FailureOrDefault();
+            var prefix = $"{id}-{payout.Attempt}-";
+            var siblings = allR
+              .SuccessOrDefault()
+              .Where(f => f.RequestId.StartsWith(prefix, StringComparison.Ordinal))
+              .OrderBy(f => f.RequestId, StringComparer.Ordinal)
+              .ToList();
+            if (siblings.Count == 0)
+              return await Stale(
+                $"settled refund event for withdrawal '{id}' with no fragments for attempt {payout.Attempt}"
+              );
+            if (siblings.Any(f => f.Status != RefundFragmentStatus.Settled))
+              // partial settlement: acknowledge and wait for the remaining
+              // fragments' events
+              return (Result<WithdrawalPrincipal>)w.Principal;
+
+            var confirmation = payout.ConfirmationNumber ?? siblings[0].AirwallexRefundId!;
+            return await CollectReserve(w, payout.Fee)
+              .ThenAwait(_ =>
+                repo.Update(
+                    null,
+                    id,
+                    null,
+                    new WithdrawalStatus { Status = WithdrawStatus.Completed },
+                    new WithdrawalComplete
+                    {
+                      Note =
+                        $"Automatically paid out via {siblings.Count} Airwallex card refund(s), first refund '{confirmation}'",
+                      Receipt = null,
+                      CompletedAt = DateTime.UtcNow,
+                      CompleterId = null,
+                    },
+                    payout with
+                    {
+                      ConfirmationNumber = confirmation,
+                    }
+                  )
+                  .NullToError(id.ToString())
+              );
+          })
+    );
+  }
+
+  public async Task<Result<WithdrawalPrincipal>> FailRefundFragment(
+    Guid id,
+    string requestId,
+    string refundId,
+    string reason,
+    int? attempt
+  )
+  {
+    // Step 1 (own transaction): record the terminal failure. The fragment
+    // releases its claim on the funding payment's refundable amount, and the
+    // evidence survives any staleness fencing below.
+    var recorded = await transactionManager.Start(
+      () =>
+        refundRepo
+          .GetByRequestId(requestId)
+          .ThenAwait(fragment =>
+          {
+            if (fragment == null)
+              return Task.FromResult(
+                (Result<WithdrawalRefundFragment?>)(WithdrawalRefundFragment?)null
+              );
+            if (fragment.Status == RefundFragmentStatus.Failed)
+              return Task.FromResult((Result<WithdrawalRefundFragment?>)fragment);
+            return refundRepo.Update(fragment.Id, RefundFragmentStatus.Failed, refundId, null);
+          })
+    );
+    if (recorded.IsFailure())
+      return recorded.FailureOrDefault();
+    if (recorded.SuccessOrDefault() == null)
+      return new StalePayoutEventException(
+        $"failure event for unknown refund fragment '{requestId}' of withdrawal '{id}': {reason}"
+      );
+
+    // Step 2: park the withdrawal. Unlike a failed PayNow transfer, a failed
+    // fragment can NOT bounce the withdrawal back to Pending: sibling
+    // fragments may already be settled — money has partially left — and a
+    // fresh attempt would refund it again. A human resolves it with the
+    // fragment evidence showing exactly which refunds settled, failed, or
+    // are still in flight.
+    return await transactionManager.Start(
+      () =>
+        repo.Get(id, null)
+          .NullToError(id.ToString())
+          .ThenAwait(w =>
+          {
+            var status = w.Principal.Status.Status;
+            var payout = w.Principal.Payout;
+
+            // idempotent redelivery: an earlier failure event already parked it
+            if (status == WithdrawStatus.RequireManualIntervention)
+              return Task.FromResult((Result<WithdrawalPrincipal>)w.Principal);
+
+            if (status != WithdrawStatus.Processing)
+              return Stale($"refund failure event for withdrawal '{id}' in '{status}': {reason}");
+
+            // a failure of a superseded attempt must not park the attempt
+            // currently in flight
+            if (payout != null && attempt != null && attempt != payout.Attempt)
+              return Stale(
+                $"refund failure event for attempt {attempt} of withdrawal '{id}', current attempt is {payout.Attempt}"
+              );
+
+            return repo.Update(
+                null,
+                id,
+                null,
+                new WithdrawalStatus { Status = WithdrawStatus.RequireManualIntervention },
+                null,
+                null
               )
               .NullToError(id.ToString());
           })
@@ -473,10 +927,12 @@ public class WithdrawalService(
   public const int MaxReconcileAttempts = 8;
 
   // Reconciliation: asks the gateway what actually happened to a Processing
-  // withdrawal's transfer. Settled/failed outcomes are delegated to the same
-  // guarded transitions the webhook uses; anything inconclusive (still in
-  // flight, not found, or the lookup itself failing) increments the attempt
-  // counter and parks the withdrawal at the cap. Never moves money itself.
+  // withdrawal's payout — the PayNow transfer, or each still-pending refund
+  // fragment of a card withdrawal. Settled/failed outcomes are delegated to
+  // the same guarded transitions the webhooks use; anything inconclusive
+  // (still in flight, not found, or the lookup itself failing) increments
+  // the attempt counter and parks the withdrawal at the cap. Never moves
+  // money itself.
   public async Task<Result<WithdrawalPrincipal>> Reconcile(Guid id)
   {
     var read = await repo.Get(id, null).NullToError(id.ToString());
@@ -491,24 +947,34 @@ public class WithdrawalService(
         WithdrawalOperations.Reconcile
       );
 
-    var lookup = await payoutGateway.GetPayoutStatus(
-      $"{id}-{payout.Attempt}",
-      payout.ConfirmationNumber
-    );
-
-    if (lookup.IsSuccess())
+    if (w.Principal.Record.Method == WithdrawalMethod.CardRefund)
     {
-      var gateway = lookup.SuccessOrDefault();
-      switch (gateway.Outcome)
+      var resolved = await this.ReconcileCardRefund(id, payout);
+      if (resolved != null)
+        return resolved.Value;
+      // fall through: inconclusive, count the sweep below
+    }
+    else
+    {
+      var lookup = await payoutGateway.GetPayoutStatus(
+        $"{id}-{payout.Attempt}",
+        payout.ConfirmationNumber
+      );
+
+      if (lookup.IsSuccess())
       {
-        case PayoutOutcome.Settled:
-          return await this.CompletePayout(id, gateway.ConfirmationNumber!, payout.Attempt);
-        case PayoutOutcome.Failed:
-          return await this.FailPayout(
-            id,
-            "reconciliation: gateway reports the transfer terminally failed",
-            payout.Attempt
-          );
+        var gateway = lookup.SuccessOrDefault();
+        switch (gateway.Outcome)
+        {
+          case PayoutOutcome.Settled:
+            return await this.CompletePayout(id, gateway.ConfirmationNumber!, payout.Attempt);
+          case PayoutOutcome.Failed:
+            return await this.FailPayout(
+              id,
+              "reconciliation: gateway reports the transfer terminally failed",
+              payout.Attempt
+            );
+        }
       }
     }
 
@@ -545,6 +1011,64 @@ public class WithdrawalService(
               .NullToError(id.ToString());
           })
     );
+  }
+
+  // Card-refund reconciliation: poll each undecided fragment of the current
+  // attempt at the gateway. Settlements/failures are delegated to the same
+  // guarded webhook transitions (idempotent). Returns the resulting
+  // principal when a decisive transition fired, or null when everything is
+  // still inconclusive (caller counts the sweep).
+  private async Task<Result<WithdrawalPrincipal>?> ReconcileCardRefund(
+    Guid id,
+    WithdrawalPayout payout
+  )
+  {
+    var allR = await refundRepo.ListByWithdrawal(id);
+    if (allR.IsFailure())
+      return allR.FailureOrDefault();
+    var prefix = $"{id}-{payout.Attempt}-";
+    var fragments = allR
+      .SuccessOrDefault()
+      .Where(f => f.RequestId.StartsWith(prefix, StringComparison.Ordinal))
+      .OrderBy(f => f.RequestId, StringComparer.Ordinal)
+      .ToList();
+
+    Result<WithdrawalPrincipal>? decisive = null;
+    foreach (var fragment in fragments)
+    {
+      if (fragment.Status != RefundFragmentStatus.Created)
+        continue;
+      // a fragment without a refund id was never confirmed at the gateway;
+      // the approve re-drive path owns it, not reconciliation
+      if (fragment.AirwallexRefundId == null)
+        continue;
+      var lookup = await refundGateway.GetRefundStatus(fragment.AirwallexRefundId);
+      if (lookup.IsFailure())
+        continue;
+      switch (lookup.SuccessOrDefault().Outcome)
+      {
+        case PayoutOutcome.Settled:
+          decisive = await this.SettleRefundFragment(
+            id,
+            fragment.RequestId,
+            fragment.AirwallexRefundId,
+            payout.Attempt
+          );
+          break;
+        case PayoutOutcome.Failed:
+          // parking is terminal for this sweep: the remaining fragments'
+          // evidence keeps flowing in via webhooks or later sweeps
+          return await this.FailRefundFragment(
+            id,
+            fragment.RequestId,
+            fragment.AirwallexRefundId,
+            "reconciliation: gateway reports the refund terminally failed",
+            payout.Attempt
+          );
+      }
+    }
+
+    return decisive;
   }
 
   // Admin only: return a parked withdrawal to Pending for another automated

--- a/Domain/Withdrawal/Service.cs
+++ b/Domain/Withdrawal/Service.cs
@@ -1090,6 +1090,36 @@ public class WithdrawalService(
                 WithdrawStatus.RequireManualIntervention
               )
           )
+          // Money safety for the card rail: a settled fragment means part of
+          // the money has ALREADY reached the user's card, but the reserve
+          // was never collected (that only happens when ALL fragments
+          // settle). Requeueing would let the next approve re-plan the FULL
+          // net against the remaining pool and pay the settled part twice.
+          // Such withdrawals must be resolved manually (partial-settlement
+          // bookkeeping is a human decision), never re-automated.
+          .DoAwait(
+            DoType.MapErrors,
+            async w =>
+            {
+              if (w.Principal.Record.Method != WithdrawalMethod.CardRefund)
+                return (Result<int>)0;
+              var fragmentsR = await refundRepo.ListByWithdrawal(id);
+              if (fragmentsR.IsFailure())
+                return (Result<int>)fragmentsR.FailureOrDefault();
+              if (
+                fragmentsR
+                  .SuccessOrDefault()
+                  .Any(f => f.Status == RefundFragmentStatus.Settled)
+              )
+                return (Result<int>)
+                  new InvalidWithdrawalOperationException(
+                    "This card-refund withdrawal has settled refund fragments — money has partially reached the user's card, so it cannot be requeued for another automated attempt; resolve it manually",
+                    w.Principal.Status.Status,
+                    WithdrawalOperations.Requeue
+                  );
+              return (Result<int>)0;
+            }
+          )
           .ThenAwait(w =>
             repo.Update(
                 null,

--- a/Domain/Withdrawal/WithdrawalOperations.cs
+++ b/Domain/Withdrawal/WithdrawalOperations.cs
@@ -12,6 +12,10 @@ public static class WithdrawalOperations
 
   public const string CompletePayout = "CompletePayout";
 
+  public const string SettleRefund = "SettleRefund";
+
+  public const string FailRefund = "FailRefund";
+
   public const string Reconcile = "Reconcile";
 
   public const string Requeue = "Requeue";

--- a/UnitTest/Withdrawals/AirwallexRefundEventAdapterTests.cs
+++ b/UnitTest/Withdrawals/AirwallexRefundEventAdapterTests.cs
@@ -1,0 +1,102 @@
+using App.Modules.Payments.Airwallex;
+using FluentAssertions;
+
+namespace UnitTest.Withdrawals;
+
+// Routing of refund.* webhook events: request-id parsing back into
+// (withdrawalId, attempt, index) and status classification. Foreign request
+// ids (refunds issued by hand on the dashboard) must parse to null so the
+// webhook acknowledges instead of crash-looping.
+public class AirwallexRefundEventAdapterTests
+{
+  private static readonly Guid WithdrawalId = Guid.NewGuid();
+
+  private static AirwallexEvent Event(string name, string requestId, string status) =>
+    new()
+    {
+      Name = name,
+      Data = new AirwallexEventData
+      {
+        Object = new AirwallexEventDataObject
+        {
+          Id = "rfd_123",
+          RequestId = requestId,
+          Status = status,
+        },
+      },
+    };
+
+  [Theory]
+  [InlineData("refund.received")]
+  [InlineData("refund.accepted")]
+  [InlineData("refund.settled")]
+  [InlineData("refund.failed")]
+  public void Refund_events_are_recognized(string name)
+  {
+    AirwallexEventAdapter.IsRefundEvent(Event(name, "x", "RECEIVED")).Should().BeTrue();
+  }
+
+  [Theory]
+  [InlineData("payment_intent.succeeded")]
+  [InlineData("transfer.paid")]
+  public void Non_refund_events_are_not_recognized(string name)
+  {
+    AirwallexEventAdapter.IsRefundEvent(Event(name, "x", "PAID")).Should().BeFalse();
+  }
+
+  [Fact]
+  public void Our_request_id_parses_into_withdrawal_attempt_and_outcome()
+  {
+    var adapter = new AirwallexEventAdapter();
+    var evt = Event("refund.settled", $"{WithdrawalId}-3-1", "SETTLED");
+
+    var (withdrawalId, requestId, refundId, attempt, outcome) = adapter.ProcessRefundEvent(evt);
+
+    withdrawalId.Should().Be(WithdrawalId);
+    requestId.Should().Be($"{WithdrawalId}-3-1");
+    refundId.Should().Be("rfd_123");
+    attempt.Should().Be(3);
+    outcome.Should().Be(TransferOutcome.Settled);
+  }
+
+  [Theory]
+  [InlineData("SETTLED", TransferOutcome.Settled)]
+  [InlineData("FAILED", TransferOutcome.Failed)]
+  [InlineData("RECEIVED", TransferOutcome.InFlight)]
+  [InlineData("ACCEPTED", TransferOutcome.InFlight)]
+  public void Status_classification(string status, TransferOutcome expected)
+  {
+    var adapter = new AirwallexEventAdapter();
+    var evt = Event("refund.settled", $"{WithdrawalId}-1-0", status);
+
+    var (_, _, _, _, outcome) = adapter.ProcessRefundEvent(evt);
+
+    outcome.Should().Be(expected);
+  }
+
+  [Theory]
+  [InlineData("manual-dashboard-refund")]
+  [InlineData("some_random_id")]
+  [InlineData("")]
+  public void Foreign_request_ids_yield_null_withdrawal(string requestId)
+  {
+    var adapter = new AirwallexEventAdapter();
+    var evt = Event("refund.settled", requestId, "SETTLED");
+
+    var (withdrawalId, _, _, _, _) = adapter.ProcessRefundEvent(evt);
+
+    withdrawalId.Should().BeNull("foreign refunds must be acknowledged and ignored");
+  }
+
+  [Fact]
+  public void Bare_guid_request_id_is_foreign_for_refunds()
+  {
+    // a bare guid is a payment-intent-style id, never a refund fragment id
+    var adapter = new AirwallexEventAdapter();
+    var evt = Event("refund.settled", WithdrawalId.ToString(), "SETTLED");
+
+    var (withdrawalId, _, _, _, _) = adapter.ProcessRefundEvent(evt);
+
+    withdrawalId.Should().BeNull();
+  }
+}

--- a/UnitTest/Withdrawals/CreateWithdrawalReqValidatorTests.cs
+++ b/UnitTest/Withdrawals/CreateWithdrawalReqValidatorTests.cs
@@ -1,0 +1,75 @@
+using App.Modules.Withdrawals.API.V1;
+using FluentAssertions;
+
+namespace UnitTest.Withdrawals;
+
+// PayNowNumber is conditionally required: mandatory (8 digits) for PayNow —
+// including requests that omit Method entirely (rollout compat) — and
+// forbidden for CardRefund.
+public class CreateWithdrawalReqValidatorTests
+{
+  private readonly CreateWithdrawalReqValidator validator = new();
+
+  [Fact]
+  public void Paynow_with_valid_number_passes()
+  {
+    var result = validator.Validate(new CreateWithdrawalReq(100m, "91234567", "PayNow"));
+    result.IsValid.Should().BeTrue();
+  }
+
+  [Fact]
+  public void Omitted_method_defaults_to_paynow_rules()
+  {
+    validator
+      .Validate(new CreateWithdrawalReq(100m, "91234567", null))
+      .IsValid.Should()
+      .BeTrue();
+    validator
+      .Validate(new CreateWithdrawalReq(100m, null, null))
+      .IsValid.Should()
+      .BeFalse("legacy requests still need a PayNow number");
+  }
+
+  [Theory]
+  [InlineData(null)]
+  [InlineData("")]
+  public void Card_refund_without_paynow_number_passes(string? payNow)
+  {
+    var result = validator.Validate(new CreateWithdrawalReq(100m, payNow, "CardRefund"));
+    result.IsValid.Should().BeTrue();
+  }
+
+  [Fact]
+  public void Card_refund_with_paynow_number_is_rejected()
+  {
+    var result = validator.Validate(new CreateWithdrawalReq(100m, "91234567", "CardRefund"));
+    result.IsValid.Should().BeFalse();
+  }
+
+  [Theory]
+  [InlineData("1234567")]
+  [InlineData("123456789")]
+  [InlineData("abcdefgh")]
+  public void Paynow_number_must_be_8_digits(string payNow)
+  {
+    var result = validator.Validate(new CreateWithdrawalReq(100m, payNow, "PayNow"));
+    result.IsValid.Should().BeFalse();
+  }
+
+  [Fact]
+  public void Unknown_method_is_rejected()
+  {
+    var result = validator.Validate(new CreateWithdrawalReq(100m, null, "Cheque"));
+    result.IsValid.Should().BeFalse();
+  }
+
+  [Fact]
+  public void Non_positive_amount_is_rejected()
+  {
+    validator.Validate(new CreateWithdrawalReq(0m, "91234567", "PayNow")).IsValid.Should().BeFalse();
+    validator
+      .Validate(new CreateWithdrawalReq(-5m, "91234567", "PayNow"))
+      .IsValid.Should()
+      .BeFalse();
+  }
+}

--- a/UnitTest/Withdrawals/WithdrawalCardRefundTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalCardRefundTests.cs
@@ -548,6 +548,44 @@ public class WithdrawalCardRefundTests
       .ContainSingle(s => s.Status == WithdrawStatus.RequireManualIntervention);
   }
 
+  // ---- Requeue (money safety on partial settlement) ----
+
+  [Fact]
+  public async Task Requeue_with_settled_fragments_is_refused()
+  {
+    var (h, w) = await ApprovedCardWithdrawal();
+    var id = w.Principal.Id;
+    (await h.Service.SettleRefundFragment(id, $"{id}-1-0", "rf_0", 1)).IsSuccess().Should().BeTrue();
+    (await h.Service.FailRefundFragment(id, $"{id}-1-1", "rf_1", "declined", 1))
+      .IsSuccess()
+      .Should()
+      .BeTrue();
+
+    var result = await h.Service.Requeue(id);
+
+    result.IsSuccess().Should().BeFalse(
+      "money already reached the card via the settled fragment; a fresh attempt would re-plan the full net and pay it twice"
+    );
+    result.FailureOrDefault().Should().BeOfType<InvalidWithdrawalOperationException>();
+    h.Repo.StatusWrites.Should().NotContain(s => s.Status == WithdrawStatus.Pending);
+  }
+
+  [Fact]
+  public async Task Requeue_with_only_failed_fragments_returns_to_pending()
+  {
+    var (h, w) = await ApprovedCardWithdrawal();
+    var id = w.Principal.Id;
+    (await h.Service.FailRefundFragment(id, $"{id}-1-0", "rf_0", "declined", 1))
+      .IsSuccess()
+      .Should()
+      .BeTrue();
+
+    var result = await h.Service.Requeue(id);
+
+    result.IsSuccess().Should().BeTrue("no money left, a fresh automated attempt is safe");
+    h.Repo.StatusWrites.Should().Contain(s => s.Status == WithdrawStatus.Pending);
+  }
+
   [Fact]
   public async Task Failed_fragment_frees_its_claim_on_the_refundable_pool()
   {

--- a/UnitTest/Withdrawals/WithdrawalCardRefundTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalCardRefundTests.cs
@@ -1,0 +1,908 @@
+using CSharp_Result;
+using Domain;
+using Domain.Exceptions;
+using Domain.Transaction;
+using Domain.User;
+using Domain.Wallet;
+using Domain.Withdrawal;
+using FluentAssertions;
+
+namespace UnitTest.Withdrawals;
+
+// The card-refund withdrawal rail: refundable-pool computation, oldest-first
+// fragment planning, approve routing per method, refund webhook transitions
+// and their money-safety invariants. The PayNow rail's regression coverage
+// lives in WithdrawalServiceGuardTests (unchanged).
+public class WithdrawalCardRefundTests
+{
+  private const decimal Amount = 100m;
+  private const decimal Fee = 4m;
+  private const decimal Net = Amount - Fee; // 96
+
+  private static readonly Guid WalletId = Guid.NewGuid();
+
+  // ---- harness ----
+
+  private sealed class Harness
+  {
+    public required WithdrawalService Service { get; init; }
+    public required FakeWithdrawalRepository Repo { get; init; }
+    public required FakeWalletRepository Wallet { get; init; }
+    public required FakeTransactionRepository Txn { get; init; }
+    public required FakeRefundRepository Refunds { get; init; }
+    public required FakeRefundGateway Gateway { get; init; }
+    public required FakePayoutGateway PayNowGateway { get; init; }
+  }
+
+  private static Harness Make(Withdrawal? withdrawal)
+  {
+    var repo = new FakeWithdrawalRepository(withdrawal);
+    var wallet = new FakeWalletRepository(withdrawal);
+    var txn = new FakeTransactionRepository();
+    var refunds = new FakeRefundRepository();
+    var gateway = new FakeRefundGateway();
+    var payNowGateway = new FakePayoutGateway();
+    var service = new WithdrawalService(
+      repo,
+      wallet,
+      txn,
+      new TransactionGenerator(),
+      new FakeWithdrawalStorage(),
+      new PassThroughTransactionManager(),
+      new FourPercentFeeCalculator(),
+      payNowGateway,
+      refunds,
+      gateway
+    );
+    return new Harness
+    {
+      Service = service,
+      Repo = repo,
+      Wallet = wallet,
+      Txn = txn,
+      Refunds = refunds,
+      Gateway = gateway,
+      PayNowGateway = payNowGateway,
+    };
+  }
+
+  private static Withdrawal WithdrawalWith(
+    WithdrawStatus status,
+    WithdrawalMethod method = WithdrawalMethod.CardRefund,
+    WithdrawalPayout? payout = null
+  )
+  {
+    var id = Guid.NewGuid();
+    return new Withdrawal
+    {
+      Principal = new WithdrawalPrincipal
+      {
+        Id = id,
+        CreatedAt = DateTime.UtcNow,
+        Status = new WithdrawalStatus { Status = status },
+        Record = new WithdrawalRecord
+        {
+          Amount = Amount,
+          Method = method,
+          PayNowNumber = method == WithdrawalMethod.PayNow ? "91234567" : null,
+        },
+        Complete = null,
+        Payout = payout,
+      },
+      Wallet = new WalletPrincipal
+      {
+        Id = WalletId,
+        UserId = "user-1",
+        Record = new WalletRecord
+        {
+          Usable = 0m,
+          WithdrawReserve = Amount,
+          BookingReserve = 0m,
+        },
+      },
+      User = new UserPrincipal
+      {
+        Id = "user-1",
+        Record = new UserRecord { Username = "tester" },
+      },
+      Completer = null,
+    };
+  }
+
+  private static FundingPayment Payment(decimal captured, int ageDays, string? intent = null) =>
+    new()
+    {
+      PaymentId = Guid.NewGuid(),
+      PaymentIntentId = intent ?? $"int_{Guid.NewGuid():N}",
+      CreatedAt = DateTime.UtcNow.AddDays(-ageDays),
+      CapturedAmount = captured,
+    };
+
+  // ---- RefundPlanner (pure fragment planning) ----
+
+  [Fact]
+  public void Plan_single_payment_exact_cover()
+  {
+    var p = Refundable(Payment(Net, 10));
+    var plan = RefundPlanner.Plan(Net, [p]);
+
+    plan.IsSuccess().Should().BeTrue();
+    plan.SuccessOrDefault().Should().ContainSingle();
+    plan.SuccessOrDefault()[0].Amount.Should().Be(Net);
+  }
+
+  [Fact]
+  public void Plan_splits_across_payments_oldest_first()
+  {
+    var oldest = Refundable(Payment(50m, 90));
+    var middle = Refundable(Payment(30m, 40));
+    var newest = Refundable(Payment(100m, 5));
+    // deliberately passed out of order — the planner must sort by CreatedAt
+    var plan = RefundPlanner.Plan(Net, [newest, middle, oldest]);
+
+    plan.IsSuccess().Should().BeTrue();
+    var fragments = plan.SuccessOrDefault();
+    fragments.Should().HaveCount(3);
+    fragments[0].Payment.PaymentId.Should().Be(oldest.PaymentId, "oldest payment drains first");
+    fragments[0].Amount.Should().Be(50m);
+    fragments[1].Payment.PaymentId.Should().Be(middle.PaymentId);
+    fragments[1].Amount.Should().Be(30m);
+    fragments[2].Payment.PaymentId.Should().Be(newest.PaymentId);
+    fragments[2].Amount.Should().Be(16m, "only the remainder is taken from the newest");
+  }
+
+  [Fact]
+  public void Plan_short_pool_is_a_distinguishable_error()
+  {
+    var plan = RefundPlanner.Plan(Net, [Refundable(Payment(40m, 10))]);
+
+    plan.IsSuccess().Should().BeFalse();
+    var e = plan.FailureOrDefault().Should().BeOfType<InsufficientRefundablePoolException>().Which;
+    e.Required.Should().Be(Net);
+    e.Available.Should().Be(40m);
+  }
+
+  [Fact]
+  public void Plan_skips_fully_refunded_payments()
+  {
+    var drained = Refundable(Payment(50m, 90)) with { Refundable = 0m };
+    var live = Refundable(Payment(Net, 10));
+    var plan = RefundPlanner.Plan(Net, [drained, live]);
+
+    plan.IsSuccess().Should().BeTrue();
+    plan.SuccessOrDefault().Should().ContainSingle();
+    plan.SuccessOrDefault()[0].Payment.PaymentId.Should().Be(live.PaymentId);
+  }
+
+  private static RefundablePayment Refundable(FundingPayment p) =>
+    new()
+    {
+      PaymentId = p.PaymentId,
+      PaymentIntentId = p.PaymentIntentId,
+      CreatedAt = p.CreatedAt,
+      Refundable = p.CapturedAmount,
+    };
+
+  // ---- Refundable pool ----
+
+  [Fact]
+  public async Task Pool_subtracts_non_failed_fragments_and_respects_the_window()
+  {
+    var w = WithdrawalWith(WithdrawStatus.Pending);
+    var h = Make(w);
+    var inWindow = Payment(100m, 30);
+    var alsoIn = Payment(50m, 179);
+    h.Refunds.FundingPayments = [inWindow, alsoIn];
+    // window filtering happens in the repository (SQL); the fake honors it
+    h.Refunds.OutOfWindowPayments = [Payment(500m, 181)];
+    // 60 already refunded against the first intent (Created counts, Failed
+    // does not — the repository only sums non-Failed rows)
+    h.Refunds.RefundedByPayment[inWindow.PaymentId] = 60m;
+
+    var pool = await h.Service.RefundablePool("user-1");
+
+    pool.IsSuccess().Should().BeTrue();
+    pool.SuccessOrDefault().Should().Be(40m + 50m);
+  }
+
+  // ---- Create (pool pre-check) ----
+
+  [Fact]
+  public async Task Create_card_refund_with_covering_pool_reserves_normally()
+  {
+    var w = WithdrawalWith(WithdrawStatus.Pending);
+    var h = Make(w);
+    h.Refunds.FundingPayments = [Payment(200m, 10)];
+
+    var result = await h.Service.Create(
+      "user-1",
+      new WithdrawalRecord
+      {
+        Amount = Amount,
+        Method = WithdrawalMethod.CardRefund,
+        PayNowNumber = null,
+      }
+    );
+
+    result.IsSuccess().Should().BeTrue();
+    h.Wallet.PrepareWithdrawCalls.Should().Be(1);
+    h.Txn.Records.Should().ContainSingle(r => r.Type == TransactionType.WithdrawRequest);
+  }
+
+  [Fact]
+  public async Task Create_card_refund_with_short_pool_is_rejected_before_reserving()
+  {
+    var w = WithdrawalWith(WithdrawStatus.Pending);
+    var h = Make(w);
+    h.Refunds.FundingPayments = [Payment(10m, 10)];
+
+    var result = await h.Service.Create(
+      "user-1",
+      new WithdrawalRecord
+      {
+        Amount = Amount,
+        Method = WithdrawalMethod.CardRefund,
+        PayNowNumber = null,
+      }
+    );
+
+    result.IsSuccess().Should().BeFalse();
+    result.FailureOrDefault().Should().BeOfType<InsufficientRefundablePoolException>();
+    h.Wallet.PrepareWithdrawCalls.Should().Be(0, "a hopeless request must not lock funds");
+    h.Txn.Records.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task Create_paynow_never_touches_the_pool()
+  {
+    var w = WithdrawalWith(WithdrawStatus.Pending, WithdrawalMethod.PayNow);
+    var h = Make(w);
+    // no funding payments at all — a PayNow create must not care
+
+    var result = await h.Service.Create(
+      "user-1",
+      new WithdrawalRecord
+      {
+        Amount = Amount,
+        Method = WithdrawalMethod.PayNow,
+        PayNowNumber = "91234567",
+      }
+    );
+
+    result.IsSuccess().Should().BeTrue();
+    h.Refunds.PoolQueries.Should().Be(0);
+  }
+
+  // ---- Approve routing ----
+
+  [Fact]
+  public async Task Approve_card_refund_plans_fragments_and_creates_refunds_oldest_first()
+  {
+    var w = WithdrawalWith(WithdrawStatus.Pending);
+    var h = Make(w);
+    var older = Payment(50m, 90, "int_A");
+    var newer = Payment(100m, 5, "int_B");
+    h.Refunds.FundingPayments = [newer, older];
+
+    var result = await h.Service.Approve(w.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    h.Repo.StatusWrites.Should().Contain(s => s.Status == WithdrawStatus.Processing);
+    h.Gateway.Requests.Should().HaveCount(2);
+    h.Gateway.Requests[0].PaymentIntentId.Should().Be("int_A", "oldest payment drains first");
+    h.Gateway.Requests[0].Amount.Should().Be(50m);
+    h.Gateway.Requests[0].RequestId.Should().Be($"{w.Principal.Id}-1-0");
+    h.Gateway.Requests[1].PaymentIntentId.Should().Be("int_B");
+    h.Gateway.Requests[1].Amount.Should().Be(Net - 50m);
+    h.Gateway.Requests[1].RequestId.Should().Be($"{w.Principal.Id}-1-1");
+    // evidence rows persisted with the gateway refund ids
+    h.Refunds.Fragments.Should().HaveCount(2);
+    h.Refunds.Fragments.Should().OnlyContain(f => f.AirwallexRefundId != null);
+    // confirmation number = FIRST fragment's refund id
+    h.Repo.LastPayoutWritten!.ConfirmationNumber
+      .Should()
+      .Be(h.Refunds.Fragments[0].AirwallexRefundId);
+    h.Wallet.WithdrawCalls.Should().Be(0, "no money is collected until settlement");
+    h.PayNowGateway.Requests.Should().BeEmpty("the card rail must never create a transfer");
+  }
+
+  [Fact]
+  public async Task Approve_card_refund_with_shrunken_pool_reverts_to_pending()
+  {
+    // the pool covered the amount at creation but shrank before approval
+    var w = WithdrawalWith(WithdrawStatus.Pending);
+    var h = Make(w);
+    h.Refunds.FundingPayments = [Payment(10m, 10)];
+
+    var result = await h.Service.Approve(w.Principal.Id);
+
+    result.IsSuccess().Should().BeFalse();
+    result.FailureOrDefault().Should().BeOfType<InsufficientRefundablePoolException>();
+    h.Repo.StatusWrites.Select(s => s.Status)
+      .Should()
+      .ContainInOrder(WithdrawStatus.Processing, WithdrawStatus.Pending);
+    h.Gateway.Requests.Should().BeEmpty("no refund may exist when the plan fails");
+    h.Refunds.Fragments.Should().BeEmpty();
+    h.Wallet.WithdrawCalls.Should().Be(0);
+  }
+
+  [Fact]
+  public async Task Approve_paynow_still_routes_to_the_transfer_rail()
+  {
+    var w = WithdrawalWith(WithdrawStatus.Pending, WithdrawalMethod.PayNow);
+    var h = Make(w);
+
+    var result = await h.Service.Approve(w.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    h.PayNowGateway.Requests.Should().ContainSingle();
+    h.PayNowGateway.Requests[0].Amount.Should().Be(Net);
+    h.Gateway.Requests.Should().BeEmpty("PayNow must never create card refunds");
+    h.Refunds.Fragments.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task Approve_card_refund_partial_gateway_failure_stays_processing()
+  {
+    var w = WithdrawalWith(WithdrawStatus.Pending);
+    var h = Make(w);
+    h.Refunds.FundingPayments = [Payment(50m, 90, "int_A"), Payment(100m, 5, "int_B")];
+    h.Gateway.FailFromRequest = 1; // first refund lands, second dies
+
+    var result = await h.Service.Approve(w.Principal.Id);
+
+    result.IsSuccess().Should().BeFalse();
+    h.Repo.StatusWrites.Select(s => s.Status)
+      .Should()
+      .Equal([WithdrawStatus.Processing], "ambiguous mid-fragment failure keeps the claim");
+    h.Refunds.Fragments.Should().HaveCount(2, "the evidence rows precede the gateway calls");
+    h.Refunds.Fragments[0].AirwallexRefundId.Should().NotBeNull();
+    h.Refunds.Fragments[1].AirwallexRefundId.Should().BeNull();
+  }
+
+  [Fact]
+  public async Task Approve_redrive_reuses_existing_fragments_and_request_ids()
+  {
+    // first attempt: fragment 0 created at the gateway, fragment 1 failed to
+    // send; the re-drive must re-send ONLY the unconfirmed fragment with the
+    // SAME request id, never re-plan
+    var w = WithdrawalWith(WithdrawStatus.Pending);
+    var h = Make(w);
+    h.Refunds.FundingPayments = [Payment(50m, 90, "int_A"), Payment(100m, 5, "int_B")];
+    h.Gateway.FailFromRequest = 1;
+    (await h.Service.Approve(w.Principal.Id)).IsSuccess().Should().BeFalse();
+
+    h.Gateway.FailFromRequest = null;
+    var redrive = await h.Service.Approve(w.Principal.Id);
+
+    redrive.IsSuccess().Should().BeTrue();
+    h.Gateway.Requests.Should().HaveCount(3, "2 initial sends + 1 re-send of the failed one");
+    h.Gateway.Requests[2].RequestId
+      .Should()
+      .Be($"{w.Principal.Id}-1-1", "the re-drive reuses attempt 1's deterministic id");
+    h.Refunds.Fragments.Should().HaveCount(2, "no re-planning on re-drive");
+    h.Refunds.Fragments.Should().OnlyContain(f => f.AirwallexRefundId != null);
+    h.Repo.LastPayoutWritten!.ConfirmationNumber
+      .Should()
+      .Be(h.Refunds.Fragments[0].AirwallexRefundId);
+  }
+
+  // ---- SettleRefundFragment (webhook success) ----
+
+  private static WithdrawalPayout Claimed(int attempt = 1) =>
+    new()
+    {
+      ConfirmationNumber = null,
+      Fee = Fee,
+      Attempt = attempt,
+    };
+
+  private async Task<(Harness H, Withdrawal W)> ApprovedCardWithdrawal()
+  {
+    var w = WithdrawalWith(WithdrawStatus.Pending);
+    var h = Make(w);
+    h.Refunds.FundingPayments = [Payment(50m, 90, "int_A"), Payment(100m, 5, "int_B")];
+    var approved = await h.Service.Approve(w.Principal.Id);
+    approved.IsSuccess().Should().BeTrue();
+    return (h, w);
+  }
+
+  [Fact]
+  public async Task Settle_last_fragment_completes_and_books_the_paynow_identical_ledger()
+  {
+    var (h, w) = await ApprovedCardWithdrawal();
+    var id = w.Principal.Id;
+
+    var first = await h.Service.SettleRefundFragment(
+      id,
+      $"{id}-1-0",
+      h.Refunds.Fragments[0].AirwallexRefundId!,
+      1
+    );
+    first.IsSuccess().Should().BeTrue();
+    h.Wallet.WithdrawCalls.Should().Be(0, "money is only collected when ALL fragments settled");
+    h.Repo.StatusWrites.Should().NotContain(s => s.Status == WithdrawStatus.Completed);
+
+    var second = await h.Service.SettleRefundFragment(
+      id,
+      $"{id}-1-1",
+      h.Refunds.Fragments[1].AirwallexRefundId!,
+      1
+    );
+
+    second.IsSuccess().Should().BeTrue();
+    h.Wallet.WithdrawCalls.Should().Be(1);
+    h.Wallet.LastWithdrawAmount.Should().Be(Amount, "the full reserved amount is collected");
+    h.Txn.Records.Should().HaveCount(2, "settlement books the same 2 ledger rows as PayNow");
+    var settleRows = h.Txn.Records;
+    settleRows[0].Type.Should().Be(TransactionType.WithdrawComplete);
+    settleRows[0].Amount.Should().Be(Net);
+    settleRows[1].Type.Should().Be(TransactionType.WithdrawFee);
+    settleRows[1].Amount.Should().Be(Fee);
+    settleRows[1].To.Should().Be(Accounts.WithdrawalFee.DisplayName);
+    h.Repo.StatusWrites.Should().ContainSingle(s => s.Status == WithdrawStatus.Completed);
+    h.Refunds.Fragments.Should().OnlyContain(f => f.Status == RefundFragmentStatus.Settled);
+    h.Refunds.Fragments.Should().OnlyContain(f => f.SettledAt != null);
+  }
+
+  [Fact]
+  public async Task Settle_redelivered_event_acks_without_moving_money_again()
+  {
+    var (h, w) = await ApprovedCardWithdrawal();
+    var id = w.Principal.Id;
+    (await h.Service.SettleRefundFragment(id, $"{id}-1-0", "rf_0", 1)).IsSuccess().Should().BeTrue();
+    (await h.Service.SettleRefundFragment(id, $"{id}-1-1", "rf_1", 1)).IsSuccess().Should().BeTrue();
+    h.Wallet.WithdrawCalls.Should().Be(1);
+
+    var redelivered = await h.Service.SettleRefundFragment(id, $"{id}-1-1", "rf_1", 1);
+
+    redelivered.IsSuccess().Should().BeTrue("gateways redeliver webhooks at least once");
+    h.Wallet.WithdrawCalls.Should().Be(1, "the reserve is collected exactly once");
+    h.Txn.Records.Should().HaveCount(2);
+  }
+
+  [Fact]
+  public async Task Settle_for_superseded_attempt_records_evidence_but_moves_no_money()
+  {
+    var (h, w) = await ApprovedCardWithdrawal();
+    var id = w.Principal.Id;
+    // supersede: pretend a second attempt is now live
+    h.Repo.MutateState(WithdrawStatus.Processing, Claimed(attempt: 2));
+
+    var result = await h.Service.SettleRefundFragment(id, $"{id}-1-0", "rf_stale", 1);
+
+    result.IsSuccess().Should().BeFalse();
+    result.FailureOrDefault().Should().BeOfType<StalePayoutEventException>();
+    h.Wallet.WithdrawCalls.Should().Be(0);
+    // the settlement is real money and must be recorded regardless
+    h.Refunds.Fragments.First(f => f.RequestId == $"{id}-1-0")
+      .Status.Should()
+      .Be(RefundFragmentStatus.Settled, "evidence survives staleness fencing");
+  }
+
+  [Fact]
+  public async Task Settle_of_unknown_fragment_is_stale_not_a_crash()
+  {
+    var (h, w) = await ApprovedCardWithdrawal();
+
+    var result = await h.Service.SettleRefundFragment(
+      w.Principal.Id,
+      $"{w.Principal.Id}-9-7",
+      "rf_x",
+      9
+    );
+
+    result.IsSuccess().Should().BeFalse();
+    result.FailureOrDefault().Should().BeOfType<StalePayoutEventException>();
+    h.Wallet.WithdrawCalls.Should().Be(0);
+  }
+
+  // ---- FailRefundFragment (webhook failure) ----
+
+  [Fact]
+  public async Task Failed_fragment_parks_the_withdrawal_not_pending()
+  {
+    var (h, w) = await ApprovedCardWithdrawal();
+    var id = w.Principal.Id;
+    // sibling settled first: money has partially left
+    (await h.Service.SettleRefundFragment(id, $"{id}-1-0", "rf_0", 1)).IsSuccess().Should().BeTrue();
+
+    var result = await h.Service.FailRefundFragment(id, $"{id}-1-1", "rf_1", "card expired", 1);
+
+    result.IsSuccess().Should().BeTrue();
+    h.Repo.StatusWrites
+      .Should()
+      .ContainSingle(s => s.Status == WithdrawStatus.RequireManualIntervention);
+    h.Repo.StatusWrites
+      .Should()
+      .NotContain(
+        s => s.Status == WithdrawStatus.Pending,
+        "returning to Pending would let a fresh attempt double-refund the settled sibling"
+      );
+    h.Wallet.WithdrawCalls.Should().Be(0);
+    h.Wallet.CancelWithdrawCalls.Should().Be(0, "no automatic refund of the reserve either");
+    // evidence: one settled, one failed
+    h.Refunds.Fragments.First(f => f.RequestId == $"{id}-1-0")
+      .Status.Should()
+      .Be(RefundFragmentStatus.Settled);
+    h.Refunds.Fragments.First(f => f.RequestId == $"{id}-1-1")
+      .Status.Should()
+      .Be(RefundFragmentStatus.Failed);
+  }
+
+  [Fact]
+  public async Task Failed_fragment_redelivery_acks_idempotently()
+  {
+    var (h, w) = await ApprovedCardWithdrawal();
+    var id = w.Principal.Id;
+    (await h.Service.FailRefundFragment(id, $"{id}-1-0", "rf_0", "declined", 1))
+      .IsSuccess()
+      .Should()
+      .BeTrue();
+
+    var redelivered = await h.Service.FailRefundFragment(id, $"{id}-1-0", "rf_0", "declined", 1);
+
+    redelivered.IsSuccess().Should().BeTrue();
+    h.Repo.StatusWrites
+      .Should()
+      .ContainSingle(s => s.Status == WithdrawStatus.RequireManualIntervention);
+  }
+
+  [Fact]
+  public async Task Failed_fragment_frees_its_claim_on_the_refundable_pool()
+  {
+    var (h, w) = await ApprovedCardWithdrawal();
+    var id = w.Principal.Id;
+    (await h.Service.FailRefundFragment(id, $"{id}-1-0", "rf_0", "declined", 1))
+      .IsSuccess()
+      .Should()
+      .BeTrue();
+
+    // pool = 150 captured − 46 still-active fragment (int_B) = 104; the
+    // failed 50 fragment (int_A) no longer counts
+    var pool = await h.Service.RefundablePool("user-1");
+    pool.SuccessOrDefault().Should().Be(150m - (Net - 50m));
+  }
+
+  // ---- fakes ----
+
+  private sealed class PassThroughTransactionManager : ITransactionManager
+  {
+    public Task<Result<T>> Start<T>(Func<Task<Result<T>>> func) => func();
+  }
+
+  private sealed class FourPercentFeeCalculator : IFeeCalculator
+  {
+    public Task<Result<FeeSpec>> Current(FeeType type) =>
+      Task.FromResult<Result<FeeSpec>>(new FeeSpec { Percentage = 4m, FlatAmount = 0m });
+
+    public Task<Result<decimal>> Compute(FeeType type, decimal amount) =>
+      Task.FromResult<Result<decimal>>(Math.Round(amount * 0.04m, 2, MidpointRounding.ToEven));
+  }
+
+  private sealed class FakeWithdrawalStorage : IWithdrawalStorage
+  {
+    public Task<Result<string>> Save(Stream stream) =>
+      Task.FromResult((Result<string>)"receipt-key");
+
+    public Task<Result<string>> Get(string key) => Task.FromResult((Result<string>)"url");
+  }
+
+  private sealed class FakeRefundGateway : IRefundGateway
+  {
+    public List<RefundRequest> Requests { get; } = [];
+
+    // fail every request whose ordinal (0-based, across the whole test) is
+    // >= this value; null = all succeed
+    public int? FailFromRequest { get; set; }
+
+    private int counter;
+
+    public Task<Result<RefundConfirmation>> CreateRefund(RefundRequest request)
+    {
+      var ordinal = this.counter++;
+      Requests.Add(request);
+      if (FailFromRequest != null && ordinal >= FailFromRequest)
+        return Task.FromResult<Result<RefundConfirmation>>(
+          new HttpRequestException("gateway timeout")
+        );
+      return Task.FromResult<Result<RefundConfirmation>>(
+        new RefundConfirmation { Id = $"rf_{request.RequestId}" }
+      );
+    }
+
+    // reconciliation lookups are not exercised in this suite
+    public Task<Result<PayoutStatus>> GetRefundStatus(string refundId) =>
+      throw new NotImplementedException();
+  }
+
+  private sealed class FakeRefundRepository : IWithdrawalRefundRepository
+  {
+    public List<FundingPayment> FundingPayments { get; set; } = [];
+    public List<FundingPayment> OutOfWindowPayments { get; set; } = [];
+
+    // pre-existing refunds against a payment (e.g. from other withdrawals)
+    public Dictionary<Guid, decimal> RefundedByPayment { get; } = [];
+
+    public List<WithdrawalRefundFragment> Fragments { get; } = [];
+
+    public int PoolQueries { get; private set; }
+
+    public Task<Result<List<FundingPayment>>> ListFundingPayments(Guid walletId, DateTime since)
+    {
+      PoolQueries++;
+      var all = FundingPayments.Concat(OutOfWindowPayments);
+      return Task.FromResult<Result<List<FundingPayment>>>(
+        all.Where(p => p.CreatedAt >= since).OrderBy(p => p.CreatedAt).ToList()
+      );
+    }
+
+    public Task<Result<Dictionary<Guid, decimal>>> SumActiveRefundsByPayment(
+      IEnumerable<Guid> paymentIds
+    )
+    {
+      var ids = paymentIds.ToHashSet();
+      var sums = new Dictionary<Guid, decimal>();
+      foreach (var (paymentId, amount) in RefundedByPayment)
+        if (ids.Contains(paymentId))
+          sums[paymentId] = sums.GetValueOrDefault(paymentId) + amount;
+      foreach (
+        var f in Fragments.Where(f =>
+          ids.Contains(f.PaymentId) && f.Status != RefundFragmentStatus.Failed
+        )
+      )
+        sums[f.PaymentId] = sums.GetValueOrDefault(f.PaymentId) + f.Amount;
+      return Task.FromResult<Result<Dictionary<Guid, decimal>>>(sums);
+    }
+
+    public Task<Result<List<WithdrawalRefundFragment>>> ListByWithdrawal(Guid withdrawalId) =>
+      Task.FromResult<Result<List<WithdrawalRefundFragment>>>(
+        Fragments
+          .Where(f => f.WithdrawalId == withdrawalId)
+          .OrderBy(f => f.RequestId, StringComparer.Ordinal)
+          .ToList()
+      );
+
+    public Task<Result<WithdrawalRefundFragment?>> GetByRequestId(string requestId) =>
+      Task.FromResult<Result<WithdrawalRefundFragment?>>(
+        Fragments.FirstOrDefault(f => f.RequestId == requestId)
+      );
+
+    public Task<Result<List<WithdrawalRefundFragment>>> CreateMany(
+      IEnumerable<WithdrawalRefundFragment> fragments
+    )
+    {
+      var list = fragments.ToList();
+      Fragments.AddRange(list);
+      return Task.FromResult<Result<List<WithdrawalRefundFragment>>>(list);
+    }
+
+    public Task<Result<WithdrawalRefundFragment?>> Update(
+      Guid id,
+      RefundFragmentStatus? status,
+      string? airwallexRefundId,
+      DateTime? settledAt
+    )
+    {
+      var idx = Fragments.FindIndex(f => f.Id == id);
+      if (idx < 0)
+        return Task.FromResult<Result<WithdrawalRefundFragment?>>(
+          (WithdrawalRefundFragment?)null
+        );
+      var updated = Fragments[idx] with
+      {
+        Status = status ?? Fragments[idx].Status,
+        AirwallexRefundId = airwallexRefundId ?? Fragments[idx].AirwallexRefundId,
+        SettledAt = settledAt ?? Fragments[idx].SettledAt,
+      };
+      Fragments[idx] = updated;
+      return Task.FromResult<Result<WithdrawalRefundFragment?>>(updated);
+    }
+  }
+
+  private sealed class FakePayoutGateway : IPayoutGateway
+  {
+    public List<PayoutRequest> Requests { get; } = [];
+
+    public Task<Result<PayoutConfirmation>> CreatePayout(PayoutRequest request)
+    {
+      Requests.Add(request);
+      return Task.FromResult<Result<PayoutConfirmation>>(
+        new PayoutConfirmation { Id = "transfer-1" }
+      );
+    }
+
+    public Task<Result<PayoutStatus>> GetPayoutStatus(
+      string requestId,
+      string? confirmationNumber
+    ) => throw new NotImplementedException();
+  }
+
+  private sealed class FakeWithdrawalRepository(Withdrawal? withdrawal) : IWithdrawalRepository
+  {
+    private WithdrawStatus? current;
+    private WithdrawalPayout? currentPayout = withdrawal?.Principal.Payout;
+    private bool payoutTouched;
+
+    public List<WithdrawalStatus> StatusWrites { get; } = [];
+    public WithdrawalPayout? LastPayoutWritten { get; private set; }
+    public WithdrawalComplete? LastCompleteWritten { get; private set; }
+
+    public void MutateState(WithdrawStatus status, WithdrawalPayout? payout)
+    {
+      current = status;
+      currentPayout = payout;
+      payoutTouched = true;
+      LastPayoutWritten = payout;
+    }
+
+    public Task<Result<Withdrawal?>> Get(Guid id, string? userId)
+    {
+      if (withdrawal == null)
+        return Task.FromResult((Result<Withdrawal?>)(Withdrawal?)null);
+      var status =
+        current == null
+          ? withdrawal.Principal.Status
+          : withdrawal.Principal.Status with
+          {
+            Status = current.Value,
+          };
+      var w = withdrawal with
+      {
+        Principal = withdrawal.Principal with
+        {
+          Status = status,
+          Payout = payoutTouched ? currentPayout : withdrawal.Principal.Payout,
+        },
+      };
+      return Task.FromResult((Result<Withdrawal?>)w);
+    }
+
+    public Task<Result<WithdrawalPrincipal?>> Update(
+      string? userId,
+      Guid id,
+      WithdrawalRecord? record,
+      WithdrawalStatus? status,
+      WithdrawalComplete? complete,
+      WithdrawalPayout? payout = null
+    )
+    {
+      if (status != null)
+      {
+        StatusWrites.Add(status);
+        current = status.Status;
+      }
+      if (payout != null)
+      {
+        LastPayoutWritten = payout;
+        currentPayout = payout;
+        payoutTouched = true;
+      }
+      if (complete != null)
+        LastCompleteWritten = complete;
+      var principal = withdrawal!.Principal with
+      {
+        Status = status ?? withdrawal.Principal.Status,
+        Payout = payout ?? currentPayout ?? withdrawal.Principal.Payout,
+        Complete = complete ?? withdrawal.Principal.Complete,
+      };
+      return Task.FromResult((Result<WithdrawalPrincipal?>)principal);
+    }
+
+    public Task<Result<IEnumerable<WithdrawalPrincipal>>> Search(WithdrawalSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WithdrawalPrincipal>> Create(Guid walletId, WithdrawalRecord record) =>
+      Task.FromResult(
+        (Result<WithdrawalPrincipal>)(
+          withdrawal!.Principal with
+          {
+            Record = record,
+          }
+        )
+      );
+
+    public Task<Result<Unit?>> Delete(Guid id) => throw new NotImplementedException();
+  }
+
+  private sealed class FakeWalletRepository(Withdrawal? withdrawal) : IWalletRepository
+  {
+    public int WithdrawCalls { get; private set; }
+    public int CancelWithdrawCalls { get; private set; }
+    public int PrepareWithdrawCalls { get; private set; }
+    public decimal? LastWithdrawAmount { get; private set; }
+
+    private static WalletPrincipal Wallet(Guid id) =>
+      new()
+      {
+        Id = id,
+        UserId = "user-1",
+        Record = new WalletRecord
+        {
+          Usable = 200m,
+          WithdrawReserve = 0m,
+          BookingReserve = 0m,
+        },
+      };
+
+    public Task<Result<Wallet?>> GetByUserId(string userId) =>
+      Task.FromResult(
+        (Result<Wallet?>)
+          new Wallet
+          {
+            Principal = withdrawal?.Wallet ?? Wallet(WalletId),
+            User = new UserPrincipal
+            {
+              Id = "user-1",
+              Record = new UserRecord { Username = "tester" },
+            },
+          }
+      );
+
+    public Task<Result<WalletPrincipal?>> Withdraw(Guid id, decimal amount)
+    {
+      WithdrawCalls++;
+      LastWithdrawAmount = amount;
+      return Task.FromResult((Result<WalletPrincipal?>)Wallet(id));
+    }
+
+    public Task<Result<WalletPrincipal?>> CancelWithdraw(Guid id, decimal amount)
+    {
+      CancelWithdrawCalls++;
+      return Task.FromResult((Result<WalletPrincipal?>)Wallet(id));
+    }
+
+    public Task<Result<WalletPrincipal?>> PrepareWithdraw(Guid id, decimal amount)
+    {
+      PrepareWithdrawCalls++;
+      return Task.FromResult((Result<WalletPrincipal?>)Wallet(id));
+    }
+
+    public Task<Result<IEnumerable<WalletPrincipal>>> Search(WalletSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Wallet?>> Get(Guid id, string? userId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WalletPrincipal?>> Deposit(Guid id, decimal amount) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WalletPrincipal?>> Collect(Guid id, decimal amount) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WalletPrincipal?>> BookStart(Guid id, decimal amount) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WalletPrincipal?>> BookEnd(Guid id, decimal revert, decimal collect) =>
+      throw new NotImplementedException();
+  }
+
+  private sealed class FakeTransactionRepository : ITransactionRepository
+  {
+    public List<TransactionRecord> Records { get; } = [];
+
+    public Task<Result<TransactionPrincipal>> Create(
+      Guid walletId,
+      TransactionRecord record,
+      Guid? paymentId = null
+    )
+    {
+      Records.Add(record);
+      var principal = new TransactionPrincipal
+      {
+        Id = Guid.NewGuid(),
+        CreatedAt = DateTime.UtcNow,
+        Record = record,
+      };
+      return Task.FromResult((Result<TransactionPrincipal>)principal);
+    }
+
+    public Task<Result<IEnumerable<TransactionPrincipal>>> Search(TransactionSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Transaction?>> Get(Guid id, string? userId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Unit?>> Delete(Guid id) => throw new NotImplementedException();
+  }
+}

--- a/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
@@ -45,7 +45,9 @@ public class WithdrawalServiceGuardTests
       new FakeWithdrawalStorage(),
       new PassThroughTransactionManager(),
       new FourPercentFeeCalculator(),
-      gateway
+      gateway,
+      new UnusedRefundRepository(),
+      new UnusedRefundGateway()
     );
     return (service, repo, wallet, txn, gateway);
   }
@@ -63,7 +65,12 @@ public class WithdrawalServiceGuardTests
         Id = id,
         CreatedAt = DateTime.UtcNow,
         Status = new WithdrawalStatus { Status = status },
-        Record = new WithdrawalRecord { Amount = Amount, PayNowNumber = "91234567" },
+        Record = new WithdrawalRecord
+        {
+          Amount = Amount,
+          Method = WithdrawalMethod.PayNow,
+          PayNowNumber = "91234567",
+        },
         Complete = null,
         Payout = payout,
       },
@@ -794,6 +801,43 @@ public class WithdrawalServiceGuardTests
   }
 
   // ---- fakes ----
+
+  // the PayNow rail must never touch the card-refund collaborators
+  private sealed class UnusedRefundRepository : IWithdrawalRefundRepository
+  {
+    public Task<Result<List<FundingPayment>>> ListFundingPayments(Guid walletId, DateTime since) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Dictionary<Guid, decimal>>> SumActiveRefundsByPayment(
+      IEnumerable<Guid> paymentIds
+    ) => throw new NotImplementedException();
+
+    public Task<Result<List<WithdrawalRefundFragment>>> ListByWithdrawal(Guid withdrawalId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WithdrawalRefundFragment?>> GetByRequestId(string requestId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<List<WithdrawalRefundFragment>>> CreateMany(
+      IEnumerable<WithdrawalRefundFragment> fragments
+    ) => throw new NotImplementedException();
+
+    public Task<Result<WithdrawalRefundFragment?>> Update(
+      Guid id,
+      RefundFragmentStatus? status,
+      string? airwallexRefundId,
+      DateTime? settledAt
+    ) => throw new NotImplementedException();
+  }
+
+  private sealed class UnusedRefundGateway : IRefundGateway
+  {
+    public Task<Result<RefundConfirmation>> CreateRefund(RefundRequest request) =>
+      throw new NotImplementedException();
+
+    public Task<Result<PayoutStatus>> GetRefundStatus(string refundId) =>
+      throw new NotImplementedException();
+  }
 
   private sealed class PassThroughTransactionManager : ITransactionManager
   {

--- a/infra/api_chart/app/schema.json
+++ b/infra/api_chart/app/schema.json
@@ -57,6 +57,9 @@
     },
     "Smtp": {
       "$ref": "#/definitions/Smtp"
+    },
+    "Withdrawal": {
+      "$ref": "#/definitions/Withdrawal"
     }
   },
   "definitions": {
@@ -1366,6 +1369,22 @@
               "format": "int32"
             }
           }
+        }
+      }
+    },
+    "Withdrawal": {
+      "title": "WithdrawalOption",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "RefundWindowDays"
+      ],
+      "properties": {
+        "RefundWindowDays": {
+          "type": "integer",
+          "format": "int32",
+          "maximum": 3650.0,
+          "minimum": 1.0
         }
       }
     }

--- a/infra/api_chart/app/settings.yaml
+++ b/infra/api_chart/app/settings.yaml
@@ -193,6 +193,11 @@ Terminator:
 Recovery:
   MaxRetries: 10
 
+# card-refund withdrawals: how far back (days) a captured card payment still
+# counts toward the refundable pool
+Withdrawal:
+  RefundWindowDays: 180
+
 Smtp:
   TRANSACTIONAL:
     Host: smtp.larksuite.com

--- a/infra/migration_chart/app/schema.json
+++ b/infra/migration_chart/app/schema.json
@@ -57,6 +57,9 @@
     },
     "Smtp": {
       "$ref": "#/definitions/Smtp"
+    },
+    "Withdrawal": {
+      "$ref": "#/definitions/Withdrawal"
     }
   },
   "definitions": {
@@ -1366,6 +1369,22 @@
               "format": "int32"
             }
           }
+        }
+      }
+    },
+    "Withdrawal": {
+      "title": "WithdrawalOption",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "RefundWindowDays"
+      ],
+      "properties": {
+        "RefundWindowDays": {
+          "type": "integer",
+          "format": "int32",
+          "maximum": 3650.0,
+          "minimum": 1.0
         }
       }
     }

--- a/infra/migration_chart/app/settings.yaml
+++ b/infra/migration_chart/app/settings.yaml
@@ -193,6 +193,11 @@ Terminator:
 Recovery:
   MaxRetries: 10
 
+# card-refund withdrawals: how far back (days) a captured card payment still
+# counts toward the refundable pool
+Withdrawal:
+  RefundWindowDays: 180
+
 Smtp:
   TRANSACTIONAL:
     Host: smtp.larksuite.com


### PR DESCRIPTION
## Design summary

Adds a second withdrawal payout rail. A withdrawal now carries a **Method** — `PayNow` (existing transfer rail, unchanged) or `CardRefund`. For card withdrawals, the net amount (gross − the unchanged 4% withdrawal fee) is returned as **Airwallex card refunds against the captured payments that funded the wallet**, walked **oldest-first** within a configurable window (`Withdrawal:RefundWindowDays`, default 180).

### Refundable pool
`pool = Σ over captured Airwallex payments (Status=SUCCEEDED, CreatedAt ≥ now−window) of (CapturedAmount − Σ non-Failed refund fragments against that payment)`. Checked **before reserving** at Create (hopeless requests never lock funds) and **re-checked at Approve** (the pool may have shrunk); a short pool at approve reverts the claim Processing→Pending and returns a distinguishable `409 insufficient_refundable_pool` (Required/Available in the body) — a sweep sees a failure and moves on, no hot loop.

### Approve (card path)
1. Same phase-1 claim as PayNow (Pending→Processing, fee snapshot, attempt++).
2. Plan fragments oldest-first; persist evidence rows **before any gateway call** with deterministic request ids `"{withdrawalId}-{attempt}-{index}"`.
3. One `POST /api/v1/pa/refunds/create` per fragment (reason "BunnyBooker Withdrawal", idempotent per request id). Any failure mid-fragmenting leaves the withdrawal Processing; a re-drive reuses the existing rows and re-sends identical request ids, so the gateway's idempotency collapses retries — never double-refunds.
4. `ConfirmationNumber` = **first fragment's refund id** (written only once all fragments hold refund ids); remaining ids live on the evidence rows.

### Settlement (refund.* webhooks: received / accepted / settled / failed)
- Fragment **settled** → evidence recorded first (survives staleness fencing), and when **all** fragments of the current attempt are settled: reserve collected once, `WithdrawComplete` (net) + `WithdrawalFee` ledger rows — money model identical to PayNow.
- Fragment **failed** → withdrawal parks **RequireManualIntervention** (never back to Pending: sibling refunds may already have settled, money has partially left). The evidence rows show the admin exactly which refunds settled/failed/are in flight.
- Foreign request ids (dashboard-issued refunds) are acknowledged and ignored; stale/superseded-attempt events fence exactly like the transfer rail.
- Reconcile now polls pending fragments via `GET /api/v1/pa/refunds/{id}`, delegating to the same webhook transitions, under the existing 8-sweep RMI cap.

## Endpoints
- `POST api/v1/Withdrawal/{userId}` — accepts `Method` (`"PayNow"` default when omitted / `"CardRefund"`); `PayNowNumber` required for PayNow, must be empty for CardRefund.
- `GET api/v1/Withdrawal/refundable/{userId}` — `{ pool, windowDays }` (owner or field/admin) for the argon "up to $X refundable via card" display.
- `GET api/v1/Withdrawal/{id}` — response now carries `refunds`: per fragment `paymentIntentId`, `airwallexRefundId`, `amount`, `status`, `createdAt`, `settledAt`. Same visibility as the withdrawal detail itself (owner or field/admin) — this is the user-facing evidence of where the money went.
- `Record` in responses now carries `method`; `payNowNumber` is nullable.

## Migration
`20260711203552_AddWithdrawalMethodAndRefundFragments`
- `Withdrawals.Method` smallint NOT NULL DEFAULT 0 — **existing rows are PayNow**.
- New `WithdrawalRefunds` table (evidence + per-intent refunded ledger); unique index on `RequestId`, indexes on `WithdrawalId` and `PaymentId`.

## Evidence model
`WithdrawalRefundData`: Id, WithdrawalId FK, PaymentId FK, PaymentIntentId (denormalized), AirwallexRefundId, RequestId (unique), Amount (16,8), Status (Created/Settled/Failed), CreatedAt, SettledAt. Rows double as the refunded-so-far ledger the pool computation subtracts (non-Failed rows across all withdrawals).

## Choices made
- Confirmation number = first refund id; the fragments carry the rest (a comma-joined list would overflow the 64-char column and duplicates the evidence table).
- Failed fragment ⇒ RMI, never Pending (documented money-safety invariant).
- Requeue of a parked card withdrawal is REFUSED once any fragment settled: money partially reached the card while the reserve was never collected, so a fresh attempt would re-plan the full net and double-pay — such cases are resolved manually. Only-failed fragments still requeue normally.
- Pool check at Create uses the fee rate current at that moment; approve re-plans with the snapshot fee.
- New `refund.*` statuses classified as SETTLED/SUCCEEDED = settled, FAILED/CANCELLED = failed, RECEIVED/ACCEPTED = in flight.

## Rollout
- argon UI + tin unchanged; existing withdrawals default to PayNow; requests without `Method` behave exactly as before.
- Card path goes live once argon ships the method selector. The approve endpoint stays AdminOrTin and assumes no particular caller — with tin's nightly sweep disabled by config (separate tin/infra change), an admin clicking Approve drives the card refund interactively with identical semantics.

## Tests
47 new unit tests (411 total, all green): pool computation (window edge, fragment subtraction, failed-fragment release), planner (exact cover, multi-intent oldest-first split, short pool), approve routing per method (incl. shrunken-pool revert, partial-failure re-drive with identical request ids), refund webhook transitions (all-settled→Completed with correct ledger, one-failed→RMI, idempotent redelivery, superseded-attempt fencing), requeue money-safety guard, webhook adapter parsing, validator conditional rules, and the untouched PayNow regression suite.
