### PR TITLE
feat(analysis): sales analysis endpoints and priority boost targeting

### DIFF
--- a/App/Migrations/20260712005801_AddPriorityTargets.Designer.cs
+++ b/App/Migrations/20260712005801_AddPriorityTargets.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using App.StartUp.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace App.Migrations
 {
     [DbContext(typeof(MainDbContext))]
-    partial class MainDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260712005801_AddPriorityTargets")]
+    partial class AddPriorityTargets
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/App/Migrations/20260712005801_AddPriorityTargets.cs
+++ b/App/Migrations/20260712005801_AddPriorityTargets.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace App.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPriorityTargets : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AccessTarget",
+                table: "PrioritySettings",
+                type: "jsonb",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "FreeTarget",
+                table: "PrioritySettings",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AccessTarget",
+                table: "PrioritySettings");
+
+            migrationBuilder.DropColumn(
+                name: "FreeTarget",
+                table: "PrioritySettings");
+        }
+    }
+}

--- a/App/Modules/Bookings/API/V1/BookingController.cs
+++ b/App/Modules/Bookings/API/V1/BookingController.cs
@@ -32,6 +32,7 @@ public class BookingController(
   SetPrioritySettingsReqValidator setPrioritySettingsReqValidator,
   IPrioritySettingsRepository prioritySettingsRepo,
   IPriorityAccessRepository priorityAccessRepo,
+  IBookingAnalysisRepository analysisRepo,
   IUserService userService,
   IOptions<TerminatorOption> terminatorOptions,
   IOptions<RecoveryOption> recoveryOptions,
@@ -107,6 +108,23 @@ public class BookingController(
       .ValidateAsyncResult(query, "Invalid BookingStatsQueryReq")
       .ThenAwait(q => service.Stats(q.ToDomain()))
       .Then(rows => rows.Select(r => r.ToRes()), Errors.MapAll);
+    return this.ReturnResult(x);
+  }
+
+  // sales/revenue analysis for the admin Analysis page: per SGT-day rows of
+  // completed tickets + gross revenue, plus a range summary (deposits
+  // captured and BunnyBooker's internal fees). GROSS only — Airwallex's own
+  // gateway fees are not stored anywhere.
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("analysis")]
+  public async Task<ActionResult<BookingAnalysisRes>> Analysis(
+    [FromQuery] BookingAnalysisQueryReq query,
+    [FromServices] BookingAnalysisQueryReqValidator analysisValidator
+  )
+  {
+    var x = await analysisValidator
+      .ValidateAsyncResult(query, "Invalid BookingAnalysisQueryReq")
+      .ThenAwait(q => analysisRepo.Analyze(q.ToDomain()))
+      .Then(a => a.ToRes(), Errors.MapAll);
     return this.ReturnResult(x);
   }
 
@@ -462,13 +480,19 @@ public class BookingController(
     );
   }
 
-  // may the CALLING user prioritize a booking right now, and at what fee —
-  // powers the prioritize button on the booking page
+  // may the CALLING user prioritize a booking right now, at what fee, and
+  // free for them — powers the prioritize button on the booking page. The
+  // caller IS the target, so their JWT roles are authoritative for the
+  // free/access targeting (∪ ExtraRoles happens in the domain, exactly like
+  // pricing)
   [Authorize, HttpGet("priority/eligibility")]
   public async Task<ActionResult<PriorityEligibilityRes>> PriorityEligibility()
   {
     var sub = this.Sub()!;
-    var x = await service.PriorityEligibility(sub).Then(e => e.ToRes(), Errors.MapNone);
+    var tokenRoles = helper.FieldToScope(this.HttpContext.User, AuthRoles.Field).ToArray();
+    var x = await service
+      .PriorityEligibility(sub, tokenRoles)
+      .Then(e => e.ToRes(), Errors.MapNone);
     return this.ReturnResult(x);
   }
 

--- a/App/Modules/Bookings/API/V1/BookingMapper.cs
+++ b/App/Modules/Bookings/API/V1/BookingMapper.cs
@@ -1,3 +1,4 @@
+using App.Modules.Discounts.API.V1;
 using App.Modules.Passengers.API.V1;
 using App.Modules.Timings.API.V1;
 using App.Modules.Users.API.V1;
@@ -85,6 +86,35 @@ public static class BookingMapper
   public static BookingStatsQuery ToDomain(this BookingStatsQueryReq req) =>
     new() { After = req.After?.ToDate(), Before = req.Before?.ToDate() };
 
+  // Sales/revenue analysis
+  public static BookingAnalysisQuery ToDomain(this BookingAnalysisQueryReq req) =>
+    new() { After = req.After?.ToDate(), Before = req.Before?.ToDate() };
+
+  public static BookingAnalysisRowRes ToRes(this BookingAnalysisRow r) =>
+    new(
+      r.Date.ToStandardDateFormat(),
+      r.Direction.ToRes(),
+      r.Time.ToStandardTimeFormat(),
+      r.TicketsCompleted,
+      r.GrossRevenue
+    );
+
+  public static BookingAnalysisRes ToRes(this BookingAnalysis a) =>
+    new(
+      a.Rows.Select(r => r.ToRes()),
+      new BookingAnalysisSummaryRes(
+        a.Summary.TotalTickets,
+        a.Summary.TotalGross,
+        new DepositSummaryRes(a.Summary.Deposits.Count, a.Summary.Deposits.Captured),
+        new InternalFeesRes(
+          a.Summary.InternalFees.Deposit,
+          a.Summary.InternalFees.Withdrawal,
+          a.Summary.InternalFees.Priority,
+          a.Summary.InternalFees.Termination
+        )
+      )
+    );
+
   // REQ -> DOMAIN
   public static BookingCountSearch ToDomain(this BookingCountQuery q) =>
     new() { Date = q.Date.ToDate(), Direction = q.Direction.DirectionToDomain() };
@@ -164,19 +194,21 @@ public static class BookingMapper
       _ => throw new ArgumentOutOfRangeException(nameof(sort), sort, null),
     };
 
-  // Priority queue
+  // Priority queue (target shapes reuse the Discounts API mapper)
   public static PrioritySettingsRes ToRes(this PrioritySettingsRecord r) =>
     new(
       r.Fee,
       r.AllowAll,
       r.WindowStartSgt?.ToStandardTimeFormat(),
-      r.WindowEndSgt?.ToStandardTimeFormat()
+      r.WindowEndSgt?.ToStandardTimeFormat(),
+      r.FreeTarget?.ToRes(),
+      r.AccessTarget?.ToRes()
     );
 
   public static PriorityAccessRes ToRes(this PriorityAccess a) => new(a.UserId, a.CreatedAt);
 
   public static PriorityEligibilityRes ToRes(this PriorityEligibility e) =>
-    new(e.Eligible, e.Fee);
+    new(e.Eligible, e.Fee, e.Free);
 
   public static PrioritySettingsRecord ToDomain(this SetPrioritySettingsReq req) =>
     new()
@@ -185,5 +217,7 @@ public static class BookingMapper
       AllowAll = req.AllowAll,
       WindowStartSgt = req.WindowStartSgt?.ToTime(),
       WindowEndSgt = req.WindowEndSgt?.ToTime(),
+      FreeTarget = req.FreeTarget?.ToDomain(),
+      AccessTarget = req.AccessTarget?.ToDomain(),
     };
 }

--- a/App/Modules/Bookings/API/V1/BookingModel.cs
+++ b/App/Modules/Bookings/API/V1/BookingModel.cs
@@ -1,3 +1,4 @@
+using App.Modules.Discounts.API.V1;
 using App.Modules.Users.API.V1;
 
 namespace App.Modules.Bookings.API.V1;
@@ -20,6 +21,10 @@ public record SearchBookingQuery(
 );
 
 public record BookingStatsQueryReq(string? After, string? Before);
+
+// sales/revenue analysis range (dd-MM-yyyy, inclusive SGT dates; null =
+// unbounded) — the admin Analysis page source
+public record BookingAnalysisQueryReq(string? After, string? Before);
 
 public record ReserveBookingQuery(string Date, string Direction, string Time);
 
@@ -93,6 +98,42 @@ public record BookingQueuePositionRes(string Status, int? Position, int? Total);
 // RefValid = that key resolves to a real object in block storage
 public record BookingTicketHealthRes(bool HasRef, bool RefValid);
 
+// Sales/revenue analysis. GROSS figures + BunnyBooker's internal fees only:
+// Airwallex's own gateway fees are not stored anywhere (no API for them yet).
+// Rows bucket completed bookings by the SGT calendar date of CompletedAt
+// (same wall-clock convention as booking_stats), direction and departure
+// time; GrossRevenue = the booking cost collected at completion.
+public record BookingAnalysisRowRes(
+  string Date,
+  string Direction,
+  string Time,
+  int TicketsCompleted,
+  decimal GrossRevenue
+);
+
+public record DepositSummaryRes(int Count, decimal Captured);
+
+// Priority is NET (charges minus refunds); Termination = collected cost of
+// terminated bookings minus what was refunded
+public record InternalFeesRes(
+  decimal Deposit,
+  decimal Withdrawal,
+  decimal Priority,
+  decimal Termination
+);
+
+public record BookingAnalysisSummaryRes(
+  int TotalTickets,
+  decimal TotalGross,
+  DepositSummaryRes Deposits,
+  InternalFeesRes InternalFees
+);
+
+public record BookingAnalysisRes(
+  IEnumerable<BookingAnalysisRowRes> Rows,
+  BookingAnalysisSummaryRes Summary
+);
+
 public record BookingStatRes(
   string DayOfWeek,
   string Time,
@@ -114,11 +155,17 @@ public record BookingStatRes(
 // REQ: replace the priority settings (insert-only latest, like Cost).
 // Window times are SGT HH:mm:ss; both null = always available; start > end
 // wraps midnight. Fee 0 disables charging (prioritizing stays free).
+// FreeTarget/AccessTarget use the SAME shape as the Discounts API targets:
+// FreeTarget = who boosts free (fee 0, no ledger row); AccessTarget = who may
+// prioritize at all — when set it takes precedence over AllowAll/the
+// allowlist; null keeps legacy behavior.
 public record SetPrioritySettingsReq(
   decimal Fee,
   bool AllowAll,
   string? WindowStartSgt,
-  string? WindowEndSgt
+  string? WindowEndSgt,
+  DiscountTargetReq? FreeTarget = null,
+  DiscountTargetReq? AccessTarget = null
 );
 
 // RESP
@@ -126,10 +173,13 @@ public record PrioritySettingsRes(
   decimal Fee,
   bool AllowAll,
   string? WindowStartSgt,
-  string? WindowEndSgt
+  string? WindowEndSgt,
+  DiscountTargetRes? FreeTarget,
+  DiscountTargetRes? AccessTarget
 );
 
 public record PriorityAccessRes(string UserId, DateTime CreatedAt);
 
-// may the calling user prioritize right now, and at what fee
-public record PriorityEligibilityRes(bool Eligible, decimal Fee);
+// may the calling user prioritize right now, at what fee, and free for them
+// (Free => Fee is 0)
+public record PriorityEligibilityRes(bool Eligible, decimal Fee, bool Free);

--- a/App/Modules/Bookings/API/V1/BookingValidator.cs
+++ b/App/Modules/Bookings/API/V1/BookingValidator.cs
@@ -1,3 +1,4 @@
+using App.Modules.Discounts.API.V1;
 using App.Utility;
 using Domain.Booking;
 using FluentValidation;
@@ -91,6 +92,15 @@ public class BookingStatsQueryReqValidator : AbstractValidator<BookingStatsQuery
   }
 }
 
+public class BookingAnalysisQueryReqValidator : AbstractValidator<BookingAnalysisQueryReq>
+{
+  public BookingAnalysisQueryReqValidator()
+  {
+    this.RuleFor(x => x.After).NullableDateValid();
+    this.RuleFor(x => x.Before).NullableDateValid();
+  }
+}
+
 public class BookingCountQueryValidator : AbstractValidator<BookingCountQuery>
 {
   public BookingCountQueryValidator()
@@ -124,5 +134,12 @@ public class SetPrioritySettingsReqValidator : AbstractValidator<SetPrioritySett
     this.RuleFor(x => x.WindowEndSgt)
       .Must((req, x) => (x == null) == (req.WindowStartSgt == null))
       .WithMessage("WindowStartSgt and WindowEndSgt must be set together (or both omitted)");
+    // targets reuse the Discounts API shapes and validation; null = omitted
+    this.RuleFor(x => x.FreeTarget)!
+      .SetValidator(new DiscountTargetReqValidator()!)
+      .When(x => x.FreeTarget != null);
+    this.RuleFor(x => x.AccessTarget)!
+      .SetValidator(new DiscountTargetReqValidator()!)
+      .When(x => x.AccessTarget != null);
   }
 }

--- a/App/Modules/Bookings/Data/BookingAnalysisRepository.cs
+++ b/App/Modules/Bookings/Data/BookingAnalysisRepository.cs
@@ -1,0 +1,184 @@
+using App.Modules.Timings.Data;
+using App.StartUp.Database;
+using App.Utility;
+using CSharp_Result;
+using Domain;
+using Domain.Booking;
+using Domain.Transaction;
+using Microsoft.EntityFrameworkCore;
+
+namespace App.Modules.Bookings.Data;
+
+// Sales/revenue analysis for the admin "Analysis" page. Everything is
+// aggregated DB-side (no N+1, no per-booking fetches).
+//
+// AMOUNT SOURCE (authoritative): the booking's REQUEST transaction amount
+// (Bookings.TransactionId -> Transactions.Amount). Generator.CompleteBooking
+// copies create.Amount verbatim into the BookingComplete ledger row and
+// Complete() collects exactly b.Transaction.Record.Amount from the reserve,
+// so the request row, the BookingComplete row and the wallet movement agree
+// by construction — and only the request row is FK-linked per booking, which
+// makes it the joinable source of truth.
+//
+// DATE CONVENTION: rows bucket completed bookings on the SGT (UTC+8)
+// calendar date of CompletedAt — the same wall-clock convention booking_stats
+// uses for travel dates (its DepartureUtc treats Date+Time as SGT). After/
+// Before are inclusive SGT dates, resolved to UTC instants for the scan.
+public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysisRepository> logger)
+  : IBookingAnalysisRepository
+{
+  // raw-SQL row shape: grouping by an SGT calendar date derived from a
+  // timestamptz is not LINQ-translatable, so the row query is raw (and still
+  // fully DB-side); column names must match the SELECT aliases
+  private sealed class RowDto
+  {
+    public DateOnly Date { get; set; }
+
+    public int Direction { get; set; }
+
+    public TimeOnly Time { get; set; }
+
+    public int TicketsCompleted { get; set; }
+
+    public decimal GrossRevenue { get; set; }
+  }
+
+  public async Task<Result<BookingAnalysis>> Analyze(BookingAnalysisQuery query)
+  {
+    try
+    {
+      logger.LogInformation("Computing booking analysis with {@Query}", query.ToJson());
+      var sgt = TimeZoneInfo.FindSystemTimeZoneById("Asia/Singapore");
+      // inclusive SGT dates -> half-open UTC instant range [after, before)
+      var afterUtc =
+        query.After?.ToZonedDateTime(TimeOnly.MinValue, sgt)
+        ?? DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc);
+      var beforeUtc =
+        query.Before?.AddDays(1).ToZonedDateTime(TimeOnly.MinValue, sgt)
+        ?? DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc);
+
+      var completed = (byte)BookStatus.Completed;
+      // AT TIME ZONE 'UTC' renders the instant as UTC wall-clock regardless
+      // of the session TimeZone; +8h then CAST AS date = the SGT calendar
+      // date (same arithmetic booking_stats bakes into its view)
+      var rows = await db
+        .Database.SqlQuery<RowDto>(
+          $"""
+          SELECT
+            CAST((b."CompletedAt" AT TIME ZONE 'UTC' + INTERVAL '8 hours') AS date) AS "Date",
+            b."Direction" AS "Direction",
+            b."Time" AS "Time",
+            CAST(COUNT(*) AS int) AS "TicketsCompleted",
+            SUM(t."Amount") AS "GrossRevenue"
+          FROM "Bookings" b
+          JOIN "Transactions" t ON t."Id" = b."TransactionId"
+          WHERE b."Status" = {completed}
+            AND b."CompletedAt" IS NOT NULL
+            AND b."CompletedAt" >= {afterUtc}
+            AND b."CompletedAt" < {beforeUtc}
+          GROUP BY 1, b."Direction", b."Time"
+          ORDER BY 1, b."Direction", b."Time"
+          """
+        )
+        .ToArrayAsync();
+
+      // re-sort client-side: EF may wrap the raw SQL in an outer SELECT,
+      // which does not guarantee the subquery's ORDER BY survives
+      var analysisRows = rows
+        .OrderBy(x => x.Date)
+        .ThenBy(x => x.Direction)
+        .ThenBy(x => x.Time)
+        .Select(x => new BookingAnalysisRow
+        {
+          Date = x.Date,
+          Direction = x.Direction.ToTrainDirection(),
+          Time = x.Time,
+          TicketsCompleted = x.TicketsCompleted,
+          GrossRevenue = x.GrossRevenue,
+        })
+        .ToArray();
+
+      // Airwallex intents that captured money, created in range (gateway
+      // fees are NOT stored anywhere — deliberately gross)
+      var capturedInRange = db.Payments.Where(p =>
+        p.CapturedAmount > 0 && p.CreatedAt >= afterUtc && p.CreatedAt < beforeUtc
+      );
+      var depositCount = await capturedInRange.CountAsync();
+      var depositCaptured = await capturedInRange.SumAsync(p => (decimal?)p.CapturedAmount);
+
+      // internal-fee ledger rows in range, one grouped scan; PriorityFee
+      // charges and refunds share a type and are told apart by the To account
+      var feeTypes = new[]
+      {
+        (short)TransactionType.DepositFee,
+        (short)TransactionType.WithdrawFee,
+        (short)TransactionType.PriorityFee,
+        (short)TransactionType.BookingTerminated,
+      };
+      var ledger = await db
+        .Transactions.Where(x =>
+          feeTypes.Contains(x.TransactionType)
+          && x.CreatedAt >= afterUtc
+          && x.CreatedAt < beforeUtc
+        )
+        .GroupBy(x => new { x.TransactionType, x.To })
+        .Select(g => new
+        {
+          g.Key.TransactionType,
+          g.Key.To,
+          Sum = g.Sum(x => x.Amount),
+        })
+        .ToArrayAsync();
+
+      // termination fee = what the terminated bookings had collected minus
+      // what their BookingTerminated ledger rows refunded in the same range
+      var terminatedGross = await db
+        .Bookings.Where(b =>
+          b.Status == (byte)BookStatus.Terminated
+          && b.CompletedAt >= afterUtc
+          && b.CompletedAt < beforeUtc
+        )
+        .SumAsync(b => (decimal?)b.Transaction.Amount);
+
+      decimal LedgerSum(TransactionType type, string? to = null) =>
+        ledger
+          .Where(x => x.TransactionType == (short)type && (to == null || x.To == to))
+          .Sum(x => x.Sum);
+
+      var sums = new BookingAnalysisLedgerSums
+      {
+        DepositFees = LedgerSum(TransactionType.DepositFee),
+        WithdrawalFees = LedgerSum(TransactionType.WithdrawFee),
+        PriorityFeesCharged = LedgerSum(
+          TransactionType.PriorityFee,
+          Accounts.PriorityFee.DisplayName
+        ),
+        PriorityFeesRefunded = LedgerSum(
+          TransactionType.PriorityFee,
+          Accounts.Usable.DisplayName
+        ),
+        TerminatedGross = terminatedGross ?? 0m,
+        TerminationRefunds = LedgerSum(TransactionType.BookingTerminated),
+      };
+
+      return new BookingAnalysis
+      {
+        Rows = analysisRows,
+        Summary = BookingAnalysisCalculator.Summarize(
+          analysisRows,
+          new DepositSummary
+          {
+            Count = depositCount,
+            Captured = depositCaptured ?? 0m,
+          },
+          sums
+        ),
+      };
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to compute booking analysis with {@Query}", query.ToJson());
+      return e;
+    }
+  }
+}

--- a/App/Modules/Bookings/Data/BookingRepository.cs
+++ b/App/Modules/Bookings/Data/BookingRepository.cs
@@ -535,7 +535,7 @@ public class BookingRepository(
     }
   }
 
-  public async Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal fee)
+  public async Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee)
   {
     try
     {

--- a/App/Modules/Bookings/Data/PriorityData.cs
+++ b/App/Modules/Bookings/Data/PriorityData.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using App.Modules.Discounts.Data;
 using Microsoft.EntityFrameworkCore;
 
 namespace App.Modules.Bookings.Data;
@@ -22,6 +23,14 @@ public class PrioritySettingsData
   public TimeOnly? WindowStartSgt { get; set; }
 
   public TimeOnly? WindowEndSgt { get; set; }
+
+  // Who gets the boost FREE — owned JSON blob, same shape and storage
+  // convention as DiscountData.Target; null = nobody is free
+  public DiscountTargetData? FreeTarget { get; set; }
+
+  // Who MAY prioritize at all — when set it takes precedence over
+  // AllowAll/PriorityAccessData; null = legacy behavior unchanged
+  public DiscountTargetData? AccessTarget { get; set; }
 }
 
 // A user allowed to prioritize bookings (when AllowAll is off)

--- a/App/Modules/Bookings/Data/PriorityRepository.cs
+++ b/App/Modules/Bookings/Data/PriorityRepository.cs
@@ -1,3 +1,4 @@
+using App.Modules.Discounts.Data;
 using App.StartUp.Database;
 using App.Utility;
 using CSharp_Result;
@@ -134,6 +135,8 @@ public static class PriorityDataMapper
       AllowAll = data.AllowAll,
       WindowStartSgt = data.WindowStartSgt,
       WindowEndSgt = data.WindowEndSgt,
+      FreeTarget = data.FreeTarget?.ToTarget(),
+      AccessTarget = data.AccessTarget?.ToTarget(),
     };
 
   public static PrioritySettingsPrincipal ToPrincipal(this PrioritySettingsData data) =>
@@ -157,6 +160,8 @@ public static class PriorityDataMapper
     data.AllowAll = record.AllowAll;
     data.WindowStartSgt = record.WindowStartSgt;
     data.WindowEndSgt = record.WindowEndSgt;
+    data.FreeTarget = record.FreeTarget?.ToData();
+    data.AccessTarget = record.AccessTarget?.ToData();
     return data;
   }
 }

--- a/App/Modules/Discounts/Data/DiscountsMapper.cs
+++ b/App/Modules/Discounts/Data/DiscountsMapper.cs
@@ -35,18 +35,31 @@ public static class DiscountMapper
   public static DiscountStatus ToStatus(this DiscountData data) =>
     new() { Disabled = data.Disabled };
 
-  public static DiscountTarget ToTarget(this DiscountData data) =>
+  // reusable for every DiscountTarget-shaped blob (discounts, priority
+  // free/access targeting)
+  public static DiscountTarget ToTarget(this DiscountTargetData data) =>
     new()
     {
-      MatchMode = data.Target.MatchMode.ToDiscountMatchMode(),
+      MatchMode = data.MatchMode.ToDiscountMatchMode(),
       Matches = data
-        .Target.Matches.Select(x => new DiscountMatch
+        .Matches.Select(x => new DiscountMatch
         {
           Type = x.Type.ToDiscountMatchType(),
           Value = x.Value,
         })
         .ToList(),
     };
+
+  public static DiscountTargetData ToData(this DiscountTarget target) =>
+    new()
+    {
+      MatchMode = target.MatchMode.ToData(),
+      Matches = target
+        .Matches.Select(x => new DiscountMatchData { Type = x.Type.ToData(), Value = x.Value })
+        .ToList(),
+    };
+
+  public static DiscountTarget ToTarget(this DiscountData data) => data.Target.ToTarget();
 
   public static DiscountRecord ToRecord(this DiscountData data) =>
     new()

--- a/App/Modules/DomainServices.cs
+++ b/App/Modules/DomainServices.cs
@@ -72,6 +72,10 @@ public static class DomainServices
     s.AddScoped<IBookingTerminatorRepository, BookingTerminatorRepository>()
       .AutoTrace<IBookingTerminatorRepository>();
 
+    // Sales/revenue analysis (admin Analysis page)
+    s.AddScoped<IBookingAnalysisRepository, BookingAnalysisRepository>()
+      .AutoTrace<IBookingAnalysisRepository>();
+
     // Priority queue
     s.AddScoped<IPrioritySettingsRepository, PrioritySettingsRepository>()
       .AutoTrace<IPrioritySettingsRepository>();

--- a/App/Modules/Payments/API/V1/PaymentController.cs
+++ b/App/Modules/Payments/API/V1/PaymentController.cs
@@ -42,6 +42,22 @@ public class PaymentController(
     return this.ReturnResult(x);
   }
 
+  // intent-level evidence rows for the admin Analysis page: which payment
+  // intents captured money in the (inclusive SGT date) range, newest first,
+  // capped at 100 rows
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("captured")]
+  public async Task<ActionResult<IEnumerable<CapturedPaymentRes>>> Captured(
+    [FromQuery] CapturedPaymentsQueryReq query,
+    [FromServices] CapturedPaymentsQueryReqValidator capturedValidator
+  )
+  {
+    var x = await capturedValidator
+      .ValidateAsyncResult(query, "Invalid CapturedPaymentsQueryReq")
+      .ThenAwait(q => service.ListCaptured(q.ToDomain()))
+      .Then(r => r.Select(p => p.ToRes()), Errors.MapNone);
+    return this.ReturnResult(x);
+  }
+
   [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("id/{id:guid}")]
   public async Task<ActionResult<PaymentRes>> GetById(Guid id)
   {

--- a/App/Modules/Payments/API/V1/PaymentMapper.cs
+++ b/App/Modules/Payments/API/V1/PaymentMapper.cs
@@ -42,7 +42,18 @@ public static class PaymentMapper
   public static PaymentRes ToRes(this Payment p) =>
     new(p.Principal.ToRes(), p.Wallet.ToRes(), p.Transaction?.ToRes());
 
+  public static CapturedPaymentRes ToRes(this CapturedPayment p) =>
+    new(p.PaymentIntentId, p.CapturedAmount, p.Currency, p.CreatedAt, p.Status);
+
   // REQ
+  public static CapturedPaymentsQuery ToDomain(this CapturedPaymentsQueryReq q) =>
+    new()
+    {
+      After = q.After?.ToDate(),
+      Before = q.Before?.ToDate(),
+      Limit = q.Limit ?? 100,
+    };
+
   public static PaymentSearch ToDomain(this SearchPaymentQuery q)
   {
     var tz = TimeZoneInfo.FindSystemTimeZoneById("Asia/Singapore");

--- a/App/Modules/Payments/API/V1/PaymentModel.cs
+++ b/App/Modules/Payments/API/V1/PaymentModel.cs
@@ -26,6 +26,10 @@ public record SearchPaymentQuery(
 
 public record CreatePaymentReq(decimal Amount, string Currency);
 
+// intent-level evidence rows for the analysis page: which payment intents
+// captured money in the (inclusive SGT date, dd-MM-yyyy) range
+public record CapturedPaymentsQueryReq(string? After, string? Before, int? Limit);
+
 // RESP
 public record CreatePaymentRes(
   Guid Id,
@@ -59,4 +63,14 @@ public record PaymentRes(
   PaymentPrincipalRes Principal,
   WalletPrincipalRes Wallet,
   TransactionPrincipalRes? Transaction
+);
+
+// one captured intent (newest first); PaymentIntentId = the gateway's
+// external reference (the Airwallex intent id)
+public record CapturedPaymentRes(
+  string PaymentIntentId,
+  decimal CapturedAmount,
+  string Currency,
+  DateTime CreatedAt,
+  string Status
 );

--- a/App/Modules/Payments/API/V1/PaymentValidator.cs
+++ b/App/Modules/Payments/API/V1/PaymentValidator.cs
@@ -18,6 +18,16 @@ public class SearchPaymentQueryValidator : AbstractValidator<SearchPaymentQuery>
   }
 }
 
+public class CapturedPaymentsQueryReqValidator : AbstractValidator<CapturedPaymentsQueryReq>
+{
+  public CapturedPaymentsQueryReqValidator()
+  {
+    this.RuleFor(x => x.After).NullableDateValid();
+    this.RuleFor(x => x.Before).NullableDateValid();
+    this.RuleFor(x => x.Limit).Limit();
+  }
+}
+
 public class CreatePaymentReqValidator : AbstractValidator<CreatePaymentReq>
 {
   public CreatePaymentReqValidator()

--- a/App/Modules/Payments/Data/PaymentRepository.cs
+++ b/App/Modules/Payments/Data/PaymentRepository.cs
@@ -2,6 +2,7 @@ using App.Error.V1;
 using App.StartUp.Database;
 using App.Utility;
 using CSharp_Result;
+using Domain;
 using Domain.Payment;
 using EntityFramework.Exceptions.Common;
 using Microsoft.EntityFrameworkCore;
@@ -65,6 +66,52 @@ public class PaymentRepository(MainDbContext db, ILogger<PaymentRepository> logg
     {
       logger.LogError(e, "Failed search for Payments with '{@Search}'", search.ToJson());
       throw;
+    }
+  }
+
+  // intents that captured money in the range (inclusive SGT dates), newest
+  // first — evidence rows for the analysis page's deposit figures
+  public async Task<Result<IEnumerable<CapturedPayment>>> ListCaptured(
+    CapturedPaymentsQuery query
+  )
+  {
+    try
+    {
+      logger.LogInformation("Listing captured Payments with '{@Query}'", query.ToJson());
+      var sgt = TimeZoneInfo.FindSystemTimeZoneById("Asia/Singapore");
+      var q = db.Payments.Where(x => x.CapturedAmount > 0);
+      if (query.After != null)
+      {
+        var a = query.After.Value.ToZonedDateTime(TimeOnly.MinValue, sgt);
+        q = q.Where(x => x.CreatedAt >= a);
+      }
+
+      if (query.Before != null)
+      {
+        // inclusive date -> exclusive next-midnight instant
+        var b = query.Before.Value.AddDays(1).ToZonedDateTime(TimeOnly.MinValue, sgt);
+        q = q.Where(x => x.CreatedAt < b);
+      }
+
+      var result = await q
+        .OrderByDescending(x => x.CreatedAt)
+        .ThenBy(x => x.Id)
+        .Take(query.Limit)
+        .Select(x => new CapturedPayment
+        {
+          PaymentIntentId = x.ExternalReference,
+          CapturedAmount = x.CapturedAmount,
+          Currency = x.Currency,
+          CreatedAt = x.CreatedAt,
+          Status = x.Status,
+        })
+        .ToArrayAsync();
+      return result.AsEnumerable().ToResult();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed listing captured Payments with '{@Query}'", query.ToJson());
+      return e;
     }
   }
 

--- a/App/StartUp/Database/MainDbContext.cs
+++ b/App/StartUp/Database/MainDbContext.cs
@@ -183,6 +183,26 @@ public class MainDbContext(
       }
     );
 
+    // priority-boost targeting: two owned JSON blobs, same shape and storage
+    // convention as DiscountData.Target; null column = target not configured
+    var prioritySettings = modelBuilder.Entity<PrioritySettingsData>();
+    prioritySettings.OwnsOne(
+      x => x.FreeTarget,
+      d =>
+      {
+        d.ToJson();
+        d.OwnsMany(dt => dt.Matches);
+      }
+    );
+    prioritySettings.OwnsOne(
+      x => x.AccessTarget,
+      d =>
+      {
+        d.ToJson();
+        d.OwnsMany(dt => dt.Matches);
+      }
+    );
+
     var withdrawal = modelBuilder.Entity<WithdrawalData>();
     // existing rows predate the method column and are all PayNow transfers
     withdrawal

--- a/Domain/Booking/Analysis.cs
+++ b/Domain/Booking/Analysis.cs
@@ -1,0 +1,124 @@
+using CSharp_Result;
+using Domain.Timings;
+
+namespace Domain.Booking;
+
+// Sales/revenue analysis for the admin "Analysis" page. All figures are
+// GROSS and internal: Airwallex's own gateway fees are not stored anywhere
+// (no API for them yet), so they are deliberately out of scope.
+public record BookingAnalysisQuery
+{
+  // SGT calendar-date range (inclusive), same convention as booking_stats:
+  // travel/CompletedAt instants are bucketed on their SGT (UTC+8) wall-clock
+  // date; null = unbounded
+  public DateOnly? After { get; init; }
+
+  public DateOnly? Before { get; init; }
+}
+
+// One completed-revenue row: bookings completed on this SGT date, for this
+// departure slot. GrossRevenue = the booking cost collected at completion
+// (BookingReserve -> BunnyBooker).
+public record BookingAnalysisRow
+{
+  // SGT date of CompletedAt (matches booking_stats' SGT date convention)
+  public required DateOnly Date { get; init; }
+
+  public required TrainDirection Direction { get; init; }
+
+  public required TimeOnly Time { get; init; }
+
+  public required int TicketsCompleted { get; init; }
+
+  public required decimal GrossRevenue { get; init; }
+}
+
+// Airwallex deposits captured in the range: how many intents captured money
+// and the total captured amount
+public record DepositSummary
+{
+  public required int Count { get; init; }
+
+  public required decimal Captured { get; init; }
+}
+
+// BunnyBooker's own fee revenue in the range, per fee kind
+public record InternalFees
+{
+  public required decimal Deposit { get; init; }
+
+  public required decimal Withdrawal { get; init; }
+
+  // net: priority fees charged minus priority fees refunded (both ledger
+  // rows share TransactionType.PriorityFee and are told apart by account)
+  public required decimal Priority { get; init; }
+
+  // kept on termination: the terminated bookings' collected cost minus what
+  // was refunded (the ledger's BookingTerminated row only carries the refund)
+  public required decimal Termination { get; init; }
+}
+
+public record BookingAnalysisSummary
+{
+  public required int TotalTickets { get; init; }
+
+  public required decimal TotalGross { get; init; }
+
+  public required DepositSummary Deposits { get; init; }
+
+  public required InternalFees InternalFees { get; init; }
+}
+
+public record BookingAnalysis
+{
+  public required IEnumerable<BookingAnalysisRow> Rows { get; init; }
+
+  public required BookingAnalysisSummary Summary { get; init; }
+}
+
+// The raw range-scoped sums the data layer computes DB-side; the pure
+// calculator below turns them into the reported fee figures
+public record BookingAnalysisLedgerSums
+{
+  public required decimal DepositFees { get; init; }
+
+  public required decimal WithdrawalFees { get; init; }
+
+  public required decimal PriorityFeesCharged { get; init; }
+
+  public required decimal PriorityFeesRefunded { get; init; }
+
+  // gross collected for bookings that ended Terminated in the range
+  public required decimal TerminatedGross { get; init; }
+
+  // what the BookingTerminated ledger rows returned to wallets in the range
+  public required decimal TerminationRefunds { get; init; }
+}
+
+// Pure summary math, shared by the repository and the unit tests
+public static class BookingAnalysisCalculator
+{
+  public static BookingAnalysisSummary Summarize(
+    IReadOnlyCollection<BookingAnalysisRow> rows,
+    DepositSummary deposits,
+    BookingAnalysisLedgerSums sums
+  ) =>
+    new()
+    {
+      TotalTickets = rows.Sum(r => r.TicketsCompleted),
+      TotalGross = rows.Sum(r => r.GrossRevenue),
+      Deposits = deposits,
+      InternalFees = new InternalFees
+      {
+        Deposit = sums.DepositFees,
+        Withdrawal = sums.WithdrawalFees,
+        Priority = sums.PriorityFeesCharged - sums.PriorityFeesRefunded,
+        Termination = sums.TerminatedGross - sums.TerminationRefunds,
+      },
+    };
+}
+
+public interface IBookingAnalysisRepository
+{
+  Task<Result<BookingAnalysis>> Analyze(BookingAnalysisQuery query);
+}

--- a/Domain/Booking/IService.cs
+++ b/Domain/Booking/IService.cs
@@ -74,8 +74,13 @@ public interface IBookingService
 
   Task<Result<IEnumerable<BookingCount>>> Count(BookingCountSearch query);
 
-  // may this user prioritize a booking right now, and at what fee
-  Task<Result<PriorityEligibility>> PriorityEligibility(string userId);
+  // may this user prioritize a booking right now, at what fee, and is the
+  // boost free for them; callerTokenRoles = the target user's own JWT roles
+  // when they are the caller (null = fall back to the persisted Roles mirror)
+  Task<Result<PriorityEligibility>> PriorityEligibility(
+    string userId,
+    string[]? callerTokenRoles = null
+  );
 
   // charge the priority fee and move the booking to the front of its queue
   Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id);

--- a/Domain/Booking/Priority.cs
+++ b/Domain/Booking/Priority.cs
@@ -1,4 +1,5 @@
 using CSharp_Result;
+using Domain.Discount;
 
 namespace Domain.Booking;
 
@@ -18,12 +19,25 @@ public record PrioritySettingsRecord
 
   public required TimeOnly? WindowEndSgt { get; init; }
 
+  // Who gets the priority boost FREE (fee 0, no ledger row) — matched against
+  // the user's id and PRICING roles (JWT roles ∪ admin-granted ExtraRoles,
+  // the same union discount targeting prices with). null = nobody is free.
+  // Same shape and semantics as discount targeting (All/Any/None).
+  public DiscountTarget? FreeTarget { get; init; }
+
+  // Who MAY use priority at all — richer replacement for AllowAll + the
+  // allowlist. When set it takes PRECEDENCE over AllowAll/PriorityAccessData;
+  // null = legacy behavior (allowlisted OR AllowAll) unchanged.
+  public DiscountTarget? AccessTarget { get; init; }
+
   public static readonly PrioritySettingsRecord Default = new()
   {
     Fee = 10m,
     AllowAll = false,
     WindowStartSgt = null,
     WindowEndSgt = null,
+    FreeTarget = null,
+    AccessTarget = null,
   };
 }
 
@@ -45,12 +59,15 @@ public record PriorityAccess
 }
 
 // What the eligibility endpoint (and the prioritize guard) answers: may this
-// user prioritize right now, and at what fee
+// user prioritize right now, at what fee, and whether the boost is free for
+// them (Free => Fee is 0)
 public record PriorityEligibility
 {
   public required bool Eligible { get; init; }
 
   public required decimal Fee { get; init; }
+
+  public required bool Free { get; init; }
 }
 
 // Pure eligibility rules, shared by the endpoint, the prioritize guard and
@@ -70,11 +87,29 @@ public static class PriorityRules
       : nowSgt >= start.Value || nowSgt < end.Value;
   }
 
-  public static bool Eligible(bool allowlisted, PrioritySettingsRecord settings, TimeOnly nowSgt)
+  // May this user prioritize: AccessTarget (when configured) REPLACES the
+  // legacy allowlist/AllowAll gate; otherwise legacy semantics apply. The SGT
+  // availability window gates both paths.
+  public static bool Eligible(
+    bool allowlisted,
+    PrioritySettingsRecord settings,
+    TimeOnly nowSgt,
+    string userId = "",
+    string[]? roles = null
+  )
   {
-    return (allowlisted || settings.AllowAll)
-      && WindowOpen(settings.WindowStartSgt, settings.WindowEndSgt, nowSgt);
+    var access =
+      settings.AccessTarget != null
+        ? Discount.TargetMatcher.Matches(settings.AccessTarget, userId, roles ?? [])
+        : allowlisted || settings.AllowAll;
+    return access && WindowOpen(settings.WindowStartSgt, settings.WindowEndSgt, nowSgt);
   }
+
+  // Is the boost free for this user: FreeTarget matched against the user's
+  // id and pricing roles; no target = never free
+  public static bool Free(PrioritySettingsRecord settings, string userId, string[] roles) =>
+    settings.FreeTarget != null
+    && Discount.TargetMatcher.Matches(settings.FreeTarget, userId, roles);
 }
 
 public interface IPrioritySettingsRepository

--- a/Domain/Booking/Repository.cs
+++ b/Domain/Booking/Repository.cs
@@ -33,8 +33,9 @@ public interface IBookingRepository
   Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly Time);
 
   // marks the booking priority (front of its queue) and snapshots the fee
-  // charged; null when the booking does not exist (or is not visible to userId)
-  Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal fee);
+  // charged (null = FREE boost, nothing charged so nothing to refund); null
+  // result when the booking does not exist (or is not visible to userId)
+  Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee);
 
   // bumps the recovery retry counter by one; null when the booking does not
   // exist. Runs inside the caller's RecoverRevert transaction so the counter

--- a/Domain/Booking/Service.cs
+++ b/Domain/Booking/Service.cs
@@ -2,6 +2,7 @@ using CSharp_Result;
 using Domain.Exceptions;
 using Domain.Timings;
 using Domain.Transaction;
+using Domain.User;
 using Domain.Wallet;
 using Microsoft.Extensions.Logging;
 
@@ -20,6 +21,7 @@ public class BookingService(
   IBookingNotificationService notificationService,
   IPrioritySettingsRepository prioritySettingsRepo,
   IPriorityAccessRepository priorityAccessRepo,
+  IUserRepository userRepo,
   ILogger<BookingService> logger,
   TimeProvider? timeProvider = null
 ) : IBookingService
@@ -1047,10 +1049,21 @@ public class BookingService(
       .Then(_ => 0, Errors.MapNone);
   }
 
-  // Eligibility: (allowlisted OR AllowAll) AND the SGT availability window
-  // (when configured) is open right now. Also carries the fee the user would
-  // be charged, for pre-submission display.
-  public Task<Result<PriorityEligibility>> PriorityEligibility(string userId)
+  // Eligibility: AccessTarget (when configured) or the legacy allowlist/
+  // AllowAll gate, AND the SGT availability window (when configured) is open
+  // right now. Also carries the fee the user would be charged (0 when the
+  // FreeTarget matches) for pre-submission display.
+  //
+  // Targeting roles = the TARGET user's roles ∪ their admin-granted
+  // ExtraRoles, the same union pricing uses (PurchasePricingRoles): when the
+  // caller IS the target their JWT roles are authoritative
+  // (callerTokenRoles != null); when checked on behalf of someone else (the
+  // prioritize guard on an admin-assisted call) that user's JWT is absent, so
+  // fall back to the persisted Descope-synced Roles mirror.
+  public Task<Result<PriorityEligibility>> PriorityEligibility(
+    string userId,
+    string[]? callerTokenRoles = null
+  )
   {
     return prioritySettingsRepo
       .GetCurrent()
@@ -1058,6 +1071,29 @@ public class BookingService(
       .ThenAwait(s =>
         priorityAccessRepo.Contains(userId).Then(allowed => (s, allowed), Errors.MapNone)
       )
+      .ThenAwait(t =>
+      {
+        // targets untouched: skip the user lookup, roles are never consulted
+        if (t.s.FreeTarget == null && t.s.AccessTarget == null)
+          return Task.FromResult(
+            (Result<(PrioritySettingsRecord s, bool allowed, string[] roles)>)(t.s, t.allowed, [])
+          );
+        return userRepo
+          .GetById(userId)
+          .Then(
+            (PrioritySettingsRecord s, bool allowed, string[] roles) (u) =>
+              (
+                t.s,
+                t.allowed,
+                PurchasePricingRoles.For(
+                  callerTokenRoles != null,
+                  callerTokenRoles ?? [],
+                  u?.Principal.Record
+                )
+              ),
+            Errors.MapNone
+          );
+      })
       .Then(
         t =>
         {
@@ -1065,10 +1101,12 @@ public class BookingService(
           var nowSgt = TimeOnly.FromDateTime(
             TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, singapore)
           );
+          var free = PriorityRules.Free(t.s, userId, t.roles);
           return new PriorityEligibility
           {
-            Eligible = PriorityRules.Eligible(t.allowed, t.s, nowSgt),
-            Fee = t.s.Fee,
+            Eligible = PriorityRules.Eligible(t.allowed, t.s, nowSgt, userId, t.roles),
+            Fee = free ? 0m : t.s.Fee,
+            Free = free,
           };
         },
         Errors.MapNone
@@ -1104,42 +1142,46 @@ public class BookingService(
                 return Task.FromResult((Result<int>)r);
               }
             )
-            // guard: the booking's owner must be eligible right now
+            // guard: the booking's owner must be eligible right now (their
+            // pricing roles decide free/access targeting; the owner's JWT is
+            // absent here, so the persisted Roles mirror is used)
             .ThenAwait(b =>
               this.PriorityEligibility(b.Principal.UserId)
                 .ThenAwait(e =>
                 {
                   if (e.Eligible)
-                    return Task.FromResult((Result<(Booking b, decimal Fee)>)(b, e.Fee));
+                    return Task.FromResult((Result<(Booking b, PriorityEligibility e)>)(b, e));
                   var r = new InvalidBookingOperationException(
                     "Prioritize requires the booking's owner to be eligible (allowlisted or allow-all, within the availability window)",
                     b.Principal.Status.Status,
                     BookingOperations.Prioritize
                   );
-                  return Task.FromResult((Result<(Booking b, decimal Fee)>)r);
+                  return Task.FromResult((Result<(Booking b, PriorityEligibility e)>)r);
                 })
             )
-            // collect the fee from Usable + ledger row (a zero fee books
-            // neither — a "SGD 0.00 charged" row would contradict the fee
-            // being disabled)
+            // collect the fee from Usable + ledger row (a zero or free fee
+            // books neither — a "SGD 0.00 charged" row would contradict the
+            // fee being disabled/waived)
             .DoAwait(
               DoType.MapErrors,
               t =>
-                t.Fee > 0
+                t.e.Fee > 0
                   ? walletRepo
-                    .Collect(t.b.Wallet.Id, t.Fee)
+                    .Collect(t.b.Wallet.Id, t.e.Fee)
                     .NullToError(t.b.Wallet.Id.ToString())
                     .ThenAwait(_ =>
                       transactionRepo.Create(
                         t.b.Wallet.Id,
-                        transactionGenerator.PriorityFeeCharge(t.Fee, t.b.Principal.Record)
+                        transactionGenerator.PriorityFeeCharge(t.e.Fee, t.b.Principal.Record)
                       )
                     )
                     .Then(_ => 0, Errors.MapNone)
                   : Task.FromResult((Result<int>)0)
             )
-            // flag the booking + snapshot the charged fee for the refund path
-            .ThenAwait(t => repo.Prioritize(userId, id, t.Fee))
+            // flag the booking + snapshot the charged fee for the refund
+            // path; a FREE boost snapshots null (nothing was charged, so
+            // there is nothing to refund — the refund path must stay silent)
+            .ThenAwait(t => repo.Prioritize(userId, id, t.e.Free ? null : t.e.Fee))
             .NullToError(id.ToString())
       )
       .DoAwait(DoType.Ignore, _ => cdcRepository.Add("update"))

--- a/Domain/Discount/DiscountMatcher.cs
+++ b/Domain/Discount/DiscountMatcher.cs
@@ -39,36 +39,8 @@ public class DiscountMatcher(ILogger<DiscountMatcher> logger) : IDiscountMatcher
     );
     if (!DiscountSlotMatcher.Applies(record, spec, nowUtc))
       return false;
-    return target.MatchMode switch
-    {
-      DiscountMatchMode.All => this.MatchAll(target.Matches, userId, roles),
-      DiscountMatchMode.Any => this.MatchAny(target.Matches, userId, roles),
-      DiscountMatchMode.None => true,
-      _ => throw new ArgumentOutOfRangeException(),
-    };
-  }
-
-  private bool MatchAll(IEnumerable<DiscountMatch> matches, string userId, string[] roles)
-  {
-    return matches.All(x =>
-      x.Type switch
-      {
-        DiscountMatchType.UserId => x.Value == userId,
-        DiscountMatchType.Role => roles.Contains(x.Value),
-        _ => throw new ArgumentOutOfRangeException(),
-      }
-    );
-  }
-
-  private bool MatchAny(IEnumerable<DiscountMatch> matches, string userId, string[] roles)
-  {
-    return matches.Any(x =>
-      x.Type switch
-      {
-        DiscountMatchType.UserId => x.Value == userId,
-        DiscountMatchType.Role => roles.Contains(x.Value),
-        _ => throw new ArgumentOutOfRangeException(),
-      }
-    );
+    // the user/role semantics live in TargetMatcher, shared with the
+    // priority-boost targeting so the two features can never drift
+    return TargetMatcher.Matches(target, userId, roles);
   }
 }

--- a/Domain/Discount/TargetMatcher.cs
+++ b/Domain/Discount/TargetMatcher.cs
@@ -1,0 +1,27 @@
+namespace Domain.Discount;
+
+// Pure user/role targeting semantics for a DiscountTarget-shaped blob, shared
+// by discount matching and priority-boost targeting so the two features can
+// never drift: All = every match must hit, Any = at least one match must hit,
+// None = matches everyone.
+public static class TargetMatcher
+{
+  public static bool Matches(DiscountTarget target, string userId, string[] roles)
+  {
+    return target.MatchMode switch
+    {
+      DiscountMatchMode.All => target.Matches.All(x => Hit(x, userId, roles)),
+      DiscountMatchMode.Any => target.Matches.Any(x => Hit(x, userId, roles)),
+      DiscountMatchMode.None => true,
+      _ => throw new ArgumentOutOfRangeException(nameof(target)),
+    };
+  }
+
+  private static bool Hit(DiscountMatch match, string userId, string[] roles) =>
+    match.Type switch
+    {
+      DiscountMatchType.UserId => match.Value == userId,
+      DiscountMatchType.Role => roles.Contains(match.Value),
+      _ => throw new ArgumentOutOfRangeException(nameof(match)),
+    };
+}

--- a/Domain/Payment/IService.cs
+++ b/Domain/Payment/IService.cs
@@ -6,6 +6,9 @@ public interface IPaymentService
 {
   Task<Result<IEnumerable<PaymentPrincipal>>> Search(PaymentSearch search);
 
+  // intents that captured money in the range, newest first
+  Task<Result<IEnumerable<CapturedPayment>>> ListCaptured(CapturedPaymentsQuery query);
+
   Task<Result<Payment?>> GetById(Guid id);
 
   Task<Result<Payment?>> GetByRef(string id);

--- a/Domain/Payment/Model.cs
+++ b/Domain/Payment/Model.cs
@@ -31,6 +31,33 @@ public record PaymentSecret
   public required string Secret { get; init; }
 }
 
+// evidence query for the analysis page: which payment intents captured
+// money in the (inclusive SGT date) range
+public record CapturedPaymentsQuery
+{
+  public DateOnly? After { get; init; }
+
+  public DateOnly? Before { get; init; }
+
+  public int Limit { get; init; }
+}
+
+// one captured intent, newest first — intent-level evidence rows backing the
+// deposit summary figures
+public record CapturedPayment
+{
+  // the gateway's intent id (ExternalReference, e.g. the Airwallex intent)
+  public required string PaymentIntentId { get; init; }
+
+  public required decimal CapturedAmount { get; init; }
+
+  public required string Currency { get; init; }
+
+  public required DateTime CreatedAt { get; init; }
+
+  public required string Status { get; init; }
+}
+
 public record Payment
 {
   public required TransactionPrincipal? Transaction { get; init; }

--- a/Domain/Payment/Repository.cs
+++ b/Domain/Payment/Repository.cs
@@ -6,6 +6,10 @@ public interface IPaymentRepository
 {
   Task<Result<IEnumerable<PaymentPrincipal>>> Search(PaymentSearch search);
 
+  // intents that captured money in the range, newest first — evidence rows
+  // for the analysis page's deposit figures
+  Task<Result<IEnumerable<CapturedPayment>>> ListCaptured(CapturedPaymentsQuery query);
+
   Task<Result<Payment?>> GetById(Guid id);
 
   Task<Result<Payment?>> GetByRef(string id);

--- a/Domain/Payment/Service.cs
+++ b/Domain/Payment/Service.cs
@@ -44,6 +44,11 @@ public class PaymentService(
     return repo.Search(search);
   }
 
+  public Task<Result<IEnumerable<CapturedPayment>>> ListCaptured(CapturedPaymentsQuery query)
+  {
+    return repo.ListCaptured(query);
+  }
+
   public Task<Result<Payment?>> GetById(Guid id)
   {
     return repo.GetById(id);

--- a/UnitTest/Bookings/BookingAnalysisCalculatorTests.cs
+++ b/UnitTest/Bookings/BookingAnalysisCalculatorTests.cs
@@ -1,0 +1,135 @@
+using Domain.Booking;
+using Domain.Timings;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// The pure summary math behind GET Booking/analysis: totals are sums over
+// the per-day rows; priority fees are net of refunds; termination fees are
+// the collected cost of terminated bookings minus what was refunded.
+public class BookingAnalysisCalculatorTests
+{
+  private static BookingAnalysisRow Row(
+    int tickets,
+    decimal gross,
+    TrainDirection direction = TrainDirection.JToW
+  ) =>
+    new()
+    {
+      Date = new DateOnly(2026, 7, 1),
+      Direction = direction,
+      Time = new TimeOnly(8, 30),
+      TicketsCompleted = tickets,
+      GrossRevenue = gross,
+    };
+
+  private static readonly DepositSummary NoDeposits = new() { Count = 0, Captured = 0m };
+
+  private static readonly BookingAnalysisLedgerSums ZeroSums = new()
+  {
+    DepositFees = 0m,
+    WithdrawalFees = 0m,
+    PriorityFeesCharged = 0m,
+    PriorityFeesRefunded = 0m,
+    TerminatedGross = 0m,
+    TerminationRefunds = 0m,
+  };
+
+  [Fact]
+  public void Totals_sum_across_rows()
+  {
+    var rows = new[]
+    {
+      Row(3, 42m),
+      Row(2, 28m, TrainDirection.WToJ),
+      Row(5, 80m),
+    };
+
+    var s = BookingAnalysisCalculator.Summarize(rows, NoDeposits, ZeroSums);
+
+    s.TotalTickets.Should().Be(10);
+    s.TotalGross.Should().Be(150m);
+  }
+
+  [Fact]
+  public void Empty_rows_produce_zero_totals()
+  {
+    var s = BookingAnalysisCalculator.Summarize([], NoDeposits, ZeroSums);
+
+    s.TotalTickets.Should().Be(0);
+    s.TotalGross.Should().Be(0m);
+  }
+
+  [Fact]
+  public void Deposits_pass_through_unchanged()
+  {
+    var deposits = new DepositSummary { Count = 7, Captured = 350.5m };
+
+    var s = BookingAnalysisCalculator.Summarize([], deposits, ZeroSums);
+
+    s.Deposits.Count.Should().Be(7);
+    s.Deposits.Captured.Should().Be(350.5m);
+  }
+
+  [Fact]
+  public void Deposit_and_withdrawal_fees_pass_through()
+  {
+    var sums = ZeroSums with { DepositFees = 12.5m, WithdrawalFees = 4m };
+
+    var s = BookingAnalysisCalculator.Summarize([], NoDeposits, sums);
+
+    s.InternalFees.Deposit.Should().Be(12.5m);
+    s.InternalFees.Withdrawal.Should().Be(4m);
+  }
+
+  [Fact]
+  public void Priority_fee_is_net_of_refunds()
+  {
+    // both charge and refund rows share TransactionType.PriorityFee; the
+    // net is what BunnyBooker actually kept
+    var sums = ZeroSums with { PriorityFeesCharged = 50m, PriorityFeesRefunded = 20m };
+
+    var s = BookingAnalysisCalculator.Summarize([], NoDeposits, sums);
+
+    s.InternalFees.Priority.Should().Be(30m);
+  }
+
+  [Fact]
+  public void Termination_fee_is_collected_minus_refunded()
+  {
+    // the BookingTerminated ledger row only carries the refund; the kept fee
+    // is the terminated bookings' collected cost minus that refund
+    var sums = ZeroSums with { TerminatedGross = 100m, TerminationRefunds = 60m };
+
+    var s = BookingAnalysisCalculator.Summarize([], NoDeposits, sums);
+
+    s.InternalFees.Termination.Should().Be(40m);
+  }
+
+  [Fact]
+  public void Full_summary_combines_all_parts()
+  {
+    var rows = new[] { Row(4, 64m) };
+    var deposits = new DepositSummary { Count = 2, Captured = 100m };
+    var sums = new BookingAnalysisLedgerSums
+    {
+      DepositFees = 1m,
+      WithdrawalFees = 2m,
+      PriorityFeesCharged = 30m,
+      PriorityFeesRefunded = 10m,
+      TerminatedGross = 16m,
+      TerminationRefunds = 8m,
+    };
+
+    var s = BookingAnalysisCalculator.Summarize(rows, deposits, sums);
+
+    s.TotalTickets.Should().Be(4);
+    s.TotalGross.Should().Be(64m);
+    s.Deposits.Count.Should().Be(2);
+    s.Deposits.Captured.Should().Be(100m);
+    s.InternalFees.Deposit.Should().Be(1m);
+    s.InternalFees.Withdrawal.Should().Be(2m);
+    s.InternalFees.Priority.Should().Be(20m);
+    s.InternalFees.Termination.Should().Be(8m);
+  }
+}

--- a/UnitTest/Bookings/BookingMapperTests.cs
+++ b/UnitTest/Bookings/BookingMapperTests.cs
@@ -47,4 +47,56 @@ public class BookingMapperTests
     ((int)BookStatus.Duplicate).Should().Be(7);
     ((int)BookStatus.RequireManualIntervention).Should().Be(8);
   }
+
+  // ---- priority settings targets: API <-> domain round trip ----
+
+  [Fact]
+  public void Priority_settings_targets_round_trip_through_req_and_res()
+  {
+    var req = new SetPrioritySettingsReq(
+      Fee: 5m,
+      AllowAll: false,
+      WindowStartSgt: null,
+      WindowEndSgt: null,
+      FreeTarget: new App.Modules.Discounts.API.V1.DiscountTargetReq(
+        "Any",
+        [new App.Modules.Discounts.API.V1.DiscountMatchReq("admin", "Role")]
+      ),
+      AccessTarget: new App.Modules.Discounts.API.V1.DiscountTargetReq(
+        "All",
+        [new App.Modules.Discounts.API.V1.DiscountMatchReq("u1", "UserId")]
+      )
+    );
+
+    var domain = req.ToDomain();
+    domain.FreeTarget.Should().NotBeNull();
+    domain.FreeTarget!.MatchMode.Should().Be(Domain.Discount.DiscountMatchMode.Any);
+    domain.FreeTarget.Matches.Should().ContainSingle(m =>
+      m.Type == Domain.Discount.DiscountMatchType.Role && m.Value == "admin"
+    );
+    domain.AccessTarget!.MatchMode.Should().Be(Domain.Discount.DiscountMatchMode.All);
+
+    var res = domain.ToRes();
+    res.FreeTarget!.MatchMode.Should().Be("Any");
+    res.FreeTarget.Matches.Should().ContainSingle(m =>
+      m.MatchType == "Role" && m.Value == "admin"
+    );
+    res.AccessTarget!.MatchMode.Should().Be("All");
+    res.AccessTarget.Matches.Should().ContainSingle(m =>
+      m.MatchType == "UserId" && m.Value == "u1"
+    );
+  }
+
+  [Fact]
+  public void Priority_settings_null_targets_stay_null_in_both_directions()
+  {
+    var req = new SetPrioritySettingsReq(10m, true, null, null);
+    var domain = req.ToDomain();
+    domain.FreeTarget.Should().BeNull();
+    domain.AccessTarget.Should().BeNull();
+
+    var res = domain.ToRes();
+    res.FreeTarget.Should().BeNull();
+    res.AccessTarget.Should().BeNull();
+  }
 }

--- a/UnitTest/Bookings/BookingPurchaseTimingTests.cs
+++ b/UnitTest/Bookings/BookingPurchaseTimingTests.cs
@@ -123,6 +123,7 @@ public class BookingPurchaseTimingTests
       notifications,
       settings,
       access,
+      null!,
       NullLogger<BookingService>.Instance
     );
     var yesterday = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-1));
@@ -177,6 +178,7 @@ public class BookingPurchaseTimingTests
       notifications,
       settings,
       access,
+      null!,
       NullLogger<BookingService>.Instance,
       clock
     );

--- a/UnitTest/Bookings/BookingServiceAttachTicketTests.cs
+++ b/UnitTest/Bookings/BookingServiceAttachTicketTests.cs
@@ -34,6 +34,7 @@ public class BookingServiceAttachTicketTests
       null!,
       null!,
       null!,
+      null!,
       null!
     );
 
@@ -272,7 +273,7 @@ public class BookingServiceAttachTicketTests
     public Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 
-    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal fee) =>
+    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee) =>
       throw new NotImplementedException();
 
     public Task<Result<Unit?>> Delete(string? userId, Guid id) =>

--- a/UnitTest/Bookings/BookingServiceBuyingGuardTests.cs
+++ b/UnitTest/Bookings/BookingServiceBuyingGuardTests.cs
@@ -32,6 +32,7 @@ public class BookingServiceBuyingGuardTests
       null!,
       null!,
       null!,
+      null!,
       null!
     );
 
@@ -213,7 +214,7 @@ public class BookingServiceBuyingGuardTests
     public Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 
-    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal fee) =>
+    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee) =>
       throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>

--- a/UnitTest/Bookings/BookingServiceCompleteNoCollectTests.cs
+++ b/UnitTest/Bookings/BookingServiceCompleteNoCollectTests.cs
@@ -35,6 +35,7 @@ public class BookingServiceCompleteNoCollectTests
       new FakeNotifier(),
       null!,
       null!,
+      null!,
       null!
     );
 
@@ -208,7 +209,7 @@ public class BookingServiceCompleteNoCollectTests
     public Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 
-    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal fee) =>
+    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee) =>
       throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>

--- a/UnitTest/Bookings/BookingServicePrioritizeTests.cs
+++ b/UnitTest/Bookings/BookingServicePrioritizeTests.cs
@@ -31,7 +31,8 @@ public class BookingServicePrioritizeTests
     Booking? booking,
     PrioritySettingsRecord? settings = null,
     bool allowlisted = false,
-    bool walletInsufficient = false
+    bool walletInsufficient = false,
+    UserRecord? user = null
   )
   {
     var repo = new FakeBookingRepository(booking);
@@ -50,6 +51,7 @@ public class BookingServicePrioritizeTests
       new FakeNotifier(),
       new FakePrioritySettingsRepository(settings),
       new FakePriorityAccessRepository(allowlisted),
+      new FakeUserRepository(user),
       NullLogger<BookingService>.Instance
     );
     return (service, repo, wallet, txn);
@@ -295,6 +297,198 @@ public class BookingServicePrioritizeTests
     result.SuccessOrDefault().Fee.Should().Be(Fee, "the default fee is 10");
   }
 
+  // ---- free boost (FreeTarget) ----
+
+  private static Domain.Discount.DiscountTarget RoleTarget(string role) =>
+    new()
+    {
+      MatchMode = Domain.Discount.DiscountMatchMode.Any,
+      Matches = [new Domain.Discount.DiscountMatch
+      {
+        Type = Domain.Discount.DiscountMatchType.Role,
+        Value = role,
+      }],
+    };
+
+  [Fact]
+  public async Task Prioritize_free_target_match_charges_nothing_and_snapshots_null()
+  {
+    var b = BookingWith(BookStatus.Pending);
+    var settings = PrioritySettingsRecord.Default with
+    {
+      AllowAll = true,
+      FreeTarget = RoleTarget("admin"),
+    };
+    // owner's persisted roles carry admin — matched via the Roles mirror
+    var (service, repo, wallet, txn) = Make(
+      b,
+      settings,
+      user: new UserRecord { Username = "tester", Roles = ["admin"] }
+    );
+
+    var result = await service.Prioritize("user-1", b.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    wallet.CollectCalls.Should().Be(0, "a free boost moves no money");
+    txn.Records.Should().BeEmpty("no ledger row for a free boost — cleaner ledger");
+    repo.PrioritizeCalls.Should().Be(1);
+    repo.LastPrioritizeFee.Should().BeNull("nothing charged, so nothing to ever refund");
+  }
+
+  [Fact]
+  public async Task Prioritize_free_via_extra_roles_union()
+  {
+    var b = BookingWith(BookStatus.Pending);
+    var settings = PrioritySettingsRecord.Default with
+    {
+      AllowAll = true,
+      FreeTarget = RoleTarget("vip"),
+    };
+    // the role lives in admin-granted ExtraRoles, not the JWT mirror — the
+    // union must still match, exactly like pricing
+    var (service, repo, wallet, _) = Make(
+      b,
+      settings,
+      user: new UserRecord { Username = "tester", ExtraRoles = ["vip"] }
+    );
+
+    var result = await service.Prioritize("user-1", b.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    wallet.CollectCalls.Should().Be(0);
+    repo.LastPrioritizeFee.Should().BeNull();
+  }
+
+  [Fact]
+  public async Task Prioritize_free_target_miss_charges_the_fee()
+  {
+    var b = BookingWith(BookStatus.Pending);
+    var settings = PrioritySettingsRecord.Default with
+    {
+      AllowAll = true,
+      FreeTarget = RoleTarget("admin"),
+    };
+    var (service, repo, wallet, txn) = Make(
+      b,
+      settings,
+      user: new UserRecord { Username = "tester", Roles = ["field"] }
+    );
+
+    var result = await service.Prioritize("user-1", b.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    wallet.CollectCalls.Should().Be(1, "not free for this user");
+    wallet.LastCollectAmount.Should().Be(Fee);
+    txn.Records.Should().ContainSingle(r => r.Type == TransactionType.PriorityFee);
+    repo.LastPrioritizeFee.Should().Be(Fee);
+  }
+
+  [Fact]
+  public async Task Refund_of_free_boosted_booking_refunds_no_priority_fee()
+  {
+    // a free boost snapshots PriorityFee = null: the refund path must stay
+    // silent (nothing was charged)
+    var b = BookingWith(BookStatus.Pending, priority: true, priorityFee: null);
+    var (service, _, wallet, txn) = Make(b);
+
+    var result = await service.Refund(b.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    wallet.DepositCalls.Should().Be(0, "no priority fee to return");
+    txn.Records.Should().NotContain(r => r.Type == TransactionType.PriorityFee);
+  }
+
+  [Fact]
+  public async Task PriorityEligibility_reports_free_and_zero_fee_for_free_target_match()
+  {
+    var settings = PrioritySettingsRecord.Default with
+    {
+      AllowAll = true,
+      FreeTarget = RoleTarget("admin"),
+    };
+    var (service, _, _, _) = Make(
+      null,
+      settings,
+      user: new UserRecord { Username = "tester", Roles = ["admin"] }
+    );
+
+    var result = await service.PriorityEligibility("user-1");
+
+    result.IsSuccess().Should().BeTrue();
+    result.SuccessOrDefault().Eligible.Should().BeTrue();
+    result.SuccessOrDefault().Free.Should().BeTrue();
+    result.SuccessOrDefault().Fee.Should().Be(0m, "the shown fee is 0 when free");
+  }
+
+  [Fact]
+  public async Task PriorityEligibility_caller_jwt_roles_are_authoritative_for_self()
+  {
+    var settings = PrioritySettingsRecord.Default with
+    {
+      AllowAll = true,
+      FreeTarget = RoleTarget("admin"),
+    };
+    // persisted mirror has NO admin role, but the caller's own JWT does —
+    // JWT wins for self-eligibility (∪ ExtraRoles still applies)
+    var (service, _, _, _) = Make(
+      null,
+      settings,
+      user: new UserRecord { Username = "tester", Roles = [] }
+    );
+
+    var result = await service.PriorityEligibility("user-1", ["admin"]);
+
+    result.IsSuccess().Should().BeTrue();
+    result.SuccessOrDefault().Free.Should().BeTrue();
+  }
+
+  // ---- access target (service flow) ----
+
+  [Fact]
+  public async Task Prioritize_access_target_overrides_allowlist()
+  {
+    var b = BookingWith(BookStatus.Pending);
+    var settings = PrioritySettingsRecord.Default with
+    {
+      AccessTarget = RoleTarget("vip"),
+    };
+    // allowlisted, but the access target does not match: refused
+    var (service, repo, wallet, _) = Make(
+      b,
+      settings,
+      allowlisted: true,
+      user: new UserRecord { Username = "tester", Roles = [] }
+    );
+
+    var result = await service.Prioritize("user-1", b.Principal.Id);
+
+    result.IsSuccess().Should().BeFalse("the access target replaces the allowlist");
+    wallet.CollectCalls.Should().Be(0);
+    repo.PrioritizeCalls.Should().Be(0);
+  }
+
+  [Fact]
+  public async Task Prioritize_access_target_admits_matching_user_without_allowlist()
+  {
+    var b = BookingWith(BookStatus.Pending);
+    var settings = PrioritySettingsRecord.Default with
+    {
+      AccessTarget = RoleTarget("vip"),
+    };
+    var (service, repo, wallet, _) = Make(
+      b,
+      settings,
+      allowlisted: false,
+      user: new UserRecord { Username = "tester", Roles = ["vip"] }
+    );
+
+    var result = await service.Prioritize("user-1", b.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    wallet.CollectCalls.Should().Be(1, "in the access target but not free — normal fee");
+    repo.PrioritizeCalls.Should().Be(1);
+  }
+
   // ---- priority fee refunds ----
 
   [Fact]
@@ -421,6 +615,54 @@ public class BookingServicePrioritizeTests
       Task.FromResult((Result<Unit>)new Unit());
   }
 
+  private sealed class FakeUserRepository(UserRecord? user) : IUserRepository
+  {
+    public Task<Result<User?>> GetById(string id) =>
+      Task.FromResult(
+        (Result<User?>)(
+          user == null
+            ? null
+            : new User
+            {
+              Principal = new UserPrincipal { Id = id, Record = user },
+              Wallet = new WalletPrincipal
+              {
+                Id = Guid.NewGuid(),
+                UserId = id,
+                Record = new WalletRecord
+                {
+                  Usable = 0m,
+                  WithdrawReserve = 0m,
+                  BookingReserve = 0m,
+                },
+              },
+            }
+        )
+      );
+
+    public Task<Result<IEnumerable<UserPrincipal>>> Search(UserSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<User?>> GetByUsername(string username) =>
+      throw new NotImplementedException();
+
+    public Task<Result<bool>> Exists(string username) => throw new NotImplementedException();
+
+    public Task<Result<UserPrincipal>> Create(string id, UserRecord record) =>
+      throw new NotImplementedException();
+
+    public Task<Result<UserPrincipal?>> Update(string id, UserRecord record) =>
+      throw new NotImplementedException();
+
+    public Task<Result<UserPrincipal?>> AddExtraRole(string id, string role) =>
+      throw new NotImplementedException();
+
+    public Task<Result<UserPrincipal?>> RemoveExtraRole(string id, string role) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Unit?>> Delete(string id) => throw new NotImplementedException();
+  }
+
   private sealed class FakePrioritySettingsRepository(PrioritySettingsRecord? settings)
     : IPrioritySettingsRepository
   {
@@ -505,7 +747,7 @@ public class BookingServicePrioritizeTests
       return Task.FromResult((Result<BookingPrincipal?>)Current()!.Principal);
     }
 
-    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal fee)
+    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee)
     {
       PrioritizeCalls++;
       LastPrioritizeFee = fee;

--- a/UnitTest/Bookings/BookingServiceRecoverRevertTests.cs
+++ b/UnitTest/Bookings/BookingServiceRecoverRevertTests.cs
@@ -34,6 +34,7 @@ public class BookingServiceRecoverRevertTests
       null!,
       null!,
       null!,
+      null!,
       null!
     );
 
@@ -285,7 +286,7 @@ public class BookingServiceRecoverRevertTests
     public Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 
-    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal fee) =>
+    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee) =>
       throw new NotImplementedException();
 
     public Task<Result<Unit?>> Delete(string? userId, Guid id) =>

--- a/UnitTest/Bookings/BookingServiceRevertGuardTests.cs
+++ b/UnitTest/Bookings/BookingServiceRevertGuardTests.cs
@@ -34,6 +34,7 @@ public class BookingServiceRevertGuardTests
       null!,
       null!,
       null!,
+      null!,
       null!
     );
 
@@ -346,7 +347,7 @@ public class BookingServiceRevertGuardTests
     public Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 
-    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal fee) =>
+    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee) =>
       throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>

--- a/UnitTest/Bookings/BookingServiceTerminateTests.cs
+++ b/UnitTest/Bookings/BookingServiceTerminateTests.cs
@@ -44,6 +44,7 @@ public class BookingServiceTerminateTests
       new FakeNotifier(),
       null!,
       null!,
+      null!,
       NullLogger<BookingService>.Instance
     );
     return (service, wallet, txn);
@@ -304,7 +305,7 @@ public class BookingServiceTerminateTests
       return Task.FromResult((Result<BookingPrincipal?>)Current().Principal);
     }
 
-    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal fee) =>
+    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee) =>
       throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>

--- a/UnitTest/Bookings/BookingServiceTicketHealthTests.cs
+++ b/UnitTest/Bookings/BookingServiceTicketHealthTests.cs
@@ -30,6 +30,7 @@ public class BookingServiceTicketHealthTests
       null!,
       null!,
       null!,
+      null!,
       null!
     );
 
@@ -200,7 +201,7 @@ public class BookingServiceTicketHealthTests
     public Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 
-    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal fee) =>
+    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee) =>
       throw new NotImplementedException();
 
     public Task<Result<Unit?>> Delete(string? userId, Guid id) =>

--- a/UnitTest/Bookings/PriorityTargetingTests.cs
+++ b/UnitTest/Bookings/PriorityTargetingTests.cs
@@ -1,0 +1,133 @@
+using Domain.Booking;
+using Domain.Discount;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// Priority boost targeting: FreeTarget decides who boosts free, AccessTarget
+// (when configured) replaces the legacy allowlist/AllowAll gate. Null targets
+// keep legacy behavior byte-for-byte.
+public class PriorityTargetingTests
+{
+  private static readonly TimeOnly Noon = new(12, 0);
+
+  private static DiscountTarget Target(DiscountMatchMode mode, params DiscountMatch[] matches) =>
+    new() { MatchMode = mode, Matches = matches };
+
+  private static DiscountMatch Role(string value) =>
+    new() { Type = DiscountMatchType.Role, Value = value };
+
+  private static DiscountMatch UserId(string value) =>
+    new() { Type = DiscountMatchType.UserId, Value = value };
+
+  private static PrioritySettingsRecord Settings(
+    bool allowAll = false,
+    DiscountTarget? free = null,
+    DiscountTarget? access = null,
+    TimeOnly? start = null,
+    TimeOnly? end = null
+  ) =>
+    PrioritySettingsRecord.Default with
+    {
+      AllowAll = allowAll,
+      FreeTarget = free,
+      AccessTarget = access,
+      WindowStartSgt = start,
+      WindowEndSgt = end,
+    };
+
+  // ---- FreeTarget: who boosts free ----
+
+  [Fact]
+  public void Null_free_target_means_nobody_is_free()
+  {
+    PriorityRules.Free(Settings(), "u1", ["admin"]).Should().BeFalse();
+  }
+
+  [Fact]
+  public void Free_by_role_match()
+  {
+    var s = Settings(free: Target(DiscountMatchMode.Any, Role("admin")));
+    PriorityRules.Free(s, "u1", ["admin"]).Should().BeTrue("admin role boosts free");
+    PriorityRules.Free(s, "u1", ["field"]).Should().BeFalse();
+    PriorityRules.Free(s, "u1", []).Should().BeFalse();
+  }
+
+  [Fact]
+  public void Free_by_user_id_match()
+  {
+    var s = Settings(free: Target(DiscountMatchMode.Any, UserId("vip-user"), Role("admin")));
+    PriorityRules.Free(s, "vip-user", []).Should().BeTrue("admin-added specific user");
+    PriorityRules.Free(s, "other", []).Should().BeFalse();
+  }
+
+  [Fact]
+  public void Free_all_mode_requires_every_match()
+  {
+    var s = Settings(free: Target(DiscountMatchMode.All, UserId("u1"), Role("vip")));
+    PriorityRules.Free(s, "u1", ["vip"]).Should().BeTrue();
+    PriorityRules.Free(s, "u1", []).Should().BeFalse();
+    PriorityRules.Free(s, "u2", ["vip"]).Should().BeFalse();
+  }
+
+  [Fact]
+  public void Free_none_mode_makes_everyone_free()
+  {
+    var s = Settings(free: Target(DiscountMatchMode.None));
+    PriorityRules.Free(s, "anyone", []).Should().BeTrue();
+  }
+
+  // ---- AccessTarget: who may prioritize at all ----
+
+  [Fact]
+  public void Null_access_target_keeps_legacy_allowlist_semantics()
+  {
+    PriorityRules.Eligible(true, Settings(), Noon, "u1", []).Should().BeTrue("allowlisted");
+    PriorityRules.Eligible(false, Settings(), Noon, "u1", []).Should().BeFalse();
+    PriorityRules
+      .Eligible(false, Settings(allowAll: true), Noon, "u1", [])
+      .Should()
+      .BeTrue("allow-all");
+  }
+
+  [Fact]
+  public void Access_target_takes_precedence_over_allowlist()
+  {
+    var s = Settings(access: Target(DiscountMatchMode.Any, Role("vip")));
+    // allowlisted but not in the target: the target wins — refused
+    PriorityRules.Eligible(true, s, Noon, "u1", []).Should().BeFalse();
+    // not allowlisted but in the target: allowed
+    PriorityRules.Eligible(false, s, Noon, "u1", ["vip"]).Should().BeTrue();
+  }
+
+  [Fact]
+  public void Access_target_takes_precedence_over_allow_all()
+  {
+    var s = Settings(allowAll: true, access: Target(DiscountMatchMode.Any, Role("vip")));
+    PriorityRules.Eligible(false, s, Noon, "u1", []).Should().BeFalse("AllowAll is overridden");
+    PriorityRules.Eligible(false, s, Noon, "u1", ["vip"]).Should().BeTrue();
+  }
+
+  [Fact]
+  public void Access_target_by_user_id()
+  {
+    var s = Settings(access: Target(DiscountMatchMode.Any, UserId("u1")));
+    PriorityRules.Eligible(false, s, Noon, "u1", []).Should().BeTrue();
+    PriorityRules.Eligible(false, s, Noon, "u2", []).Should().BeFalse();
+  }
+
+  [Fact]
+  public void Access_target_still_respects_the_window()
+  {
+    var s = Settings(
+      access: Target(DiscountMatchMode.None),
+      start: new TimeOnly(14, 0),
+      end: new TimeOnly(16, 0)
+    );
+    PriorityRules.Eligible(false, s, new TimeOnly(15, 0), "u1", []).Should().BeTrue();
+    PriorityRules
+      .Eligible(false, s, Noon, "u1", [])
+      .Should()
+      .BeFalse("outside the window even though the target matches");
+  }
+}

--- a/UnitTest/Discounts/TargetMatcherTests.cs
+++ b/UnitTest/Discounts/TargetMatcherTests.cs
@@ -1,0 +1,69 @@
+using Domain.Discount;
+using FluentAssertions;
+
+namespace UnitTest.Discounts;
+
+// The shared user/role targeting semantics (discounts + priority boost
+// free/access targeting): All = every match must hit, Any = at least one,
+// None = matches everyone.
+public class TargetMatcherTests
+{
+  private static DiscountTarget Target(DiscountMatchMode mode, params DiscountMatch[] matches) =>
+    new() { MatchMode = mode, Matches = matches };
+
+  private static DiscountMatch Role(string value) =>
+    new() { Type = DiscountMatchType.Role, Value = value };
+
+  private static DiscountMatch UserId(string value) =>
+    new() { Type = DiscountMatchType.UserId, Value = value };
+
+  [Fact]
+  public void None_matches_everyone_even_with_no_matches()
+  {
+    TargetMatcher.Matches(Target(DiscountMatchMode.None), "u1", []).Should().BeTrue();
+    TargetMatcher
+      .Matches(Target(DiscountMatchMode.None, Role("admin")), "u1", [])
+      .Should()
+      .BeTrue("None ignores the match list");
+  }
+
+  [Fact]
+  public void Any_hits_on_role_membership()
+  {
+    var t = Target(DiscountMatchMode.Any, Role("admin"), Role("vip"));
+    TargetMatcher.Matches(t, "u1", ["vip"]).Should().BeTrue();
+    TargetMatcher.Matches(t, "u1", ["staff"]).Should().BeFalse();
+    TargetMatcher.Matches(t, "u1", []).Should().BeFalse();
+  }
+
+  [Fact]
+  public void Any_hits_on_user_id()
+  {
+    var t = Target(DiscountMatchMode.Any, UserId("u1"), Role("admin"));
+    TargetMatcher.Matches(t, "u1", []).Should().BeTrue("targeted by id");
+    TargetMatcher.Matches(t, "u2", []).Should().BeFalse();
+    TargetMatcher.Matches(t, "u2", ["admin"]).Should().BeTrue("targeted by role");
+  }
+
+  [Fact]
+  public void All_requires_every_match_to_hit()
+  {
+    var t = Target(DiscountMatchMode.All, UserId("u1"), Role("vip"));
+    TargetMatcher.Matches(t, "u1", ["vip"]).Should().BeTrue();
+    TargetMatcher.Matches(t, "u1", []).Should().BeFalse("role missing");
+    TargetMatcher.Matches(t, "u2", ["vip"]).Should().BeFalse("wrong user");
+  }
+
+  [Fact]
+  public void All_with_empty_matches_matches_everyone()
+  {
+    // vacuous truth, mirroring the discount matcher's historical behavior
+    TargetMatcher.Matches(Target(DiscountMatchMode.All), "u1", []).Should().BeTrue();
+  }
+
+  [Fact]
+  public void Any_with_empty_matches_matches_no_one()
+  {
+    TargetMatcher.Matches(Target(DiscountMatchMode.Any), "u1", ["admin"]).Should().BeFalse();
+  }
+}

--- a/UnitTest/Payments/PaymentServiceDepositFeeTests.cs
+++ b/UnitTest/Payments/PaymentServiceDepositFeeTests.cs
@@ -119,6 +119,9 @@ public class PaymentServiceDepositFeeTests
 
   private sealed class FakePaymentRepository : IPaymentRepository
   {
+    public Task<Result<IEnumerable<CapturedPayment>>> ListCaptured(CapturedPaymentsQuery query) =>
+      throw new NotSupportedException();
+
     public Task<Result<IEnumerable<PaymentPrincipal>>> Search(PaymentSearch search) =>
       throw new NotSupportedException();
 


### PR DESCRIPTION
## Summary

Two features in one branch:

### Feature A — Sales/revenue analysis (backs the new argon "Analysis" page)

**`GET api/v1/Booking/analysis?After=&Before=`** (OnlyAdmin, dates `dd-MM-yyyy`, inclusive):

```json
{
  "rows": [
    { "date": "01-07-2026", "direction": "JToW", "time": "08:30:00",
      "ticketsCompleted": 4, "grossRevenue": 64.0 }
  ],
  "summary": {
    "totalTickets": 4,
    "totalGross": 64.0,
    "deposits": { "count": 2, "captured": 100.0 },
    "internalFees": { "deposit": 1.0, "withdrawal": 2.0, "priority": 20.0, "termination": 8.0 }
  }
}
```

- Rows come from **Completed** bookings grouped DB-side by the **SGT calendar date of `CompletedAt`** (same UTC+8 wall-clock convention `booking_stats` bakes into its view), direction and departure time.
- **Authoritative amount source**: the booking's REQUEST transaction (`Bookings.TransactionId → Transactions.Amount`). `Generator.CompleteBooking` copies `create.Amount` verbatim into the BookingComplete ledger row and `Complete()` collects exactly `b.Transaction.Record.Amount`, so the request row, the completion ledger row and the wallet movement agree by construction — and only the request row is FK-linked per booking, making it the joinable source of truth.
- `internalFees.priority` is **net** (charges minus refunds — both rows share `TransactionType.PriorityFee`, told apart by account); `internalFees.termination` = terminated bookings' collected cost minus the refunds their `BookingTerminated` ledger rows returned.
- **GROSS figures + our internal fees only**: Airwallex's own gateway fees are not stored anywhere (no API for them yet).
- All aggregation is DB-side (one raw grouped SQL query + grouped ledger scan); no N+1, no schema changes.

**`GET api/v1/Payment/captured?After=&Before=&Limit=`** (OnlyAdmin, limit ≤ 100, default 100) — intent-level evidence rows, newest first:

```json
[ { "paymentIntentId": "int_...", "capturedAmount": 50.0, "currency": "SGD",
    "createdAt": "...", "status": "succeeded" } ]
```

### Feature B — Priority boost role targeting (admin boosts = free)

`PrioritySettings` (insert-only settings row) gains two nullable owned-JSON targets, same shape as discount targets (`MatchMode: All|Any|None`, matches over `UserId`/`Role`):

- **`FreeTarget`** — who gets the boost FREE: fee shown as 0 (`free: true` in eligibility), **no wallet movement and no ledger row** on prioritize, `PriorityFee` snapshot stays `null` so the refund path stays silent. Matched against the user's **pricing roles** (JWT roles ∪ admin-granted `ExtraRoles` via `PurchasePricingRoles` — the same union pricing uses), plus userId matches for boosting specific people.
- **`AccessTarget`** — who may prioritize at all: when set it **takes precedence over** `AllowAll`/the `PriorityAccessData` allowlist; `null` = legacy behavior byte-for-byte. The SGT availability window still gates both paths.

API changes (backwards compatible — old fields untouched, new fields optional):
- `GET/POST api/v1/Booking/priority/settings` carry `freeTarget`/`accessTarget` using the Discounts API target shapes (`{ matchMode, matches: [{ value, matchType }] }`).
- `GET api/v1/Booking/priority/eligibility` response: `{ eligible, fee, free }`.

Migration: **`20260712005801_AddPriorityTargets`** — two nullable `jsonb` columns on `PrioritySettings`.

`TargetMatcher` extracted so discount matching and priority targeting share one matcher implementation.

## Tests

- Baseline 411 → **444 passing** (33 new): analysis summary math (net priority, termination fee, deposit pass-through), target-matching matrix (All/Any/None × role/userId, null targets → legacy, access-target precedence over allowlist/AllowAll), free-boost service flow (no collect/no ledger/null snapshot, ExtraRoles union, JWT-authoritative self checks, refund silence), API mapper round-trips.
- `dotnet format style`/`whitespace` run on changed files; build clean.