### PR TITLE
feat(withdrawal): configurable method policy and sweep switch

### DIFF
--- a/App/Migrations/20260712013109_AddWithdrawalSettings.Designer.cs
+++ b/App/Migrations/20260712013109_AddWithdrawalSettings.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using App.StartUp.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace App.Migrations
 {
     [DbContext(typeof(MainDbContext))]
-    partial class MainDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260712013109_AddWithdrawalSettings")]
+    partial class AddWithdrawalSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/App/Migrations/20260712013109_AddWithdrawalSettings.cs
+++ b/App/Migrations/20260712013109_AddWithdrawalSettings.cs
@@ -1,0 +1,37 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace App.Migrations
+{
+  /// <inheritdoc />
+  public partial class AddWithdrawalSettings : Migration
+  {
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+      migrationBuilder.CreateTable(
+          name: "WithdrawalSettings",
+          columns: table => new
+          {
+            Id = table.Column<Guid>(type: "uuid", nullable: false),
+            CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+            CardRefundEnabled = table.Column<bool>(type: "boolean", nullable: false),
+            PayNowMode = table.Column<byte>(type: "smallint", nullable: false),
+            SweepEnabled = table.Column<bool>(type: "boolean", nullable: false)
+          },
+          constraints: table =>
+          {
+            table.PrimaryKey("PK_WithdrawalSettings", x => x.Id);
+          });
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+      migrationBuilder.DropTable(
+          name: "WithdrawalSettings");
+    }
+  }
+}

--- a/App/Modules/DomainServices.cs
+++ b/App/Modules/DomainServices.cs
@@ -125,6 +125,9 @@ public static class DomainServices
 
     s.AddScoped<IRefundGateway, AirwallexRefundGateway>().AutoTrace<IRefundGateway>();
 
+    s.AddScoped<IWithdrawalSettingsRepository, WithdrawalSettingsRepository>()
+      .AutoTrace<IWithdrawalSettingsRepository>();
+
     // Cost
     s.AddScoped<ICostCalculator, CostCalculator>().AutoTrace<ICostCalculator>();
 
@@ -159,7 +162,7 @@ public static class DomainServices
     s.AddScoped<AirwallexEventAdapter>();
     s.AddScoped<AirwallexHmacCalculator>();
     s.AddScoped<AirwallexWebhookService>();
-    
+
     // Booking Email Notifications
     s.AddScoped<IBookingEmailNotifier, BookingEmailNotifierAdapter>()
       .AutoTrace<IBookingEmailNotifier>();

--- a/App/Modules/Withdrawals/API/V1/WithdrawalController.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalController.cs
@@ -26,6 +26,7 @@ public class WithdrawalController(
   RejectWithdrawalReqValidator rejectWithdrawalReqValidator,
   CancelWithdrawalReqValidator cancelWithdrawalReqValidator,
   SearchWithdrawalQueryValidator searchWithdrawalQueryValidator,
+  SetWithdrawalSettingsReqValidator setWithdrawalSettingsReqValidator,
   IWithdrawalImageEnricher enrich,
   IFeeCalculator feeCalculator,
   IOptionsSnapshot<WithdrawalOption> withdrawalOptions,
@@ -142,6 +143,32 @@ public class WithdrawalController(
       .Approve(id, this.RefundWindowDays)
       .Then(w => w.ToRes(), Errors.MapNone)
       .ThenAwait(enrich.Enrich);
+    return this.ReturnResult(x);
+  }
+
+  // The withdrawal settings in effect right now (defaults when never
+  // configured). Readable by ANY authenticated caller: the create dialog
+  // needs the method availability for regular users, and tin's sweep polls
+  // SweepEnabled — plain [Authorize] admits tin's M2M token, since it is the
+  // same JWT bearer authentication the AdminOrTin endpoints already pass
+  // (the policy only ADDS a roles check on top).
+  [Authorize, HttpGet("settings/current")]
+  public async Task<ActionResult<WithdrawalSettingsRes>> GetSettings()
+  {
+    var x = await service.GetCurrentSettings().Then(s => s.ToRes(), Errors.MapNone);
+    return this.ReturnResult(x);
+  }
+
+  // Replace the withdrawal settings (insert-only latest, like PrioritySettings)
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpPost("settings")]
+  public async Task<ActionResult<WithdrawalSettingsRes>> SetSettings(
+    [FromBody] SetWithdrawalSettingsReq req
+  )
+  {
+    var x = await setWithdrawalSettingsReqValidator
+      .ValidateAsyncResult(req, "Invalid SetWithdrawalSettingsReq")
+      .ThenAwait(r => service.CreateSettings(r.ToDomain()))
+      .Then(s => s.Record.ToRes(), Errors.MapNone);
     return this.ReturnResult(x);
   }
 

--- a/App/Modules/Withdrawals/API/V1/WithdrawalMapper.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalMapper.cs
@@ -78,7 +78,36 @@ public static class WithdrawalMapper
       w.Refunds.Select(x => x.ToRes())
     );
 
+  public static string ToRes(this PayNowMode mode) =>
+    mode switch
+    {
+      PayNowMode.Enabled => "Enabled",
+      PayNowMode.Disabled => "Disabled",
+      PayNowMode.FallbackOnly => "FallbackOnly",
+      _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null),
+    };
+
+  public static WithdrawalSettingsRes ToRes(this WithdrawalSettingsRecord record) =>
+    new(record.CardRefundEnabled, record.PayNowMode.ToRes(), record.SweepEnabled);
+
   // REQ -> Domain
+  public static PayNowMode ToPayNowMode(this string mode) =>
+    mode switch
+    {
+      "Enabled" => PayNowMode.Enabled,
+      "Disabled" => PayNowMode.Disabled,
+      "FallbackOnly" => PayNowMode.FallbackOnly,
+      _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null),
+    };
+
+  public static WithdrawalSettingsRecord ToDomain(this SetWithdrawalSettingsReq req) =>
+    new()
+    {
+      CardRefundEnabled = req.CardRefundEnabled,
+      PayNowMode = req.PayNowMode.ToPayNowMode(),
+      SweepEnabled = req.SweepEnabled,
+    };
+
   public static WithdrawalMethod ToWithdrawalMethod(this string? method) =>
     method switch
     {

--- a/App/Modules/Withdrawals/API/V1/WithdrawalModel.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalModel.cs
@@ -68,3 +68,21 @@ public record WithdrawalRes(
 // GET Withdrawal/refundable/{userId}: how much the user could withdraw via
 // card refunds right now, and the window that pool was computed over
 public record RefundablePoolRes(decimal Pool, int WindowDays);
+
+// POST Withdrawal/settings: replace the withdrawal method policy and the tin
+// sweep switch. PayNowMode: "Enabled" | "Disabled" | "FallbackOnly" (PayNow
+// accepted only when the refundable pool cannot cover the amount).
+public record SetWithdrawalSettingsReq(
+  bool CardRefundEnabled,
+  string PayNowMode,
+  bool SweepEnabled
+);
+
+// GET Withdrawal/settings/current: the settings in effect right now
+// (defaults when never configured). Any logged-in caller may read it — the
+// create dialog needs the method availability, and tin polls SweepEnabled.
+public record WithdrawalSettingsRes(
+  bool CardRefundEnabled,
+  string PayNowMode,
+  bool SweepEnabled
+);

--- a/App/Modules/Withdrawals/API/V1/WithdrawalValidator.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalValidator.cs
@@ -49,6 +49,18 @@ public class CreateWithdrawalReqValidator : AbstractValidator<CreateWithdrawalRe
   }
 }
 
+public class SetWithdrawalSettingsReqValidator : AbstractValidator<SetWithdrawalSettingsReq>
+{
+  private static readonly string[] Modes = ["Enabled", "Disabled", "FallbackOnly"];
+
+  public SetWithdrawalSettingsReqValidator()
+  {
+    this.RuleFor(x => x.PayNowMode)
+      .Must(m => Modes.Contains(m))
+      .WithMessage("PayNowMode must be 'Enabled', 'Disabled' or 'FallbackOnly'");
+  }
+}
+
 public class CancelWithdrawalReqValidator : AbstractValidator<CancelWithdrawalReq>
 {
   public CancelWithdrawalReqValidator()

--- a/App/Modules/Withdrawals/Data/WithdrawalSettingsData.cs
+++ b/App/Modules/Withdrawals/Data/WithdrawalSettingsData.cs
@@ -1,0 +1,22 @@
+namespace App.Modules.Withdrawals.Data;
+
+// Insert-only withdrawal method policy + tin sweep switch (newest CreatedAt
+// wins, like PrioritySettings); with no row the domain defaults apply
+// (CardRefundEnabled, PayNow fallback-only, sweep off)
+public class WithdrawalSettingsData
+{
+  public Guid Id { get; set; }
+
+  public DateTime CreatedAt { get; set; }
+
+  // Record
+  // may users create card-refund withdrawals
+  public bool CardRefundEnabled { get; set; }
+
+  // 0 = Enabled, 1 = Disabled, 2 = FallbackOnly (accepted only when the
+  // refundable pool cannot cover the requested amount)
+  public byte PayNowMode { get; set; }
+
+  // runtime switch for tin's automated withdrawal sweep
+  public bool SweepEnabled { get; set; }
+}

--- a/App/Modules/Withdrawals/Data/WithdrawalSettingsRepository.cs
+++ b/App/Modules/Withdrawals/Data/WithdrawalSettingsRepository.cs
@@ -1,0 +1,80 @@
+using App.StartUp.Database;
+using App.Utility;
+using CSharp_Result;
+using Domain.Withdrawal;
+using Microsoft.EntityFrameworkCore;
+
+namespace App.Modules.Withdrawals.Data;
+
+public class WithdrawalSettingsRepository(
+  MainDbContext db,
+  ILogger<WithdrawalSettingsRepository> logger
+) : IWithdrawalSettingsRepository
+{
+  public async Task<Result<WithdrawalSettingsPrincipal?>> GetCurrent()
+  {
+    try
+    {
+      var r = await db
+        .WithdrawalSettings.OrderByDescending(x => x.CreatedAt)
+        .ThenByDescending(x => x.Id)
+        .FirstOrDefaultAsync();
+      return r?.ToPrincipal();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to read the current withdrawal settings");
+      return e;
+    }
+  }
+
+  public async Task<Result<WithdrawalSettingsPrincipal>> Create(WithdrawalSettingsRecord record)
+  {
+    try
+    {
+      logger.LogInformation("Creating WithdrawalSettings: {@Record}", record.ToJson());
+      var data = new WithdrawalSettingsData { CreatedAt = DateTime.UtcNow };
+      data.UpdateData(record);
+      var r = db.WithdrawalSettings.Add(data);
+      await db.SaveChangesAsync();
+      return r.Entity.ToPrincipal();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to create WithdrawalSettings {@Record}", record.ToJson());
+      return e;
+    }
+  }
+}
+
+public static class WithdrawalSettingsDataMapper
+{
+  // Data -> Domain
+  public static WithdrawalSettingsRecord ToRecord(this WithdrawalSettingsData data) =>
+    new()
+    {
+      CardRefundEnabled = data.CardRefundEnabled,
+      PayNowMode = (PayNowMode)data.PayNowMode,
+      SweepEnabled = data.SweepEnabled,
+    };
+
+  public static WithdrawalSettingsPrincipal ToPrincipal(this WithdrawalSettingsData data) =>
+    new()
+    {
+      Id = data.Id,
+      CreatedAt = data.CreatedAt,
+      Record = data.ToRecord(),
+    };
+
+  // Domain -> Data
+  public static WithdrawalSettingsData UpdateData(
+    this WithdrawalSettingsData data,
+    WithdrawalSettingsRecord record
+  )
+  {
+    data.CardRefundEnabled = record.CardRefundEnabled;
+    data.PayNowMode = (byte)record.PayNowMode;
+    data.SweepEnabled = record.SweepEnabled;
+    return data;
+  }
+}

--- a/App/StartUp/Database/MainDbContext.cs
+++ b/App/StartUp/Database/MainDbContext.cs
@@ -40,6 +40,8 @@ public class MainDbContext(
 
   public DbSet<WithdrawalRefundData> WithdrawalRefunds { get; set; }
 
+  public DbSet<WithdrawalSettingsData> WithdrawalSettings { get; set; }
+
   public DbSet<FeeData> Fees { get; set; }
 
   public DbSet<TransactionData> Transactions { get; set; }

--- a/Domain/Withdrawal/IService.cs
+++ b/Domain/Withdrawal/IService.cs
@@ -104,4 +104,11 @@ public interface IWithdrawalService
   Task<Result<WithdrawalPrincipal>> Requeue(Guid id);
 
   Task<Result<Unit?>> Delete(Guid id);
+
+  // The withdrawal settings in effect right now: the newest settings row, or
+  // the domain defaults when none was ever written
+  Task<Result<WithdrawalSettingsRecord>> GetCurrentSettings();
+
+  // Replace the withdrawal settings (insert-only latest, like PrioritySettings)
+  Task<Result<WithdrawalSettingsPrincipal>> CreateSettings(WithdrawalSettingsRecord record);
 }

--- a/Domain/Withdrawal/Service.cs
+++ b/Domain/Withdrawal/Service.cs
@@ -16,7 +16,8 @@ public class WithdrawalService(
   IFeeCalculator feeCalculator,
   IPayoutGateway payoutGateway,
   IWithdrawalRefundRepository refundRepo,
-  IRefundGateway refundGateway
+  IRefundGateway refundGateway,
+  IWithdrawalSettingsRepository settingsRepo
 ) : IWithdrawalService
 {
   private const int DefaultRefundWindowDays = IWithdrawalService.DefaultRefundWindowDays;
@@ -54,6 +55,10 @@ public class WithdrawalService(
         walletRepo
           .GetByUserId(userId)
           .NullToError(userId)
+          // method policy: the admin-configured withdrawal settings decide
+          // which rails accept NEW withdrawals right now (existing
+          // withdrawals are unaffected — approve/webhooks run regardless)
+          .ThenAwait(w => this.GuardMethodPolicy(w, record, refundWindowDays))
           // a card-refund withdrawal is only accepted when the refundable
           // pool covers the net amount — checked BEFORE the reserve moves so
           // a hopeless request never locks the user's funds. The pool is
@@ -90,6 +95,60 @@ public class WithdrawalService(
           )
           .ThenAwait(w => repo.Create(w.Principal.Id, record))
     );
+  }
+
+  // Method policy for NEW withdrawals, from the admin-configured settings
+  // (defaults when never configured): CardRefund requires the rail to be
+  // enabled; PayNow is accepted when Enabled, or under FallbackOnly only
+  // when the refundable pool cannot cover the requested amount (the pool is
+  // computed once, only when FallbackOnly makes it relevant). Rejections are
+  // distinguishable invalid-operation errors so the UI can explain why.
+  private async Task<Result<WalletAggregate>> GuardMethodPolicy(
+    WalletAggregate w,
+    WithdrawalRecord record,
+    int refundWindowDays
+  )
+  {
+    var settingsR = await settingsRepo.GetCurrent();
+    if (settingsR.IsFailure())
+      return settingsR.FailureOrDefault();
+    var settings = settingsR.SuccessOrDefault()?.Record ?? WithdrawalSettingsRecord.Default;
+
+    if (record.Method == WithdrawalMethod.CardRefund)
+    {
+      if (!settings.CardRefundEnabled)
+        return new InvalidWithdrawalOperationException(
+          "Card-refund withdrawals are currently disabled — use PayNow instead",
+          WithdrawStatus.Pending,
+          WithdrawalOperations.Create
+        );
+      return w;
+    }
+
+    switch (settings.PayNowMode)
+    {
+      case PayNowMode.Enabled:
+        return w;
+      case PayNowMode.Disabled:
+        return new InvalidWithdrawalOperationException(
+          "PayNow withdrawals are currently disabled — use a card refund instead",
+          WithdrawStatus.Pending,
+          WithdrawalOperations.Create
+        );
+      default:
+        // FallbackOnly: PayNow only carries what the card rail cannot cover
+        var poolR = await this.ComputePool(w.Principal.Id, refundWindowDays);
+        if (poolR.IsFailure())
+          return poolR.FailureOrDefault();
+        var pool = poolR.SuccessOrDefault().Sum(x => x.Refundable);
+        if (pool < record.Amount)
+          return w;
+        return new InvalidWithdrawalOperationException(
+          $"A card refund can cover this amount (refundable pool SGD {pool:0.00}) — PayNow is available only as a fallback when card refunds cannot cover the withdrawal",
+          WithdrawStatus.Pending,
+          WithdrawalOperations.Create
+        );
+    }
   }
 
   // The wallet's refundable pool: captured Airwallex card payments inside the
@@ -1193,6 +1252,20 @@ public class WithdrawalService(
   public Task<Result<Unit?>> Delete(Guid id)
   {
     return repo.Delete(id);
+  }
+
+  public Task<Result<WithdrawalSettingsRecord>> GetCurrentSettings()
+  {
+    return settingsRepo
+      .GetCurrent()
+      .Then(s => s?.Record ?? WithdrawalSettingsRecord.Default, Errors.MapNone);
+  }
+
+  public Task<Result<WithdrawalSettingsPrincipal>> CreateSettings(
+    WithdrawalSettingsRecord record
+  )
+  {
+    return settingsRepo.Create(record);
   }
 
   // Collects the full reserved amount: net to BunnyBooker (paid out to the

--- a/Domain/Withdrawal/Settings.cs
+++ b/Domain/Withdrawal/Settings.cs
@@ -1,0 +1,57 @@
+using CSharp_Result;
+
+namespace Domain.Withdrawal;
+
+// Availability of the PayNow rail for NEW withdrawals: always, never, or only
+// when the card rail cannot cover the requested amount (fallback)
+public enum PayNowMode
+{
+  Enabled = 0,
+  Disabled = 1,
+
+  // PayNow is accepted only when the refundable pool cannot cover the
+  // requested amount — card refunds are the preferred rail
+  FallbackOnly = 2,
+}
+
+// Admin-editable withdrawal method policy and the tin sweep switch
+// (insert-only, newest row wins — same pattern as PrioritySettings). With no
+// row the defaults apply.
+public record WithdrawalSettingsRecord
+{
+  // may users create card-refund withdrawals
+  public required bool CardRefundEnabled { get; init; }
+
+  // when may users create PayNow withdrawals
+  public required PayNowMode PayNowMode { get; init; }
+
+  // runtime switch for tin's automated withdrawal sweep (tin polls
+  // GET Withdrawal/settings/current and skips the sweep when off)
+  public required bool SweepEnabled { get; init; }
+
+  // matches the deployed reality before this table existed: both rails were
+  // live (PayNow as the fallback), and the tin nightly sweep is disabled
+  public static readonly WithdrawalSettingsRecord Default = new()
+  {
+    CardRefundEnabled = true,
+    PayNowMode = PayNowMode.FallbackOnly,
+    SweepEnabled = false,
+  };
+}
+
+public record WithdrawalSettingsPrincipal
+{
+  public required Guid Id { get; init; }
+
+  public required DateTime CreatedAt { get; init; }
+
+  public required WithdrawalSettingsRecord Record { get; init; }
+}
+
+public interface IWithdrawalSettingsRepository
+{
+  // the newest settings row, or null when none was ever written (defaults apply)
+  Task<Result<WithdrawalSettingsPrincipal?>> GetCurrent();
+
+  Task<Result<WithdrawalSettingsPrincipal>> Create(WithdrawalSettingsRecord record);
+}

--- a/Domain/Withdrawal/WithdrawalOperations.cs
+++ b/Domain/Withdrawal/WithdrawalOperations.cs
@@ -2,6 +2,8 @@ namespace Domain.Withdrawal;
 
 public static class WithdrawalOperations
 {
+  public const string Create = "Create";
+
   public const string Cancel = "Cancel";
 
   public const string Reject = "Reject";

--- a/UnitTest/Withdrawals/FakeWithdrawalSettingsRepository.cs
+++ b/UnitTest/Withdrawals/FakeWithdrawalSettingsRepository.cs
@@ -1,0 +1,45 @@
+using CSharp_Result;
+using Domain.Withdrawal;
+
+namespace UnitTest.Withdrawals;
+
+// Shared fake for the insert-only withdrawal settings store: null = no row
+// was ever written (the service falls back to WithdrawalSettingsRecord.Default)
+internal sealed class FakeWithdrawalSettingsRepository(WithdrawalSettingsRecord? settings)
+  : IWithdrawalSettingsRepository
+{
+  public WithdrawalSettingsRecord? Settings { get; set; } = settings;
+
+  public List<WithdrawalSettingsRecord> Created { get; } = [];
+
+  public int GetCurrentCalls { get; private set; }
+
+  public Task<Result<WithdrawalSettingsPrincipal?>> GetCurrent()
+  {
+    GetCurrentCalls++;
+    return Task.FromResult<Result<WithdrawalSettingsPrincipal?>>(
+      Settings == null
+        ? (WithdrawalSettingsPrincipal?)null
+        : new WithdrawalSettingsPrincipal
+        {
+          Id = Guid.NewGuid(),
+          CreatedAt = DateTime.UtcNow,
+          Record = Settings,
+        }
+    );
+  }
+
+  public Task<Result<WithdrawalSettingsPrincipal>> Create(WithdrawalSettingsRecord record)
+  {
+    Created.Add(record);
+    Settings = record;
+    return Task.FromResult<Result<WithdrawalSettingsPrincipal>>(
+      new WithdrawalSettingsPrincipal
+      {
+        Id = Guid.NewGuid(),
+        CreatedAt = DateTime.UtcNow,
+        Record = record,
+      }
+    );
+  }
+}

--- a/UnitTest/Withdrawals/SetWithdrawalSettingsReqValidatorTests.cs
+++ b/UnitTest/Withdrawals/SetWithdrawalSettingsReqValidatorTests.cs
@@ -1,0 +1,60 @@
+using App.Modules.Withdrawals.API.V1;
+using Domain.Withdrawal;
+using FluentAssertions;
+
+namespace UnitTest.Withdrawals;
+
+// The settings request's PayNowMode is a closed string enum; the booleans
+// need no validation. Also pins the string <-> enum mapping both ways.
+public class SetWithdrawalSettingsReqValidatorTests
+{
+  private readonly SetWithdrawalSettingsReqValidator validator = new();
+
+  [Theory]
+  [InlineData("Enabled")]
+  [InlineData("Disabled")]
+  [InlineData("FallbackOnly")]
+  public void Known_modes_pass(string mode)
+  {
+    var result = validator.Validate(new SetWithdrawalSettingsReq(true, mode, false));
+    result.IsValid.Should().BeTrue();
+  }
+
+  [Theory]
+  [InlineData("")]
+  [InlineData("enabled")]
+  [InlineData("Fallback")]
+  [InlineData("On")]
+  public void Unknown_modes_are_rejected(string mode)
+  {
+    var result = validator.Validate(new SetWithdrawalSettingsReq(true, mode, false));
+    result.IsValid.Should().BeFalse();
+  }
+
+  [Theory]
+  [InlineData("Enabled", PayNowMode.Enabled)]
+  [InlineData("Disabled", PayNowMode.Disabled)]
+  [InlineData("FallbackOnly", PayNowMode.FallbackOnly)]
+  public void Mode_maps_round_trip(string wire, PayNowMode domain)
+  {
+    wire.ToPayNowMode().Should().Be(domain);
+    domain.ToRes().Should().Be(wire);
+  }
+
+  [Fact]
+  public void Req_maps_to_record_and_record_maps_to_res()
+  {
+    var record = new SetWithdrawalSettingsReq(false, "FallbackOnly", true).ToDomain();
+    record.Should()
+      .Be(
+        new WithdrawalSettingsRecord
+        {
+          CardRefundEnabled = false,
+          PayNowMode = PayNowMode.FallbackOnly,
+          SweepEnabled = true,
+        }
+      );
+
+    record.ToRes().Should().Be(new WithdrawalSettingsRes(false, "FallbackOnly", true));
+  }
+}

--- a/UnitTest/Withdrawals/WithdrawalCardRefundTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalCardRefundTests.cs
@@ -52,7 +52,17 @@ public class WithdrawalCardRefundTests
       new FourPercentFeeCalculator(),
       payNowGateway,
       refunds,
-      gateway
+      gateway,
+      // both rails wide open: this suite exercises the card rail's money
+      // mechanics, not the method policy (WithdrawalSettingsPolicyTests)
+      new FakeWithdrawalSettingsRepository(
+        new WithdrawalSettingsRecord
+        {
+          CardRefundEnabled = true,
+          PayNowMode = PayNowMode.Enabled,
+          SweepEnabled = false,
+        }
+      )
     );
     return new Harness
     {

--- a/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
@@ -47,7 +47,18 @@ public class WithdrawalServiceGuardTests
       new FourPercentFeeCalculator(),
       gateway,
       new UnusedRefundRepository(),
-      new UnusedRefundGateway()
+      new UnusedRefundGateway(),
+      // both rails wide open: this suite exercises the PayNow rail's guards
+      // and money movement, not the method policy
+      // (WithdrawalSettingsPolicyTests)
+      new FakeWithdrawalSettingsRepository(
+        new WithdrawalSettingsRecord
+        {
+          CardRefundEnabled = true,
+          PayNowMode = PayNowMode.Enabled,
+          SweepEnabled = false,
+        }
+      )
     );
     return (service, repo, wallet, txn, gateway);
   }

--- a/UnitTest/Withdrawals/WithdrawalSettingsPolicyTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalSettingsPolicyTests.cs
@@ -1,0 +1,494 @@
+using CSharp_Result;
+using Domain;
+using Domain.Exceptions;
+using Domain.Transaction;
+using Domain.User;
+using Domain.Wallet;
+using Domain.Withdrawal;
+using FluentAssertions;
+
+namespace UnitTest.Withdrawals;
+
+// The admin-configurable withdrawal method policy enforced at CREATE: the
+// matrix of method x PayNowMode x pool coverage, the defaults when no
+// settings row was ever written, and the settings read/write plumbing.
+// The rails' money mechanics are covered by WithdrawalCardRefundTests and
+// WithdrawalServiceGuardTests (both run with the policy wide open).
+public class WithdrawalSettingsPolicyTests
+{
+  private const decimal Amount = 100m;
+
+  private static readonly Guid WalletId = Guid.NewGuid();
+
+  // ---- harness ----
+
+  private sealed class Harness
+  {
+    public required WithdrawalService Service { get; init; }
+    public required FakeWithdrawalSettingsRepository Settings { get; init; }
+    public required FakeRefundRepository Refunds { get; init; }
+    public required FakeWalletRepository Wallet { get; init; }
+    public required FakeTransactionRepository Txn { get; init; }
+  }
+
+  private static Harness Make(WithdrawalSettingsRecord? settings)
+  {
+    var settingsRepo = new FakeWithdrawalSettingsRepository(settings);
+    var refunds = new FakeRefundRepository();
+    var wallet = new FakeWalletRepository();
+    var txn = new FakeTransactionRepository();
+    var service = new WithdrawalService(
+      new FakeWithdrawalRepository(),
+      wallet,
+      txn,
+      new TransactionGenerator(),
+      new UnusedWithdrawalStorage(),
+      new PassThroughTransactionManager(),
+      new FourPercentFeeCalculator(),
+      new UnusedPayoutGateway(),
+      refunds,
+      new UnusedRefundGateway(),
+      settingsRepo
+    );
+    return new Harness
+    {
+      Service = service,
+      Settings = settingsRepo,
+      Refunds = refunds,
+      Wallet = wallet,
+      Txn = txn,
+    };
+  }
+
+  private static WithdrawalSettingsRecord Settings(
+    bool cardRefundEnabled = true,
+    PayNowMode payNowMode = PayNowMode.Enabled,
+    bool sweepEnabled = false
+  ) =>
+    new()
+    {
+      CardRefundEnabled = cardRefundEnabled,
+      PayNowMode = payNowMode,
+      SweepEnabled = sweepEnabled,
+    };
+
+  private static WithdrawalRecord Record(WithdrawalMethod method, decimal amount = Amount) =>
+    new()
+    {
+      Amount = amount,
+      Method = method,
+      PayNowNumber = method == WithdrawalMethod.PayNow ? "91234567" : null,
+    };
+
+  private static FundingPayment Payment(decimal captured) =>
+    new()
+    {
+      PaymentId = Guid.NewGuid(),
+      PaymentIntentId = $"int_{Guid.NewGuid():N}",
+      CreatedAt = DateTime.UtcNow.AddDays(-10),
+      CapturedAmount = captured,
+    };
+
+  private static Task<Result<WithdrawalPrincipal>> Create(Harness h, WithdrawalRecord record) =>
+    h.Service.Create("user-1", record);
+
+  private static void ShouldBeRejectedCreate(Result<WithdrawalPrincipal> result, string fragment)
+  {
+    result.IsSuccess().Should().BeFalse();
+    var e = result
+      .FailureOrDefault()
+      .Should()
+      .BeOfType<InvalidWithdrawalOperationException>()
+      .Which;
+    e.Operation.Should().Be(WithdrawalOperations.Create);
+    e.Message.Should().Contain(fragment);
+  }
+
+  // ---- defaults (no settings row) ----
+
+  [Fact]
+  public async Task Defaults_match_the_deployed_reality()
+  {
+    WithdrawalSettingsRecord.Default.CardRefundEnabled.Should().BeTrue();
+    WithdrawalSettingsRecord.Default.PayNowMode.Should().Be(PayNowMode.FallbackOnly);
+    WithdrawalSettingsRecord.Default.SweepEnabled.Should().BeFalse();
+
+    var h = Make(null);
+    var current = await h.Service.GetCurrentSettings();
+    current.IsSuccess().Should().BeTrue();
+    current.SuccessOrDefault().Should().Be(WithdrawalSettingsRecord.Default);
+  }
+
+  [Fact]
+  public async Task No_row_card_refund_is_allowed()
+  {
+    var h = Make(null);
+    h.Refunds.FundingPayments = [Payment(200m)];
+
+    var result = await Create(h, Record(WithdrawalMethod.CardRefund));
+
+    result.IsSuccess().Should().BeTrue();
+  }
+
+  [Fact]
+  public async Task No_row_paynow_is_fallback_only()
+  {
+    var h = Make(null);
+    // pool covers the amount, so under the default FallbackOnly PayNow is refused
+    h.Refunds.FundingPayments = [Payment(200m)];
+
+    var result = await Create(h, Record(WithdrawalMethod.PayNow));
+
+    ShouldBeRejectedCreate(result, "fallback");
+  }
+
+  // ---- CardRefund x CardRefundEnabled ----
+
+  [Fact]
+  public async Task Card_refund_disabled_rejects_before_any_money_moves()
+  {
+    var h = Make(Settings(cardRefundEnabled: false));
+    h.Refunds.FundingPayments = [Payment(200m)];
+
+    var result = await Create(h, Record(WithdrawalMethod.CardRefund));
+
+    ShouldBeRejectedCreate(result, "disabled");
+    h.Wallet.PrepareWithdrawCalls.Should().Be(0);
+    h.Txn.Records.Should().BeEmpty();
+    h.Refunds.PoolQueries.Should().Be(0, "the policy rejects before the pool is computed");
+  }
+
+  [Fact]
+  public async Task Card_refund_enabled_passes_the_policy()
+  {
+    var h = Make(Settings(cardRefundEnabled: true, payNowMode: PayNowMode.Disabled));
+    h.Refunds.FundingPayments = [Payment(200m)];
+
+    var result = await Create(h, Record(WithdrawalMethod.CardRefund));
+
+    result.IsSuccess().Should().BeTrue();
+    h.Wallet.PrepareWithdrawCalls.Should().Be(1);
+  }
+
+  [Fact]
+  public async Task Card_refund_enabled_still_requires_a_covering_pool()
+  {
+    var h = Make(Settings(cardRefundEnabled: true));
+    h.Refunds.FundingPayments = [Payment(10m)];
+
+    var result = await Create(h, Record(WithdrawalMethod.CardRefund));
+
+    result.IsSuccess().Should().BeFalse();
+    result.FailureOrDefault().Should().BeOfType<InsufficientRefundablePoolException>();
+  }
+
+  // ---- PayNow x PayNowMode x pool ----
+
+  [Theory]
+  [InlineData(true)] // pool covers the amount
+  [InlineData(false)] // pool does not
+  public async Task Paynow_enabled_is_accepted_regardless_of_the_pool(bool poolCovers)
+  {
+    var h = Make(Settings(payNowMode: PayNowMode.Enabled));
+    h.Refunds.FundingPayments = poolCovers ? [Payment(200m)] : [];
+
+    var result = await Create(h, Record(WithdrawalMethod.PayNow));
+
+    result.IsSuccess().Should().BeTrue();
+    h.Refunds.PoolQueries.Should().Be(0, "Enabled never needs the pool");
+  }
+
+  [Theory]
+  [InlineData(true)]
+  [InlineData(false)]
+  public async Task Paynow_disabled_is_rejected_regardless_of_the_pool(bool poolCovers)
+  {
+    var h = Make(Settings(payNowMode: PayNowMode.Disabled));
+    h.Refunds.FundingPayments = poolCovers ? [Payment(200m)] : [];
+
+    var result = await Create(h, Record(WithdrawalMethod.PayNow));
+
+    ShouldBeRejectedCreate(result, "disabled");
+    h.Wallet.PrepareWithdrawCalls.Should().Be(0);
+    h.Txn.Records.Should().BeEmpty();
+    h.Refunds.PoolQueries.Should().Be(0, "Disabled never needs the pool");
+  }
+
+  [Fact]
+  public async Task Paynow_fallback_with_covering_pool_is_rejected_with_a_distinguishable_message()
+  {
+    var h = Make(Settings(payNowMode: PayNowMode.FallbackOnly));
+    h.Refunds.FundingPayments = [Payment(Amount)];
+
+    var result = await Create(h, Record(WithdrawalMethod.PayNow));
+
+    ShouldBeRejectedCreate(result, "fallback");
+    h.Wallet.PrepareWithdrawCalls.Should().Be(0);
+    h.Refunds.PoolQueries.Should().Be(1, "the pool is computed exactly once");
+  }
+
+  [Fact]
+  public async Task Paynow_fallback_with_short_pool_is_accepted()
+  {
+    var h = Make(Settings(payNowMode: PayNowMode.FallbackOnly));
+    // pool < requested GROSS amount: the card rail cannot carry this
+    // withdrawal, so PayNow is the legitimate fallback
+    h.Refunds.FundingPayments = [Payment(Amount - 1m)];
+
+    var result = await Create(h, Record(WithdrawalMethod.PayNow));
+
+    result.IsSuccess().Should().BeTrue();
+    h.Wallet.PrepareWithdrawCalls.Should().Be(1);
+    h.Refunds.PoolQueries.Should().Be(1, "the pool is computed exactly once");
+  }
+
+  [Fact]
+  public async Task Paynow_fallback_compares_the_pool_against_the_requested_amount()
+  {
+    var h = Make(Settings(payNowMode: PayNowMode.FallbackOnly));
+    // pool exactly equals the requested amount -> card refunds can cover it
+    h.Refunds.FundingPayments = [Payment(Amount)];
+
+    var rejected = await Create(h, Record(WithdrawalMethod.PayNow));
+    ShouldBeRejectedCreate(rejected, "fallback");
+  }
+
+  // ---- settings read/write plumbing ----
+
+  [Fact]
+  public async Task GetCurrentSettings_returns_the_newest_row()
+  {
+    var written = Settings(
+      cardRefundEnabled: false,
+      payNowMode: PayNowMode.Enabled,
+      sweepEnabled: true
+    );
+    var h = Make(written);
+
+    var current = await h.Service.GetCurrentSettings();
+
+    current.IsSuccess().Should().BeTrue();
+    current.SuccessOrDefault().Should().Be(written);
+  }
+
+  [Fact]
+  public async Task CreateSettings_inserts_and_becomes_current()
+  {
+    var h = Make(null);
+    var next = Settings(
+      cardRefundEnabled: false,
+      payNowMode: PayNowMode.Disabled,
+      sweepEnabled: true
+    );
+
+    var created = await h.Service.CreateSettings(next);
+
+    created.IsSuccess().Should().BeTrue();
+    created.SuccessOrDefault().Record.Should().Be(next);
+    h.Settings.Created.Should().ContainSingle().Which.Should().Be(next);
+    (await h.Service.GetCurrentSettings()).SuccessOrDefault().Should().Be(next);
+  }
+
+  // ---- fakes (create-path only; everything else is never touched) ----
+
+  private sealed class PassThroughTransactionManager : ITransactionManager
+  {
+    public Task<Result<T>> Start<T>(Func<Task<Result<T>>> func) => func();
+  }
+
+  private sealed class FourPercentFeeCalculator : IFeeCalculator
+  {
+    public Task<Result<FeeSpec>> Current(FeeType type) =>
+      Task.FromResult<Result<FeeSpec>>(new FeeSpec { Percentage = 4m, FlatAmount = 0m });
+
+    public Task<Result<decimal>> Compute(FeeType type, decimal amount) =>
+      Task.FromResult<Result<decimal>>(Math.Round(amount * 0.04m, 2, MidpointRounding.ToEven));
+  }
+
+  private sealed class FakeRefundRepository : IWithdrawalRefundRepository
+  {
+    public List<FundingPayment> FundingPayments { get; set; } = [];
+
+    public int PoolQueries { get; private set; }
+
+    public Task<Result<List<FundingPayment>>> ListFundingPayments(Guid walletId, DateTime since)
+    {
+      PoolQueries++;
+      return Task.FromResult<Result<List<FundingPayment>>>(
+        FundingPayments.Where(p => p.CreatedAt >= since).OrderBy(p => p.CreatedAt).ToList()
+      );
+    }
+
+    public Task<Result<Dictionary<Guid, decimal>>> SumActiveRefundsByPayment(
+      IEnumerable<Guid> paymentIds
+    ) => Task.FromResult<Result<Dictionary<Guid, decimal>>>(new Dictionary<Guid, decimal>());
+
+    public Task<Result<List<WithdrawalRefundFragment>>> ListByWithdrawal(Guid withdrawalId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WithdrawalRefundFragment?>> GetByRequestId(string requestId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<List<WithdrawalRefundFragment>>> CreateMany(
+      IEnumerable<WithdrawalRefundFragment> fragments
+    ) => throw new NotImplementedException();
+
+    public Task<Result<WithdrawalRefundFragment?>> Update(
+      Guid id,
+      RefundFragmentStatus? status,
+      string? airwallexRefundId,
+      DateTime? settledAt
+    ) => throw new NotImplementedException();
+  }
+
+  private sealed class FakeWithdrawalRepository : IWithdrawalRepository
+  {
+    public Task<Result<WithdrawalPrincipal>> Create(Guid walletId, WithdrawalRecord record) =>
+      Task.FromResult<Result<WithdrawalPrincipal>>(
+        new WithdrawalPrincipal
+        {
+          Id = Guid.NewGuid(),
+          CreatedAt = DateTime.UtcNow,
+          Status = new WithdrawalStatus { Status = WithdrawStatus.Pending },
+          Record = record,
+          Complete = null,
+          Payout = null,
+        }
+      );
+
+    public Task<Result<IEnumerable<WithdrawalPrincipal>>> Search(WithdrawalSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Withdrawal?>> Get(Guid id, string? userId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WithdrawalPrincipal?>> Update(
+      string? userId,
+      Guid id,
+      WithdrawalRecord? record,
+      WithdrawalStatus? status,
+      WithdrawalComplete? complete,
+      WithdrawalPayout? payout = null
+    ) => throw new NotImplementedException();
+
+    public Task<Result<Unit?>> Delete(Guid id) => throw new NotImplementedException();
+  }
+
+  private sealed class FakeWalletRepository : IWalletRepository
+  {
+    public int PrepareWithdrawCalls { get; private set; }
+
+    private static WalletPrincipal Wallet() =>
+      new()
+      {
+        Id = WalletId,
+        UserId = "user-1",
+        Record = new WalletRecord
+        {
+          Usable = 500m,
+          WithdrawReserve = 0m,
+          BookingReserve = 0m,
+        },
+      };
+
+    public Task<Result<Wallet?>> GetByUserId(string userId) =>
+      Task.FromResult<Result<Wallet?>>(
+        new Wallet
+        {
+          Principal = Wallet(),
+          User = new UserPrincipal
+          {
+            Id = "user-1",
+            Record = new UserRecord { Username = "tester" },
+          },
+        }
+      );
+
+    public Task<Result<WalletPrincipal?>> PrepareWithdraw(Guid id, decimal amount)
+    {
+      PrepareWithdrawCalls++;
+      return Task.FromResult<Result<WalletPrincipal?>>(Wallet());
+    }
+
+    public Task<Result<IEnumerable<WalletPrincipal>>> Search(WalletSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Wallet?>> Get(Guid id, string? userId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WalletPrincipal?>> Deposit(Guid id, decimal amount) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WalletPrincipal?>> Collect(Guid id, decimal amount) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WalletPrincipal?>> Withdraw(Guid id, decimal amount) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WalletPrincipal?>> CancelWithdraw(Guid id, decimal amount) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WalletPrincipal?>> BookStart(Guid id, decimal amount) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WalletPrincipal?>> BookEnd(Guid id, decimal revert, decimal collect) =>
+      throw new NotImplementedException();
+  }
+
+  private sealed class FakeTransactionRepository : ITransactionRepository
+  {
+    public List<TransactionRecord> Records { get; } = [];
+
+    public Task<Result<TransactionPrincipal>> Create(
+      Guid walletId,
+      TransactionRecord record,
+      Guid? paymentId = null
+    )
+    {
+      Records.Add(record);
+      return Task.FromResult<Result<TransactionPrincipal>>(
+        new TransactionPrincipal
+        {
+          Id = Guid.NewGuid(),
+          CreatedAt = DateTime.UtcNow,
+          Record = record,
+        }
+      );
+    }
+
+    public Task<Result<IEnumerable<TransactionPrincipal>>> Search(TransactionSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Transaction?>> Get(Guid id, string? userId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Unit?>> Delete(Guid id) => throw new NotImplementedException();
+  }
+
+  private sealed class UnusedWithdrawalStorage : IWithdrawalStorage
+  {
+    public Task<Result<string>> Save(Stream stream) => throw new NotImplementedException();
+
+    public Task<Result<string>> Get(string key) => throw new NotImplementedException();
+  }
+
+  private sealed class UnusedPayoutGateway : IPayoutGateway
+  {
+    public Task<Result<PayoutConfirmation>> CreatePayout(PayoutRequest request) =>
+      throw new NotImplementedException();
+
+    public Task<Result<PayoutStatus>> GetPayoutStatus(
+      string requestId,
+      string? confirmationNumber
+    ) => throw new NotImplementedException();
+  }
+
+  private sealed class UnusedRefundGateway : IRefundGateway
+  {
+    public Task<Result<RefundConfirmation>> CreateRefund(RefundRequest request) =>
+      throw new NotImplementedException();
+
+    public Task<Result<PayoutStatus>> GetRefundStatus(string refundId) =>
+      throw new NotImplementedException();
+  }
+}


### PR DESCRIPTION
## Summary

Admin-configurable withdrawal settings, insert-only versioned like PrioritySettings (newest `CreatedAt` wins; no row = defaults matching today's deployed reality):

| Setting | Type | Default (no row) |
|---|---|---|
| `CardRefundEnabled` | bool | `true` |
| `PayNowMode` | `Enabled` \| `Disabled` \| `FallbackOnly` | `FallbackOnly` |
| `SweepEnabled` | bool | `false` |

### Endpoints

- `GET api/v1/Withdrawal/settings/current` — **any authenticated caller** → `{ cardRefundEnabled, payNowMode, sweepEnabled }`. The create dialog needs method availability, and tin polls `sweepEnabled` as its sweep gate. Tin's M2M token passes plain `[Authorize]`: it is the same JWT bearer auth the `AdminOrTin` endpoints already pass — the policy only adds a roles check on top, so no separate sweep endpoint is needed.
- `POST api/v1/Withdrawal/settings` — **OnlyAdmin**, same body shape, FluentValidation on the `payNowMode` string, inserts a new row and returns it.

### Enforcement at withdrawal create (Domain/Withdrawal/Service.Create)

Runs after the wallet lookup, before any reserve moves; existing withdrawals are unaffected (approve/webhooks/reconcile run regardless):

- **CardRefund**: rejected with a distinguishable `InvalidWithdrawalOperation` (400) when `!cardRefundEnabled`. The existing pool-coverage pre-check still applies after the policy.
- **PayNow**: accepted when `Enabled`; rejected when `Disabled`; under `FallbackOnly` accepted only when the refundable pool < requested amount — otherwise rejected with a "card refund available — PayNow is fallback-only" message. The pool is computed exactly once, and only when `FallbackOnly` makes it relevant.

### Migration

`20260712013109_AddWithdrawalSettings` — new `WithdrawalSettings` table (Id, CreatedAt, CardRefundEnabled bool, PayNowMode smallint, SweepEnabled bool).

## Tests

33 new tests (470 total, all green):
- `WithdrawalSettingsPolicyTests` — the create-policy matrix (method x mode x pool coverage), defaults-when-no-row, pool-computed-once assertions, settings read/write plumbing.
- `SetWithdrawalSettingsReqValidatorTests` — enum-string validation and wire<->domain round-trip.
- Existing withdrawal suites run with the policy wide open (both rails enabled) so their money-mechanics coverage is unchanged.