### PR TITLE
feat(analysis): airwallex fee capture, ktmb costs, priority queue split

### DIFF
--- a/App/Migrations/20260712195219_AddGatewayFeesKtmbCostsAndBoostAudit.Designer.cs
+++ b/App/Migrations/20260712195219_AddGatewayFeesKtmbCostsAndBoostAudit.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using App.StartUp.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace App.Migrations
 {
     [DbContext(typeof(MainDbContext))]
-    partial class MainDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260712195219_AddGatewayFeesKtmbCostsAndBoostAudit")]
+    partial class AddGatewayFeesKtmbCostsAndBoostAudit
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/App/Migrations/20260712195219_AddGatewayFeesKtmbCostsAndBoostAudit.cs
+++ b/App/Migrations/20260712195219_AddGatewayFeesKtmbCostsAndBoostAudit.cs
@@ -1,0 +1,112 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace App.Migrations
+{
+  /// <inheritdoc />
+  public partial class AddGatewayFeesKtmbCostsAndBoostAudit : Migration
+  {
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+      migrationBuilder.AddColumn<string>(
+          name: "PriceBreakdown",
+          table: "Bookings",
+          type: "jsonb",
+          nullable: true);
+
+      migrationBuilder.AddColumn<DateTime>(
+          name: "PrioritizedAt",
+          table: "Bookings",
+          type: "timestamp with time zone",
+          nullable: true);
+
+      migrationBuilder.AddColumn<string>(
+          name: "PrioritizedBy",
+          table: "Bookings",
+          type: "character varying(128)",
+          maxLength: 128,
+          nullable: true);
+
+      migrationBuilder.CreateTable(
+          name: "GatewayFees",
+          columns: table => new
+          {
+            Id = table.Column<Guid>(type: "uuid", nullable: false),
+            CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+            SourceId = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+            SourceType = table.Column<byte>(type: "smallint", nullable: false),
+            FinancialTransactionId = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+            Amount = table.Column<decimal>(type: "numeric(16,8)", precision: 16, scale: 8, nullable: false),
+            Fee = table.Column<decimal>(type: "numeric(16,8)", precision: 16, scale: 8, nullable: false),
+            Net = table.Column<decimal>(type: "numeric(16,8)", precision: 16, scale: 8, nullable: false),
+            Currency = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+            TransactedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+          },
+          constraints: table =>
+          {
+            table.PrimaryKey("PK_GatewayFees", x => x.Id);
+          });
+
+      migrationBuilder.CreateTable(
+          name: "KtmbCosts",
+          columns: table => new
+          {
+            Id = table.Column<Guid>(type: "uuid", nullable: false),
+            CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+            EffectiveAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+            Direction = table.Column<int>(type: "integer", nullable: false),
+            Cost = table.Column<decimal>(type: "numeric(16,8)", precision: 16, scale: 8, nullable: false)
+          },
+          constraints: table =>
+          {
+            table.PrimaryKey("PK_KtmbCosts", x => x.Id);
+          });
+
+      migrationBuilder.CreateIndex(
+          name: "IX_GatewayFees_FinancialTransactionId",
+          table: "GatewayFees",
+          column: "FinancialTransactionId",
+          unique: true);
+
+      migrationBuilder.CreateIndex(
+          name: "IX_GatewayFees_SourceId",
+          table: "GatewayFees",
+          column: "SourceId");
+
+      migrationBuilder.CreateIndex(
+          name: "IX_GatewayFees_TransactedAt",
+          table: "GatewayFees",
+          column: "TransactedAt");
+
+      migrationBuilder.CreateIndex(
+          name: "IX_KtmbCosts_Direction_EffectiveAt",
+          table: "KtmbCosts",
+          columns: new[] { "Direction", "EffectiveAt" });
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+      migrationBuilder.DropTable(
+          name: "GatewayFees");
+
+      migrationBuilder.DropTable(
+          name: "KtmbCosts");
+
+      migrationBuilder.DropColumn(
+          name: "PriceBreakdown",
+          table: "Bookings");
+
+      migrationBuilder.DropColumn(
+          name: "PrioritizedAt",
+          table: "Bookings");
+
+      migrationBuilder.DropColumn(
+          name: "PrioritizedBy",
+          table: "Bookings");
+    }
+  }
+}

--- a/App/Modules/Bookings/API/V1/BookingController.cs
+++ b/App/Modules/Bookings/API/V1/BookingController.cs
@@ -33,6 +33,7 @@ public class BookingController(
   IPrioritySettingsRepository prioritySettingsRepo,
   IPriorityAccessRepository priorityAccessRepo,
   IBookingAnalysisRepository analysisRepo,
+  IKtmbCostRepository ktmbCostRepo,
   IUserService userService,
   IOptions<TerminatorOption> terminatorOptions,
   IOptions<RecoveryOption> recoveryOptions,
@@ -111,10 +112,12 @@ public class BookingController(
     return this.ReturnResult(x);
   }
 
-  // sales/revenue analysis for the admin Analysis page: per SGT-day rows of
-  // completed tickets + gross revenue, plus a range summary (deposits
-  // captured and BunnyBooker's internal fees). GROSS only — Airwallex's own
-  // gateway fees are not stored anywhere.
+  // Sales/revenue analysis for the admin Analysis page: per SGT-day rows of
+  // completed tickets, gross revenue and KTMB cost; a range summary
+  // (deposits, internal fees, synced gateway fees, per-direction split); a
+  // monthly rollup (net = gross − ktmbCost − gateway fees; internal fees are
+  // revenue and excluded from the cost side); and revenue-by-component over
+  // the persisted purchase price breakdowns.
   [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("analysis")]
   public async Task<ActionResult<BookingAnalysisRes>> Analysis(
     [FromQuery] BookingAnalysisQueryReq query,
@@ -125,6 +128,51 @@ public class BookingController(
       .ValidateAsyncResult(query, "Invalid BookingAnalysisQueryReq")
       .ThenAwait(q => analysisRepo.Analyze(q.ToDomain()))
       .Then(a => a.ToRes(), Errors.MapAll);
+    return this.ReturnResult(x);
+  }
+
+  // The boost ledger: who prioritized which booking, when, for what fee (or
+  // free). BoostedAt falls back to the booking's CreatedAt for boosts that
+  // predate the PrioritizedAt stamp; GrantedBy identifies admin-granted
+  // boosts from this release onward (null before, and for self-boosts).
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("analysis/boosts")]
+  public async Task<ActionResult<BookingBoostPageRes>> Boosts(
+    [FromQuery] BookingBoostQueryReq query,
+    [FromServices] BookingBoostQueryReqValidator boostValidator
+  )
+  {
+    var x = await boostValidator
+      .ValidateAsyncResult(query, "Invalid BookingBoostQueryReq")
+      .ThenAwait(q => analysisRepo.Boosts(q.ToDomain()))
+      .Then(p => p.ToRes(), Errors.MapAll);
+    return this.ReturnResult(x);
+  }
+
+  // the KTMB ticket cost in effect right now per direction + queued future
+  // changes (analysis costing source; 0 = never configured)
+  [Authorize(Policy = AuthPolicies.AdminOrTin), HttpGet("ktmb-cost/current")]
+  public async Task<ActionResult<KtmbCostRes>> GetKtmbCost()
+  {
+    var x = await ktmbCostRepo
+      .List()
+      .Then(changes => KtmbCostSchedule.View(changes, DateTime.UtcNow).ToRes(), Errors.MapNone);
+    return this.ReturnResult(x);
+  }
+
+  // queue a per-direction KTMB cost change (immediate when EffectiveAt is
+  // omitted) — insert-only, effective-dated like the withdrawal Fee queue
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpPost("ktmb-cost")]
+  public async Task<ActionResult<KtmbCostChangeRes>> SetKtmbCost(
+    [FromBody] SetKtmbCostReq req,
+    [FromServices] SetKtmbCostReqValidator ktmbCostValidator
+  )
+  {
+    var x = await ktmbCostValidator
+      .ValidateAsyncResult(req, "Invalid SetKtmbCostReq")
+      .ThenAwait(r =>
+        ktmbCostRepo.Add(r.Direction.DirectionToDomain(), r.Cost, r.EffectiveAt)
+      )
+      .Then(c => c.ToRes(), Errors.MapNone);
     return this.ReturnResult(x);
   }
 
@@ -416,7 +464,7 @@ public class BookingController(
           )
           .ThenAwait(roles =>
             costCalculator
-              .BookingCost(userId, roles, rec!)
+              .BookingCostDetail(userId, roles, rec!)
               .Then(cost =>
               {
                 // Optional for one release: old (raichu) argon clients don't
@@ -427,12 +475,16 @@ public class BookingController(
                     "Purchase without confirmed quote (legacy client): User '{UserId}'",
                     userId
                   );
-                return BookingPriceQuote.Validate(cost, req.ExpectedCost);
+                return BookingPriceQuote
+                  .Validate(cost.Final, req.ExpectedCost)
+                  .Then(_ => cost, Errors.MapNone);
               })
               .Then(cost => (c: cost, r: rec!), Errors.MapNone)
           )
       )
-      .ThenAwait(cr => service.Create(userId, cr.c, cr.r!))
+      // the charged price AND its composition — the breakdown is persisted
+      // on the booking so component analytics can rank policies/discounts
+      .ThenAwait(cr => service.Create(userId, cr.c.Final, cr.r!, cr.c.ToBreakdown()))
       .Then(b => b.ToRes(), Errors.MapNone);
 
     return this.ReturnResult(p);
@@ -550,8 +602,10 @@ public class BookingController(
   [Authorize, HttpPost("{id:guid}/prioritize")]
   public async Task<ActionResult<BookingPrincipalRes>> Prioritize(Guid id, string? userId)
   {
+    // the caller's sub is persisted as the granter when it is not the
+    // booking's owner (admin-granted boost attribution in the boost ledger)
     var p = await this.GuardOrAnyAsync(userId, AuthRoles.Field, AuthRoles.Admin)
-      .ThenAwait(_ => service.Prioritize(userId, id))
+      .ThenAwait(_ => service.Prioritize(userId, id, this.Sub()))
       .Then(b => b?.ToRes(), Errors.MapNone);
 
     return this.ReturnNullableResult(

--- a/App/Modules/Bookings/API/V1/BookingMapper.cs
+++ b/App/Modules/Bookings/API/V1/BookingMapper.cs
@@ -57,7 +57,9 @@ public static class BookingMapper
       p.Date.ToStandardDateFormat(),
       p.Time.ToStandardTimeFormat(),
       p.Direction.ToRes(),
-      p.TicketsNeeded
+      p.TicketsNeeded,
+      p.Priority,
+      p.Normal
     );
 
   public static BookingQueuePositionRes ToRes(this BookingQueuePosition p) =>
@@ -96,7 +98,23 @@ public static class BookingMapper
       r.Direction.ToRes(),
       r.Time.ToStandardTimeFormat(),
       r.TicketsCompleted,
-      r.GrossRevenue
+      r.GrossRevenue,
+      r.KtmbCost
+    );
+
+  public static DirectionBreakdownRes ToRes(this DirectionBreakdown d) =>
+    new(d.Direction.ToRes(), d.Tickets, d.Gross, d.KtmbCost);
+
+  public static MonthlyAnalysisRes ToRes(this MonthlyAnalysisRow m) =>
+    new(
+      m.Month,
+      m.Gross,
+      m.KtmbCost,
+      m.GatewayPaymentFees,
+      m.GatewayPayoutFees,
+      m.InternalFees,
+      m.Net,
+      m.ByDirection.Select(d => d.ToRes())
     );
 
   public static BookingAnalysisRes ToRes(this BookingAnalysis a) =>
@@ -105,14 +123,69 @@ public static class BookingMapper
       new BookingAnalysisSummaryRes(
         a.Summary.TotalTickets,
         a.Summary.TotalGross,
+        a.Summary.TotalKtmbCost,
         new DepositSummaryRes(a.Summary.Deposits.Count, a.Summary.Deposits.Captured),
         new InternalFeesRes(
           a.Summary.InternalFees.Deposit,
           a.Summary.InternalFees.Withdrawal,
           a.Summary.InternalFees.Priority,
           a.Summary.InternalFees.Termination
-        )
-      )
+        ),
+        new GatewayFeesRes(
+          a.Summary.GatewayFees.Payments,
+          a.Summary.GatewayFees.Payouts,
+          new GatewayFeeCoverageRes(
+            a.Summary.GatewayFees.Coverage.PaymentsWithFee,
+            a.Summary.GatewayFees.Coverage.PaymentsTotal
+          )
+        ),
+        a.Summary.ByDirection.Select(d => d.ToRes())
+      ),
+      a.Monthly.Select(m => m.ToRes()),
+      a.Components.Select(c => new PriceComponentRes(
+        c.Kind,
+        c.Name,
+        c.TimesApplied,
+        c.TotalDelta
+      )),
+      new ComponentsCoverageRes(a.ComponentsCoverage.WithBreakdown, a.ComponentsCoverage.Total)
+    );
+
+  // boost ledger
+  public static BookingBoostQuery ToDomain(this BookingBoostQueryReq req) =>
+    new()
+    {
+      After = req.After?.ToDate(),
+      Before = req.Before?.ToDate(),
+      Limit = req.Limit ?? 50,
+      Skip = req.Skip ?? 0,
+    };
+
+  public static BookingBoostRes ToRes(this BookingBoost b) =>
+    new(
+      b.BookingId,
+      b.UserId,
+      b.UserIdentity,
+      b.Date.ToStandardDateFormat(),
+      b.Time.ToStandardTimeFormat(),
+      b.Direction.ToRes(),
+      b.Fee,
+      b.Free,
+      b.BoostedAt,
+      b.GrantedBy
+    );
+
+  public static BookingBoostPageRes ToRes(this BookingBoostPage p) =>
+    new(p.Total, p.Items.Select(b => b.ToRes()));
+
+  // KTMB ticket cost
+  public static KtmbCostChangeRes ToRes(this KtmbCostChange c) =>
+    new(c.Id, c.Direction.ToRes(), c.Cost, c.EffectiveAt, c.CreatedAt);
+
+  public static KtmbCostRes ToRes(this KtmbCostView v) =>
+    new(
+      v.Current.ToDictionary(kv => kv.Key.ToRes(), kv => kv.Value),
+      v.Upcoming.Select(c => c.ToRes())
     );
 
   // REQ -> DOMAIN

--- a/App/Modules/Bookings/API/V1/BookingModel.cs
+++ b/App/Modules/Bookings/API/V1/BookingModel.cs
@@ -26,6 +26,14 @@ public record BookingStatsQueryReq(string? After, string? Before);
 // unbounded) — the admin Analysis page source
 public record BookingAnalysisQueryReq(string? After, string? Before);
 
+// the boost ledger page (dd-MM-yyyy inclusive SGT dates; Limit default 50
+// max 200, Skip offset)
+public record BookingBoostQueryReq(string? After, string? Before, int? Limit, int? Skip);
+
+// KTMB cost: queue a per-direction ticket-cost change; EffectiveAt omitted =
+// immediate
+public record SetKtmbCostReq(string Direction, decimal Cost, DateTime? EffectiveAt);
+
 public record ReserveBookingQuery(string Date, string Direction, string Time);
 
 public record BookingCountQuery(string Date, string Direction);
@@ -85,7 +93,16 @@ public record BookingPrincipalRes(
 
 public record BookingRes(BookingPrincipalRes Principal, UserPrincipalRes User);
 
-public record BookingCountRes(string Date, string Time, string Direction, int TicketsNeeded);
+// TicketsNeeded = Priority + Normal (kept as the total for old argon
+// clients; new argon reads the split for the /schedules queue badges)
+public record BookingCountRes(
+  string Date,
+  string Time,
+  string Direction,
+  int TicketsNeeded,
+  int Priority,
+  int Normal
+);
 
 // total rows matching a search, ignoring Limit/Skip — for real page numbers
 public record SearchCountRes(int Total);
@@ -98,17 +115,20 @@ public record BookingQueuePositionRes(string Status, int? Position, int? Total);
 // RefValid = that key resolves to a real object in block storage
 public record BookingTicketHealthRes(bool HasRef, bool RefValid);
 
-// Sales/revenue analysis. GROSS figures + BunnyBooker's internal fees only:
-// Airwallex's own gateway fees are not stored anywhere (no API for them yet).
-// Rows bucket completed bookings by the SGT calendar date of CompletedAt
-// (same wall-clock convention as booking_stats), direction and departure
-// time; GrossRevenue = the booking cost collected at completion.
+// Sales/revenue analysis. Revenue figures are GROSS; costs are what leaves
+// BunnyBooker's pocket: KtmbCost (admin-configured effective-dated ticket
+// cost; 0 for every row when never configured) and Airwallex's own gateway
+// fees (synced after the fact — see GatewayFeesRes.Coverage). Rows bucket
+// completed bookings by the SGT calendar date of CompletedAt (same
+// wall-clock convention as booking_stats), direction and departure time;
+// GrossRevenue = the booking cost collected at completion.
 public record BookingAnalysisRowRes(
   string Date,
   string Direction,
   string Time,
   int TicketsCompleted,
-  decimal GrossRevenue
+  decimal GrossRevenue,
+  decimal KtmbCost
 );
 
 public record DepositSummaryRes(int Count, decimal Captured);
@@ -122,16 +142,96 @@ public record InternalFeesRes(
   decimal Termination
 );
 
+// gateway-fee sync coverage over the range's captured intents — fees post
+// with delay, so PaymentsWithFee < PaymentsTotal means "sync again later"
+public record GatewayFeeCoverageRes(int PaymentsWithFee, int PaymentsTotal);
+
+// Airwallex's own fees: Payments = fees on captured intents (money in),
+// Payouts = fees on transfers + card refunds (money out)
+public record GatewayFeesRes(decimal Payments, decimal Payouts, GatewayFeeCoverageRes Coverage);
+
+// per-direction slice of the completed rows
+public record DirectionBreakdownRes(
+  string Direction,
+  int Tickets,
+  decimal Gross,
+  decimal KtmbCost
+);
+
+// One SGT calendar month ("MM-yyyy").
+// NET = Gross − KtmbCost − GatewayPaymentFees − GatewayPayoutFees.
+// InternalFees (deposit + withdrawal + net priority) is BunnyBooker's own
+// fee revenue that month — context only, never subtracted.
+public record MonthlyAnalysisRes(
+  string Month,
+  decimal Gross,
+  decimal KtmbCost,
+  decimal GatewayPaymentFees,
+  decimal GatewayPayoutFees,
+  decimal InternalFees,
+  decimal Net,
+  IEnumerable<DirectionBreakdownRes> ByDirection
+);
+
+// one pricing component's aggregate: kind = "policy" (signed delta) |
+// "discount" (negative) | "priorityFee" (positive) — ranks which components
+// make or lose money over the range
+public record PriceComponentRes(string Kind, string Name, int TimesApplied, decimal TotalDelta);
+
+// breakdown persistence started with the release that added it — completed
+// bookings without a stored breakdown are excluded from Components
+public record ComponentsCoverageRes(int WithBreakdown, int Total);
+
 public record BookingAnalysisSummaryRes(
   int TotalTickets,
   decimal TotalGross,
+  decimal TotalKtmbCost,
   DepositSummaryRes Deposits,
-  InternalFeesRes InternalFees
+  InternalFeesRes InternalFees,
+  GatewayFeesRes GatewayFees,
+  IEnumerable<DirectionBreakdownRes> ByDirection
 );
 
 public record BookingAnalysisRes(
   IEnumerable<BookingAnalysisRowRes> Rows,
-  BookingAnalysisSummaryRes Summary
+  BookingAnalysisSummaryRes Summary,
+  IEnumerable<MonthlyAnalysisRes> Monthly,
+  IEnumerable<PriceComponentRes> Components,
+  ComponentsCoverageRes ComponentsCoverage
+);
+
+// one boost-ledger row: Fee null = the boost was free; BoostedAt falls back
+// to the booking's CreatedAt for boosts predating the PrioritizedAt stamp;
+// GrantedBy = the admin's sub when an admin boosted someone else's booking
+// (stamped from this release onward, null before and for self-boosts)
+public record BookingBoostRes(
+  Guid BookingId,
+  string UserId,
+  string UserIdentity,
+  string Date,
+  string Time,
+  string Direction,
+  decimal? Fee,
+  bool Free,
+  DateTime BoostedAt,
+  string? GrantedBy
+);
+
+public record BookingBoostPageRes(int Total, IEnumerable<BookingBoostRes> Items);
+
+// KTMB ticket cost: the current per-direction cost + queued future changes
+public record KtmbCostChangeRes(
+  Guid Id,
+  string Direction,
+  decimal Cost,
+  DateTime EffectiveAt,
+  DateTime CreatedAt
+);
+
+public record KtmbCostRes(
+  // direction name -> current effective cost (0 when never configured)
+  Dictionary<string, decimal> Current,
+  IEnumerable<KtmbCostChangeRes> Upcoming
 );
 
 public record BookingStatRes(

--- a/App/Modules/Bookings/API/V1/BookingValidator.cs
+++ b/App/Modules/Bookings/API/V1/BookingValidator.cs
@@ -101,6 +101,38 @@ public class BookingAnalysisQueryReqValidator : AbstractValidator<BookingAnalysi
   }
 }
 
+public class BookingBoostQueryReqValidator : AbstractValidator<BookingBoostQueryReq>
+{
+  public BookingBoostQueryReqValidator()
+  {
+    this.RuleFor(x => x.After).NullableDateValid();
+    this.RuleFor(x => x.Before).NullableDateValid();
+    this.RuleFor(x => x.Limit)
+      .GreaterThanOrEqualTo(0)
+      .LessThanOrEqualTo(200)
+      .WithMessage("Limit has to be between 0 and 200");
+    this.RuleFor(x => x.Skip).Skip();
+  }
+}
+
+public class SetKtmbCostReqValidator : AbstractValidator<SetKtmbCostReq>
+{
+  public SetKtmbCostReqValidator()
+  {
+    this.RuleFor(x => x.Direction).NotNull().TrainDirectionValid();
+    this.RuleFor(x => x.Cost)
+      .GreaterThanOrEqualTo(0)
+      .LessThanOrEqualTo(10_000)
+      .WithMessage("Cost must be between 0 and 10000");
+    // a past effective date would insert a row that can never win the
+    // newest-effective ordering — a silently dead change (small tolerance
+    // for clock skew; omit the field for an immediate change)
+    this.RuleFor(x => x.EffectiveAt)
+      .Must(x => x == null || x > DateTime.UtcNow.AddMinutes(-5))
+      .WithMessage("EffectiveAt must be in the future (omit it for an immediate change)");
+  }
+}
+
 public class BookingCountQueryValidator : AbstractValidator<BookingCountQuery>
 {
   public BookingCountQueryValidator()

--- a/App/Modules/Bookings/Data/BookingAnalysisRepository.cs
+++ b/App/Modules/Bookings/Data/BookingAnalysisRepository.cs
@@ -4,6 +4,7 @@ using App.Utility;
 using CSharp_Result;
 using Domain;
 using Domain.Booking;
+using Domain.Payment;
 using Domain.Transaction;
 using Microsoft.EntityFrameworkCore;
 
@@ -19,6 +20,18 @@ namespace App.Modules.Bookings.Data;
 // so the request row, the BookingComplete row and the wallet movement agree
 // by construction — and only the request row is FK-linked per booking, which
 // makes it the joinable source of truth.
+//
+// KTMB COST: each completed booking is costed at the newest KtmbCosts row
+// with EffectiveAt <= its CompletedAt and a matching Direction (the SQL
+// LATERAL mirrors KtmbCostSchedule.EffectiveCost); no configured row = 0.
+//
+// GATEWAY FEES: from the synced GatewayFees rows (Airwallex financial
+// transactions), bucketed on the SGT month of TransactedAt. Payment-type
+// rows are money-in fees; Transfer + Refund rows are payout fees.
+//
+// NET (monthly): Net = Gross − KtmbCost − GatewayPaymentFees −
+// GatewayPayoutFees. Internal fees are revenue TO BunnyBooker and are
+// reported alongside but never subtracted.
 //
 // DATE CONVENTION: rows bucket completed bookings on the SGT (UTC+8)
 // calendar date of CompletedAt — the same wall-clock convention booking_stats
@@ -41,6 +54,42 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
     public int TicketsCompleted { get; set; }
 
     public decimal GrossRevenue { get; set; }
+
+    public decimal KtmbCost { get; set; }
+  }
+
+  // month-bucketed gateway fee sums (payments vs payouts)
+  private sealed class GatewayMonthDto
+  {
+    public DateOnly Month { get; set; }
+
+    public byte SourceType { get; set; }
+
+    public decimal Fee { get; set; }
+  }
+
+  // month-bucketed internal-fee ledger sums
+  private sealed class LedgerMonthDto
+  {
+    public DateOnly Month { get; set; }
+
+    public short TransactionType { get; set; }
+
+    public string To { get; set; } = string.Empty;
+
+    public decimal Sum { get; set; }
+  }
+
+  // one persisted price-breakdown line, exploded DB-side from the JSON
+  private sealed class ComponentDto
+  {
+    public string Kind { get; set; } = string.Empty;
+
+    public string Name { get; set; } = string.Empty;
+
+    public int TimesApplied { get; set; }
+
+    public decimal TotalDelta { get; set; }
   }
 
   public async Task<Result<BookingAnalysis>> Analyze(BookingAnalysisQuery query)
@@ -60,7 +109,10 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
       var completed = (byte)BookStatus.Completed;
       // AT TIME ZONE 'UTC' renders the instant as UTC wall-clock regardless
       // of the session TimeZone; +8h then CAST AS date = the SGT calendar
-      // date (same arithmetic booking_stats bakes into its view)
+      // date (same arithmetic booking_stats bakes into its view).
+      // The LATERAL resolves each booking's effective KTMB cost: the newest
+      // row effective at CompletedAt for the booking's direction — the exact
+      // DB-side mirror of KtmbCostSchedule.EffectiveCost (0 when none).
       var rows = await db
         .Database.SqlQuery<RowDto>(
           $"""
@@ -69,9 +121,17 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
             b."Direction" AS "Direction",
             b."Time" AS "Time",
             CAST(COUNT(*) AS int) AS "TicketsCompleted",
-            SUM(t."Amount") AS "GrossRevenue"
+            SUM(t."Amount") AS "GrossRevenue",
+            SUM(COALESCE(kc."Cost", 0)) AS "KtmbCost"
           FROM "Bookings" b
           JOIN "Transactions" t ON t."Id" = b."TransactionId"
+          LEFT JOIN LATERAL (
+            SELECT k."Cost"
+            FROM "KtmbCosts" k
+            WHERE k."Direction" = b."Direction" AND k."EffectiveAt" <= b."CompletedAt"
+            ORDER BY k."EffectiveAt" DESC, k."CreatedAt" DESC, k."Id" DESC
+            LIMIT 1
+          ) kc ON TRUE
           WHERE b."Status" = {completed}
             AND b."CompletedAt" IS NOT NULL
             AND b."CompletedAt" >= {afterUtc}
@@ -95,19 +155,43 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
           Time = x.Time,
           TicketsCompleted = x.TicketsCompleted,
           GrossRevenue = x.GrossRevenue,
+          KtmbCost = x.KtmbCost,
         })
         .ToArray();
 
-      // Airwallex intents that captured money, created in range (gateway
-      // fees are NOT stored anywhere — deliberately gross)
+      // Airwallex intents that captured money, created in range
       var capturedInRange = db.Payments.Where(p =>
         p.CapturedAmount > 0 && p.CreatedAt >= afterUtc && p.CreatedAt < beforeUtc
       );
       var depositCount = await capturedInRange.CountAsync();
       var depositCaptured = await capturedInRange.SumAsync(p => (decimal?)p.CapturedAmount);
+      // coverage: how many of those intents already have synced fee rows
+      // (gateway fees post with delay — the UI shows sync completeness)
+      var paymentsWithFee = await capturedInRange
+        .Where(p => db.GatewayFees.Any(f => f.SourceId == p.ExternalReference))
+        .CountAsync();
 
-      // internal-fee ledger rows in range, one grouped scan; PriorityFee
-      // charges and refunds share a type and are told apart by the To account
+      // the gateway's own fees, bucketed per SGT month of TransactedAt —
+      // one grouped scan feeds both the range summary and the monthly rollup
+      var gatewayMonths = await db
+        .Database.SqlQuery<GatewayMonthDto>(
+          $"""
+          SELECT
+            CAST(date_trunc(
+              'month', g."TransactedAt" AT TIME ZONE 'UTC' + INTERVAL '8 hours'
+            ) AS date) AS "Month",
+            g."SourceType" AS "SourceType",
+            SUM(g."Fee") AS "Fee"
+          FROM "GatewayFees" g
+          WHERE g."TransactedAt" >= {afterUtc} AND g."TransactedAt" < {beforeUtc}
+          GROUP BY 1, g."SourceType"
+          """
+        )
+        .ToArrayAsync();
+
+      // internal-fee ledger rows per SGT month, one grouped scan;
+      // PriorityFee charges and refunds share a type and are told apart by
+      // the To account
       var feeTypes = new[]
       {
         (short)TransactionType.DepositFee,
@@ -115,19 +199,23 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
         (short)TransactionType.PriorityFee,
         (short)TransactionType.BookingTerminated,
       };
-      var ledger = await db
-        .Transactions.Where(x =>
-          feeTypes.Contains(x.TransactionType)
-          && x.CreatedAt >= afterUtc
-          && x.CreatedAt < beforeUtc
+      var ledgerMonths = await db
+        .Database.SqlQuery<LedgerMonthDto>(
+          $"""
+          SELECT
+            CAST(date_trunc(
+              'month', x."CreatedAt" AT TIME ZONE 'UTC' + INTERVAL '8 hours'
+            ) AS date) AS "Month",
+            x."TransactionType" AS "TransactionType",
+            x."To" AS "To",
+            SUM(x."Amount") AS "Sum"
+          FROM "Transactions" x
+          WHERE x."TransactionType" = ANY ({feeTypes})
+            AND x."CreatedAt" >= {afterUtc}
+            AND x."CreatedAt" < {beforeUtc}
+          GROUP BY 1, x."TransactionType", x."To"
+          """
         )
-        .GroupBy(x => new { x.TransactionType, x.To })
-        .Select(g => new
-        {
-          g.Key.TransactionType,
-          g.Key.To,
-          Sum = g.Sum(x => x.Amount),
-        })
         .ToArrayAsync();
 
       // termination fee = what the terminated bookings had collected minus
@@ -141,7 +229,7 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
         .SumAsync(b => (decimal?)b.Transaction.Amount);
 
       decimal LedgerSum(TransactionType type, string? to = null) =>
-        ledger
+        ledgerMonths
           .Where(x => x.TransactionType == (short)type && (to == null || x.To == to))
           .Sum(x => x.Sum);
 
@@ -161,6 +249,55 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
         TerminationRefunds = LedgerSum(TransactionType.BookingTerminated),
       };
 
+      var payment = (byte)GatewayFeeSourceType.Payment;
+      var gatewayFees = new GatewayFeeSummary
+      {
+        Payments = gatewayMonths.Where(x => x.SourceType == payment).Sum(x => x.Fee),
+        Payouts = gatewayMonths.Where(x => x.SourceType != payment).Sum(x => x.Fee),
+        Coverage = new GatewayFeeCoverage
+        {
+          PaymentsWithFee = paymentsWithFee,
+          PaymentsTotal = depositCount,
+        },
+      };
+
+      // month-keyed external sums for the rollup. Internal fees per month:
+      // deposit + withdrawal + net priority (charged − refunded); the
+      // termination component is range-scoped only (it needs the terminated
+      // bookings' gross, which has no per-month ledger row) and is reported
+      // in the range summary, not the monthly rows.
+      var external = gatewayMonths
+        .Select(x => BookingAnalysisCalculator.MonthKey(x.Month))
+        .Concat(ledgerMonths.Select(x => BookingAnalysisCalculator.MonthKey(x.Month)))
+        .Distinct()
+        .ToDictionary(
+          m => m,
+          m =>
+          {
+            var g = gatewayMonths
+              .Where(x => BookingAnalysisCalculator.MonthKey(x.Month) == m)
+              .ToArray();
+            var l = ledgerMonths
+              .Where(x => BookingAnalysisCalculator.MonthKey(x.Month) == m)
+              .ToArray();
+            decimal MonthLedger(TransactionType type, string? to = null) =>
+              l.Where(x => x.TransactionType == (short)type && (to == null || x.To == to))
+                .Sum(x => x.Sum);
+            return new MonthlyExternalSums
+            {
+              GatewayPaymentFees = g.Where(x => x.SourceType == payment).Sum(x => x.Fee),
+              GatewayPayoutFees = g.Where(x => x.SourceType != payment).Sum(x => x.Fee),
+              InternalFees =
+                MonthLedger(TransactionType.DepositFee)
+                + MonthLedger(TransactionType.WithdrawFee)
+                + MonthLedger(TransactionType.PriorityFee, Accounts.PriorityFee.DisplayName)
+                - MonthLedger(TransactionType.PriorityFee, Accounts.Usable.DisplayName),
+            };
+          }
+        );
+
+      var (components, coverage) = await this.Components(afterUtc, beforeUtc, completed);
+
       return new BookingAnalysis
       {
         Rows = analysisRows,
@@ -171,13 +308,165 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
             Count = depositCount,
             Captured = depositCaptured ?? 0m,
           },
-          sums
+          sums,
+          gatewayFees
         ),
+        Monthly = BookingAnalysisCalculator.MonthlyRollup(analysisRows, external),
+        Components = components,
+        ComponentsCoverage = coverage,
       };
     }
     catch (Exception e)
     {
       logger.LogError(e, "Failed to compute booking analysis with {@Query}", query.ToJson());
+      return e;
+    }
+  }
+
+  // Revenue by pricing component over completed bookings in range: explode
+  // the persisted price-breakdown JSON DB-side and aggregate per (kind,
+  // name); priority-boost revenue comes from the PriorityFee column. Only
+  // bookings with a stored breakdown contribute — breakdown persistence
+  // started with this release, so coverage tells the UI how many completed
+  // bookings actually carry one (old rows are excluded, never guessed).
+  private async Task<(PriceComponentSummary[], ComponentsCoverage)> Components(
+    DateTime afterUtc,
+    DateTime beforeUtc,
+    byte completed
+  )
+  {
+    var lines = await db
+      .Database.SqlQuery<ComponentDto>(
+        $"""
+        SELECT
+          l ->> 'Kind' AS "Kind",
+          l ->> 'Name' AS "Name",
+          CAST(COUNT(*) AS int) AS "TimesApplied",
+          SUM(CAST(l ->> 'Delta' AS numeric)) AS "TotalDelta"
+        FROM "Bookings" b
+        CROSS JOIN LATERAL jsonb_array_elements(b."PriceBreakdown" -> 'Lines') AS l
+        WHERE b."Status" = {completed}
+          AND b."CompletedAt" IS NOT NULL
+          AND b."CompletedAt" >= {afterUtc}
+          AND b."CompletedAt" < {beforeUtc}
+          AND b."PriceBreakdown" IS NOT NULL
+        GROUP BY 1, 2
+        ORDER BY 1, 2
+        """
+      )
+      .ToArrayAsync();
+
+    var completedInRange = db.Bookings.Where(b =>
+      b.Status == completed
+      && b.CompletedAt != null
+      && b.CompletedAt >= afterUtc
+      && b.CompletedAt < beforeUtc
+    );
+    var total = await completedInRange.CountAsync();
+    var withBreakdown = await completedInRange.Where(b => b.PriceBreakdown != null).CountAsync();
+
+    // priority boost revenue: the persisted fee snapshots of completed
+    // bookings in range (Completed keeps the fee — the queue jump was
+    // consumed; Refunded/Cancelled returned it and are excluded with Status)
+    var boosted = completedInRange.Where(b => b.Priority && b.PriorityFee > 0);
+    var priorityCount = await boosted.CountAsync();
+    var prioritySum = await boosted.SumAsync(b => (decimal?)b.PriorityFee);
+
+    var components = lines
+      .Select(x => new PriceComponentSummary
+      {
+        Kind = x.Kind,
+        Name = x.Name,
+        TimesApplied = x.TimesApplied,
+        TotalDelta = x.TotalDelta,
+      })
+      .ToList();
+    if (priorityCount > 0)
+      components.Add(
+        new PriceComponentSummary
+        {
+          Kind = "priorityFee",
+          Name = "Priority boost",
+          TimesApplied = priorityCount,
+          TotalDelta = prioritySum ?? 0m,
+        }
+      );
+
+    return (
+      components.ToArray(),
+      new ComponentsCoverage { WithBreakdown = withBreakdown, Total = total }
+    );
+  }
+
+  // The boost ledger: prioritized bookings whose boost instant is in range,
+  // newest first. BoostedAt = PrioritizedAt when stamped (rows from this
+  // release onward); older boosts fall back to CreatedAt — the best persisted
+  // proxy, since the prioritize flow historically stamped no timestamp.
+  public async Task<Result<BookingBoostPage>> Boosts(BookingBoostQuery query)
+  {
+    try
+    {
+      logger.LogInformation("Listing booking boosts with {@Query}", query.ToJson());
+      var sgt = TimeZoneInfo.FindSystemTimeZoneById("Asia/Singapore");
+      var afterUtc =
+        query.After?.ToZonedDateTime(TimeOnly.MinValue, sgt)
+        ?? DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc);
+      var beforeUtc =
+        query.Before?.AddDays(1).ToZonedDateTime(TimeOnly.MinValue, sgt)
+        ?? DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc);
+
+      var boosts = db.Bookings.Where(b =>
+        b.Priority
+        && (b.PrioritizedAt ?? b.CreatedAt) >= afterUtc
+        && (b.PrioritizedAt ?? b.CreatedAt) < beforeUtc
+      );
+
+      var total = await boosts.CountAsync();
+      var items = await boosts
+        .OrderByDescending(b => b.PrioritizedAt ?? b.CreatedAt)
+        .ThenBy(b => b.Id)
+        .Skip(query.Skip)
+        .Take(query.Limit)
+        .Select(b => new
+        {
+          b.Id,
+          b.UserId,
+          // email when known, else username — the same identity precedence
+          // admin-facing user lists expose
+          Identity = b.User.Email ?? b.User.Username,
+          b.Date,
+          b.Time,
+          b.Direction,
+          b.PriorityFee,
+          b.PrioritizedAt,
+          b.CreatedAt,
+          b.PrioritizedBy,
+        })
+        .ToArrayAsync();
+
+      return new BookingBoostPage
+      {
+        Total = total,
+        Items = items
+          .Select(x => new BookingBoost
+          {
+            BookingId = x.Id,
+            UserId = x.UserId,
+            UserIdentity = x.Identity,
+            Date = x.Date,
+            Time = x.Time,
+            Direction = x.Direction.ToTrainDirection(),
+            Fee = x.PriorityFee,
+            Free = x.PriorityFee is null or 0m,
+            BoostedAt = x.PrioritizedAt ?? x.CreatedAt,
+            GrantedBy = x.PrioritizedBy,
+          })
+          .ToArray(),
+      };
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to list booking boosts with {@Query}", query.ToJson());
       return e;
     }
   }

--- a/App/Modules/Bookings/Data/BookingData.cs
+++ b/App/Modules/Bookings/Data/BookingData.cs
@@ -6,6 +6,30 @@ using Microsoft.EntityFrameworkCore;
 
 namespace App.Modules.Bookings.Data;
 
+// The per-booking price breakdown captured at purchase (owned JSON, like
+// PaymentStatusData): the base cost, one line per applied pricing component
+// and the final charged amount. Persisted from this release onward — old
+// bookings have a NULL column and are excluded from component analytics,
+// never guessed.
+public class BookingPriceLineData
+{
+  // "policy" (signed delta as configured) or "discount" (negative)
+  public string Kind { get; set; } = string.Empty;
+
+  public string Name { get; set; } = string.Empty;
+
+  public decimal Delta { get; set; }
+}
+
+public class BookingPriceBreakdownData
+{
+  public decimal BaseCost { get; set; }
+
+  public List<BookingPriceLineData> Lines { get; set; } = [];
+
+  public decimal Final { get; set; }
+}
+
 [ComplexType]
 public class BookingPassengerData
 {
@@ -41,6 +65,20 @@ public class BookingData
   // when the booking ends Refunded or Cancelled
   [Precision(16, 8)]
   public decimal? PriorityFee { get; set; }
+
+  // when the booking was prioritized — stamped from the boost-ledger release
+  // onward; older boosts have NULL and the ledger falls back to CreatedAt
+  public DateTime? PrioritizedAt { get; set; }
+
+  // the caller's sub when someone OTHER than the owner (an admin) invoked
+  // prioritize — admin-grant attribution, stamped from the boost-ledger
+  // release onward; NULL for self-boosts and all older rows
+  [MaxLength(128)]
+  public string? PrioritizedBy { get; set; }
+
+  // price breakdown captured at purchase (see BookingPriceBreakdownData);
+  // NULL for bookings that predate breakdown persistence
+  public BookingPriceBreakdownData? PriceBreakdown { get; set; }
 
   // how many times this booking was recycled from Recovering back to Pending
   // for another purchase attempt (RecoverRevert); capped by Recovery:MaxRetries

--- a/App/Modules/Bookings/Data/BookingMapper.cs
+++ b/App/Modules/Bookings/Data/BookingMapper.cs
@@ -67,6 +67,37 @@ public static class BookingMapper
       Wallet = data.Transaction.Wallet.ToPrincipal(),
     };
 
+  // price breakdown captured at purchase (persisted as owned JSON)
+  public static BookingPriceBreakdownData ToData(this BookingPriceBreakdown b) =>
+    new()
+    {
+      BaseCost = b.BaseCost,
+      Lines = b
+        .Lines.Select(l => new BookingPriceLineData
+        {
+          Kind = l.Kind,
+          Name = l.Name,
+          Delta = l.Delta,
+        })
+        .ToList(),
+      Final = b.Final,
+    };
+
+  public static BookingPriceBreakdown ToBreakdown(this BookingPriceBreakdownData d) =>
+    new()
+    {
+      BaseCost = d.BaseCost,
+      Lines = d
+        .Lines.Select(l => new BookingPriceLine
+        {
+          Kind = l.Kind,
+          Name = l.Name,
+          Delta = l.Delta,
+        })
+        .ToArray(),
+      Final = d.Final,
+    };
+
   // To Data
   public static BookingPassengerData ToData(this PassengerRecord p) =>
     new()

--- a/App/Modules/Bookings/Data/BookingRepository.cs
+++ b/App/Modules/Bookings/Data/BookingRepository.cs
@@ -383,7 +383,8 @@ public class BookingRepository(
   public async Task<Result<BookingPrincipal>> Create(
     string userId,
     Guid transactionId,
-    BookingRecord record
+    BookingRecord record,
+    BookingPriceBreakdown? breakdown
   )
   {
     try
@@ -392,6 +393,7 @@ public class BookingRepository(
 
       var data = new BookingData { UserId = userId, TransactionId = transactionId };
       data = data.UpdateData(record);
+      data.PriceBreakdown = breakdown?.ToData();
 
       var r = db.Bookings.Add(data);
       await db.SaveChangesAsync();
@@ -535,15 +537,21 @@ public class BookingRepository(
     }
   }
 
-  public async Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee)
+  public async Task<Result<BookingPrincipal?>> Prioritize(
+    string? userId,
+    Guid id,
+    decimal? fee,
+    string? grantedBy
+  )
   {
     try
     {
       logger.LogInformation(
-        "Prioritizing Booking '{Id}' under User '{UserId}' with fee {Fee}",
+        "Prioritizing Booking '{Id}' under User '{UserId}' with fee {Fee} granted by '{GrantedBy}'",
         id,
         userId,
-        fee
+        fee,
+        grantedBy
       );
       var v1 = await db
         .Bookings.Where(x => x.Id == id && (userId == null || x.UserId == userId))
@@ -553,6 +561,8 @@ public class BookingRepository(
 
       v1.Priority = true;
       v1.PriorityFee = fee;
+      v1.PrioritizedAt = DateTime.UtcNow;
+      v1.PrioritizedBy = grantedBy;
       await db.SaveChangesAsync();
       return v1.ToPrincipal();
     }
@@ -644,7 +654,10 @@ public class BookingRepository(
           Date = group.Key.Date,
           Time = group.Key.Time,
           Direction = group.Key.Direction.ToTrainDirection(),
+          // total stays for old argon clients; new clients read the split
           TicketsNeeded = group.Count(),
+          Priority = group.Count(x => x.Priority),
+          Normal = group.Count(x => !x.Priority),
         })
         .ToArrayAsync();
       return polls;

--- a/App/Modules/Bookings/Data/KtmbCostData.cs
+++ b/App/Modules/Bookings/Data/KtmbCostData.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace App.Modules.Bookings.Data;
+
+// Insert-only, effective-dated queue of what BunnyBooker pays KTMB per
+// ticket, per direction (same convention as the withdrawal fee queue): the
+// newest row with EffectiveAt <= the booking's CompletedAt and a matching
+// Direction is the cost of that booking; no effective row = cost 0.
+public class KtmbCostData
+{
+  public Guid Id { get; set; }
+
+  public DateTime CreatedAt { get; set; }
+
+  // the instant this cost starts applying; a future date queues it,
+  // CreatedAt (the default) makes it immediate
+  public DateTime EffectiveAt { get; set; }
+
+  // TrainDirection data value: 1 = JToW, 2 = WToJ
+  public int Direction { get; set; }
+
+  [Precision(16, 8)]
+  public decimal Cost { get; set; }
+}

--- a/App/Modules/Bookings/Data/KtmbCostRepository.cs
+++ b/App/Modules/Bookings/Data/KtmbCostRepository.cs
@@ -1,0 +1,82 @@
+using App.Modules.Timings.Data;
+using App.StartUp.Database;
+using CSharp_Result;
+using Domain.Booking;
+using Domain.Timings;
+using Microsoft.EntityFrameworkCore;
+
+namespace App.Modules.Bookings.Data;
+
+public static class KtmbCostMapper
+{
+  public static KtmbCostChange ToChange(this KtmbCostData data) =>
+    new()
+    {
+      Id = data.Id,
+      Direction = data.Direction.ToTrainDirection(),
+      Cost = data.Cost,
+      EffectiveAt = data.EffectiveAt,
+      CreatedAt = data.CreatedAt,
+    };
+}
+
+public class KtmbCostRepository(MainDbContext db, ILogger<KtmbCostRepository> logger)
+  : IKtmbCostRepository
+{
+  public async Task<Result<IEnumerable<KtmbCostChange>>> List()
+  {
+    try
+    {
+      var rows = await db.KtmbCosts.OrderBy(x => x.EffectiveAt).ToArrayAsync();
+      return rows.Select(x => x.ToChange()).ToResult();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to list KTMB cost changes");
+      return e;
+    }
+  }
+
+  public async Task<Result<KtmbCostChange>> Add(
+    TrainDirection direction,
+    decimal cost,
+    DateTime? effectiveAt
+  )
+  {
+    try
+    {
+      var now = DateTime.UtcNow;
+      logger.LogInformation(
+        "Queueing KTMB cost change: {Direction} -> {Cost}, effective {EffectiveAt}",
+        direction,
+        cost,
+        effectiveAt ?? now
+      );
+      // normalize to UTC exactly like FeeRepository.Add: JSON without a Z
+      // binds as Unspecified and an offset binds as Local — Npgsql rejects
+      // both for timestamptz
+      var effective = effectiveAt?.Kind switch
+      {
+        null => now,
+        DateTimeKind.Utc => effectiveAt.Value,
+        DateTimeKind.Local => effectiveAt.Value.ToUniversalTime(),
+        _ => DateTime.SpecifyKind(effectiveAt.Value, DateTimeKind.Utc),
+      };
+      var data = new KtmbCostData
+      {
+        CreatedAt = now,
+        EffectiveAt = effective,
+        Direction = direction.ToData(),
+        Cost = cost,
+      };
+      db.KtmbCosts.Add(data);
+      await db.SaveChangesAsync();
+      return data.ToChange();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to queue KTMB cost change");
+      return e;
+    }
+  }
+}

--- a/App/Modules/DomainServices.cs
+++ b/App/Modules/DomainServices.cs
@@ -76,6 +76,9 @@ public static class DomainServices
     s.AddScoped<IBookingAnalysisRepository, BookingAnalysisRepository>()
       .AutoTrace<IBookingAnalysisRepository>();
 
+    // KTMB ticket cost queue (effective-dated per direction, analysis costing)
+    s.AddScoped<IKtmbCostRepository, KtmbCostRepository>().AutoTrace<IKtmbCostRepository>();
+
     // Priority queue
     s.AddScoped<IPrioritySettingsRepository, PrioritySettingsRepository>()
       .AutoTrace<IPrioritySettingsRepository>();
@@ -157,6 +160,14 @@ public static class DomainServices
       .AutoTrace<IGatewayAuthenticator>();
 
     s.AddScoped<IPaymentGateway, AirwallexGateway>().AutoTrace<IPaymentGateway>();
+
+    // gateway-fee capture (Airwallex financial transactions -> GatewayFees)
+    s.AddScoped<IGatewayFeeRepository, GatewayFeeRepository>().AutoTrace<IGatewayFeeRepository>();
+
+    s.AddScoped<IGatewayFeeSource, AirwallexGatewayFeeSource>().AutoTrace<IGatewayFeeSource>();
+
+    s.AddScoped<IGatewayFeeSyncService, GatewayFeeSyncService>()
+      .AutoTrace<IGatewayFeeSyncService>();
 
     s.AddScoped<AirWallexClient>();
     s.AddScoped<AirwallexEventAdapter>();

--- a/App/Modules/Payments/API/V1/PaymentController.cs
+++ b/App/Modules/Payments/API/V1/PaymentController.cs
@@ -58,6 +58,26 @@ public class PaymentController(
     return this.ReturnResult(x);
   }
 
+  // Pull Airwallex's own fees (financial transactions) for money movements
+  // in the (inclusive SGT date) range that have no fee rows yet: captured
+  // intents, completed PayNow transfers and settled card-refund fragments.
+  // Idempotent (upsert by financial transaction id); sources the gateway has
+  // not posted fees for yet come back in missing — sync again later. Bounded
+  // per call (hasMore = call again to continue).
+  [Authorize(Policy = AuthPolicies.AdminOrTin), HttpPost("gateway-fees/sync")]
+  public async Task<ActionResult<GatewayFeeSyncRes>> SyncGatewayFees(
+    [FromQuery] GatewayFeeSyncQueryReq query,
+    [FromServices] GatewayFeeSyncQueryReqValidator syncValidator,
+    [FromServices] IGatewayFeeSyncService syncService
+  )
+  {
+    var x = await syncValidator
+      .ValidateAsyncResult(query, "Invalid GatewayFeeSyncQueryReq")
+      .ThenAwait(q => syncService.Sync(q.ToDomain()))
+      .Then(r => r.ToRes(), Errors.MapNone);
+    return this.ReturnResult(x);
+  }
+
   [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("id/{id:guid}")]
   public async Task<ActionResult<PaymentRes>> GetById(Guid id)
   {

--- a/App/Modules/Payments/API/V1/PaymentMapper.cs
+++ b/App/Modules/Payments/API/V1/PaymentMapper.cs
@@ -45,7 +45,13 @@ public static class PaymentMapper
   public static CapturedPaymentRes ToRes(this CapturedPayment p) =>
     new(p.PaymentIntentId, p.CapturedAmount, p.Currency, p.CreatedAt, p.Status);
 
+  public static GatewayFeeSyncRes ToRes(this GatewayFeeSyncResult r) =>
+    new(r.Synced, r.Missing, r.HasMore);
+
   // REQ
+  public static GatewayFeeSyncQuery ToDomain(this GatewayFeeSyncQueryReq q) =>
+    new() { After = q.After?.ToDate(), Before = q.Before?.ToDate() };
+
   public static CapturedPaymentsQuery ToDomain(this CapturedPaymentsQueryReq q) =>
     new()
     {

--- a/App/Modules/Payments/API/V1/PaymentModel.cs
+++ b/App/Modules/Payments/API/V1/PaymentModel.cs
@@ -30,7 +30,15 @@ public record CreatePaymentReq(decimal Amount, string Currency);
 // captured money in the (inclusive SGT date, dd-MM-yyyy) range
 public record CapturedPaymentsQueryReq(string? After, string? Before, int? Limit);
 
+// gateway-fee sync range (inclusive SGT dates, dd-MM-yyyy; null = unbounded)
+public record GatewayFeeSyncQueryReq(string? After, string? Before);
+
 // RESP
+
+// gateway-fee sync outcome: Synced = sources that gained fee rows this call;
+// Missing = sources the gateway has no fee rows for yet (fees post with
+// delay — sync again later); HasMore = the per-call bound was hit, call again
+public record GatewayFeeSyncRes(int Synced, string[] Missing, bool HasMore);
 public record CreatePaymentRes(
   Guid Id,
   string ExternalReference,

--- a/App/Modules/Payments/API/V1/PaymentValidator.cs
+++ b/App/Modules/Payments/API/V1/PaymentValidator.cs
@@ -28,6 +28,15 @@ public class CapturedPaymentsQueryReqValidator : AbstractValidator<CapturedPayme
   }
 }
 
+public class GatewayFeeSyncQueryReqValidator : AbstractValidator<GatewayFeeSyncQueryReq>
+{
+  public GatewayFeeSyncQueryReqValidator()
+  {
+    this.RuleFor(x => x.After).NullableDateValid();
+    this.RuleFor(x => x.Before).NullableDateValid();
+  }
+}
+
 public class CreatePaymentReqValidator : AbstractValidator<CreatePaymentReq>
 {
   public CreatePaymentReqValidator()

--- a/App/Modules/Payments/Airwallex/AirwallexGatewayFeeSource.cs
+++ b/App/Modules/Payments/Airwallex/AirwallexGatewayFeeSource.cs
@@ -1,0 +1,29 @@
+using CSharp_Result;
+using Domain.Payment;
+
+namespace App.Modules.Payments.Airwallex;
+
+// IGatewayFeeSource over the Airwallex financial_transactions API: one call
+// per source id, mapped to source-type-agnostic fee lines. An empty answer
+// means the gateway has not posted fees for the movement yet.
+public class AirwallexGatewayFeeSource(AirWallexClient client) : IGatewayFeeSource
+{
+  public Task<Result<IEnumerable<GatewayFeeLine>>> BySource(string sourceId)
+  {
+    return client
+      .ListFinancialTransactionsBySource(sourceId)
+      .Then(
+        items =>
+          items.Select(x => new GatewayFeeLine
+          {
+            FinancialTransactionId = x.Id,
+            Amount = x.Amount,
+            Fee = x.Fee,
+            Net = x.Net,
+            Currency = x.Currency,
+            TransactedAt = DateTime.SpecifyKind(x.CreatedAt, DateTimeKind.Utc),
+          }),
+        Errors.MapNone
+      );
+  }
+}

--- a/App/Modules/Payments/Airwallex/Client.cs
+++ b/App/Modules/Payments/Airwallex/Client.cs
@@ -185,6 +185,73 @@ public class AirWallexClient(
       });
   }
 
+  // The gateway's own fee ledger for one money movement: every financial
+  // transaction reported against source_id (an intent, transfer or refund
+  // id), following page_num until has_more is false. An empty list is a
+  // normal answer — fees post with delay.
+  public Task<Result<AirwallexFinancialTransactionRes[]>> ListFinancialTransactionsBySource(
+    string sourceId
+  )
+  {
+    return authenticator
+      .GetToken()
+      .ThenAwait(async token =>
+      {
+        try
+        {
+          var items = new List<AirwallexFinancialTransactionRes>();
+          var page = 0;
+          while (true)
+          {
+            var request = new HttpRequestMessage
+            {
+              Method = HttpMethod.Get,
+              RequestUri = new Uri(
+                $"api/v1/financial_transactions?source_id={Uri.EscapeDataString(sourceId)}"
+                  + $"&page_num={page}&page_size=100",
+                UriKind.Relative
+              ),
+              Headers = { Authorization = new AuthenticationHeaderValue("Bearer", token) },
+            };
+            using var response = await this.HttpClient.SendAsync(request);
+            var body = await response.Content.ReadAsStringAsync();
+            // a 404 is "no rows for this source (yet)" — a normal empty answer
+            if ((int)response.StatusCode == 404)
+              return (Result<AirwallexFinancialTransactionRes[]>)items.ToArray();
+            if (!response.IsSuccessStatusCode)
+            {
+              logger.LogError(
+                "Failed to list Airwallex financial transactions for '{SourceId}', "
+                  + "Status: {Status}, Response: {Body}",
+                sourceId,
+                (int)response.StatusCode,
+                body
+              );
+              return (Result<AirwallexFinancialTransactionRes[]>)
+                new HttpRequestException(
+                  $"Airwallex financial transaction listing failed ({(int)response.StatusCode}): {body}"
+                );
+            }
+
+            var list = body.ToObj<AirwallexFinancialTransactionListRes>();
+            items.AddRange(list.Items ?? []);
+            if (!list.HasMore || list.Items is not { Length: > 0 })
+              return (Result<AirwallexFinancialTransactionRes[]>)items.ToArray();
+            page++;
+          }
+        }
+        catch (Exception e)
+        {
+          logger.LogError(
+            e,
+            "Failed to list Airwallex financial transactions for '{SourceId}' (transport error)",
+            sourceId
+          );
+          return (Result<AirwallexFinancialTransactionRes[]>)e;
+        }
+      });
+  }
+
   // Point-in-time lookup for reconciliation. Returns null (not an error) when
   // the gateway definitively has no such transfer.
   public Task<Result<AirwallexTransferRes?>> GetTransfer(string transferId)

--- a/App/Modules/Payments/Airwallex/ResModel.cs
+++ b/App/Modules/Payments/Airwallex/ResModel.cs
@@ -86,6 +86,51 @@ public static class AirwallexTransferStatuses
   public static readonly string[] Failed = ["FAILED", "CANCELLED", "REJECTED", "RETURNED"];
 }
 
+// One Airwallex "financial transaction" — the gateway's own money-movement
+// ledger, including its fee take. Field names follow the public
+// financial_transactions API (id, source_id, transaction_type, amount, fee,
+// net, currency, created_at); the record deliberately tolerates any extra
+// fields the gateway adds, and every non-id field is defaulted so a missing
+// field never throws during deserialization.
+public record AirwallexFinancialTransactionRes
+{
+  [JsonPropertyName("id")]
+  public string Id { get; set; } = null!;
+
+  [JsonPropertyName("source_id")]
+  public string? SourceId { get; set; }
+
+  [JsonPropertyName("transaction_type")]
+  public string? TransactionType { get; set; }
+
+  [JsonPropertyName("status")]
+  public string? Status { get; set; }
+
+  [JsonPropertyName("amount")]
+  public decimal Amount { get; set; }
+
+  [JsonPropertyName("fee")]
+  public decimal Fee { get; set; }
+
+  [JsonPropertyName("net")]
+  public decimal Net { get; set; }
+
+  [JsonPropertyName("currency")]
+  public string Currency { get; set; } = string.Empty;
+
+  [JsonPropertyName("created_at")]
+  public DateTime CreatedAt { get; set; }
+}
+
+public record AirwallexFinancialTransactionListRes
+{
+  [JsonPropertyName("has_more")]
+  public bool HasMore { get; set; }
+
+  [JsonPropertyName("items")]
+  public AirwallexFinancialTransactionRes[]? Items { get; set; }
+}
+
 public record AirwallexRefundRes
 {
   [JsonPropertyName("id")]

--- a/App/Modules/Payments/Data/GatewayFeeData.cs
+++ b/App/Modules/Payments/Data/GatewayFeeData.cs
@@ -1,0 +1,43 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace App.Modules.Payments.Data;
+
+// One Airwallex "financial transaction" (the gateway's own fee ledger),
+// captured after the fact by the gateway-fee sync. FinancialTransactionId is
+// the gateway's globally unique id and the idempotent upsert key; SourceId
+// ties the row back to the object that moved the money (a payment intent, a
+// payout transfer or a card refund — see SourceType).
+public class GatewayFeeData
+{
+  public Guid Id { get; set; }
+
+  public DateTime CreatedAt { get; set; }
+
+  // the intent/transfer/refund id this fee was reported against
+  [MaxLength(256)]
+  public string SourceId { get; set; } = string.Empty;
+
+  // Domain.Payment.GatewayFeeSourceType: 0 Payment, 1 Transfer, 2 Refund
+  public byte SourceType { get; set; }
+
+  // Airwallex financial transaction id — unique, the upsert key
+  [MaxLength(256)]
+  public string FinancialTransactionId { get; set; } = string.Empty;
+
+  [Precision(16, 8)]
+  public decimal Amount { get; set; }
+
+  [Precision(16, 8)]
+  public decimal Fee { get; set; }
+
+  [Precision(16, 8)]
+  public decimal Net { get; set; }
+
+  [MaxLength(16)]
+  public string Currency { get; set; } = string.Empty;
+
+  // the gateway's created_at for the financial transaction — the instant the
+  // analysis page buckets fees on (SGT calendar convention downstream)
+  public DateTime TransactedAt { get; set; }
+}

--- a/App/Modules/Payments/Data/GatewayFeeRepository.cs
+++ b/App/Modules/Payments/Data/GatewayFeeRepository.cs
@@ -1,0 +1,165 @@
+using App.StartUp.Database;
+using CSharp_Result;
+using Domain.Payment;
+using Domain.Withdrawal;
+using Microsoft.EntityFrameworkCore;
+
+namespace App.Modules.Payments.Data;
+
+public static class GatewayFeeDataMapper
+{
+  public static GatewayFeeRecord ToRecord(this GatewayFeeData data) =>
+    new()
+    {
+      SourceId = data.SourceId,
+      SourceType = (GatewayFeeSourceType)data.SourceType,
+      FinancialTransactionId = data.FinancialTransactionId,
+      Amount = data.Amount,
+      Fee = data.Fee,
+      Net = data.Net,
+      Currency = data.Currency,
+      TransactedAt = data.TransactedAt,
+    };
+
+  public static GatewayFeeData UpdateData(this GatewayFeeData data, GatewayFeeRecord record)
+  {
+    data.SourceId = record.SourceId;
+    data.SourceType = (byte)record.SourceType;
+    data.FinancialTransactionId = record.FinancialTransactionId;
+    data.Amount = record.Amount;
+    data.Fee = record.Fee;
+    data.Net = record.Net;
+    data.Currency = record.Currency;
+    data.TransactedAt = record.TransactedAt;
+    return data;
+  }
+}
+
+// Storage for the gateway's own fees. ListPendingSources builds the sync
+// worklist (money movements in range with no fee rows yet); Upsert is
+// idempotent by FinancialTransactionId via GatewayFeePlanner.
+public class GatewayFeeRepository(MainDbContext db, ILogger<GatewayFeeRepository> logger)
+  : IGatewayFeeRepository
+{
+  public async Task<Result<IEnumerable<PendingFeeSource>>> ListPendingSources(
+    DateTime after,
+    DateTime before,
+    int max
+  )
+  {
+    try
+    {
+      logger.LogInformation(
+        "Listing pending gateway-fee sources in [{After}, {Before}), max {Max}",
+        after,
+        before,
+        max
+      );
+      var known = db.GatewayFees.Select(f => f.SourceId);
+
+      // captured intents created in range
+      var payments = db
+        .Payments.Where(p =>
+          p.CapturedAmount > 0
+          && p.CreatedAt >= after
+          && p.CreatedAt < before
+          && !known.Contains(p.ExternalReference)
+        )
+        .OrderBy(p => p.CreatedAt)
+        .Select(p => new PendingFeeSource
+        {
+          SourceId = p.ExternalReference,
+          SourceType = GatewayFeeSourceType.Payment,
+        });
+
+      // PayNow payout transfers of withdrawals completed in range
+      var completed = (byte)WithdrawStatus.Completed;
+      var transfers = db
+        .Withdrawals.Where(w =>
+          w.Status == completed
+          && w.Method == 0
+          && w.ConfirmationNumber != null
+          && w.CompletedAt != null
+          && w.CompletedAt >= after
+          && w.CompletedAt < before
+          && !known.Contains(w.ConfirmationNumber)
+        )
+        .OrderBy(w => w.CompletedAt)
+        .Select(w => new PendingFeeSource
+        {
+          SourceId = w.ConfirmationNumber!,
+          SourceType = GatewayFeeSourceType.Transfer,
+        });
+
+      // card-refund fragments of withdrawals completed in range
+      var refunds = db
+        .WithdrawalRefunds.Where(r =>
+          r.AirwallexRefundId != null
+          && r.Withdrawal.Status == completed
+          && r.Withdrawal.CompletedAt != null
+          && r.Withdrawal.CompletedAt >= after
+          && r.Withdrawal.CompletedAt < before
+          && !known.Contains(r.AirwallexRefundId)
+        )
+        .OrderBy(r => r.CreatedAt)
+        .Select(r => new PendingFeeSource
+        {
+          SourceId = r.AirwallexRefundId!,
+          SourceType = GatewayFeeSourceType.Refund,
+        });
+
+      // three bounded scans (not a union) so each keeps its own index order;
+      // the caller passes max = bound + 1, so hitting max signals hasMore
+      var result = new List<PendingFeeSource>();
+      result.AddRange(await payments.Take(max).ToArrayAsync());
+      if (result.Count < max)
+        result.AddRange(await transfers.Take(max - result.Count).ToArrayAsync());
+      if (result.Count < max)
+        result.AddRange(await refunds.Take(max - result.Count).ToArrayAsync());
+
+      return result;
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to list pending gateway-fee sources");
+      return e;
+    }
+  }
+
+  public async Task<Result<int>> Upsert(IEnumerable<GatewayFeeRecord> records)
+  {
+    try
+    {
+      var incoming = records.ToArray();
+      var ids = incoming.Select(x => x.FinancialTransactionId).Distinct().ToArray();
+      var existing = await db
+        .GatewayFees.Where(x => ids.Contains(x.FinancialTransactionId))
+        .ToArrayAsync();
+
+      var (toInsert, toUpdate) = GatewayFeePlanner.Plan(
+        existing.Select(x => x.FinancialTransactionId).ToArray(),
+        incoming
+      );
+
+      var now = DateTime.UtcNow;
+      foreach (var record in toInsert)
+        db.GatewayFees.Add(new GatewayFeeData { CreatedAt = now }.UpdateData(record));
+      foreach (var record in toUpdate)
+        existing.First(x => x.FinancialTransactionId == record.FinancialTransactionId)
+          .UpdateData(record);
+
+      await db.SaveChangesAsync();
+      logger.LogInformation(
+        "Upserted gateway fees: {Inserted} inserted, {Updated} refreshed",
+        toInsert.Length,
+        toUpdate.Length
+      );
+      return toInsert.Length + toUpdate.Length;
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to upsert gateway fees");
+      return e;
+    }
+  }
+}

--- a/App/StartUp/Database/MainDbContext.cs
+++ b/App/StartUp/Database/MainDbContext.cs
@@ -29,6 +29,10 @@ public class MainDbContext(
 
   public DbSet<PaymentData> Payments { get; set; }
 
+  // Airwallex's own per-movement fees (financial transactions), captured
+  // after the fact by the gateway-fee sync
+  public DbSet<GatewayFeeData> GatewayFees { get; set; }
+
   public DbSet<DiscountData> Discounts { get; set; }
   public DbSet<CostData> Costs { get; set; }
 
@@ -51,6 +55,9 @@ public class MainDbContext(
   public DbSet<PassengerData> Passengers { get; set; }
 
   public DbSet<BookingData> Bookings { get; set; }
+
+  // effective-dated per-direction KTMB ticket cost queue (analysis costing)
+  public DbSet<KtmbCostData> KtmbCosts { get; set; }
 
   // keyless read-only projection of the booking_stats materialized view
   public DbSet<BookingStatData> BookingStats { get; set; }
@@ -218,6 +225,29 @@ public class MainDbContext(
     // the gateway idempotency key is unique by construction; the index makes
     // webhook routing by request id an O(1) lookup and enforces the invariant
     withdrawalRefund.HasIndex(x => x.RequestId).IsUnique();
+
+    // price breakdown captured at purchase: owned JSON, same convention as
+    // PaymentData.Statuses; NULL column = booking predates persistence
+    booking.OwnsOne(
+      x => x.PriceBreakdown,
+      d =>
+      {
+        d.ToJson();
+        d.OwnsMany(b => b.Lines);
+      }
+    );
+
+    // the gateway's fee ledger: FinancialTransactionId is the idempotent
+    // upsert key (unique); SourceId is the sync's pending-lookup pivot
+    var gatewayFee = modelBuilder.Entity<GatewayFeeData>();
+    gatewayFee.HasIndex(x => x.SourceId);
+    gatewayFee.HasIndex(x => x.FinancialTransactionId).IsUnique();
+    gatewayFee.HasIndex(x => x.TransactedAt);
+
+    // effective-dated per-direction KTMB cost queue: reads scan the newest
+    // effective row per direction, exactly like the withdrawal fee queue
+    var ktmbCost = modelBuilder.Entity<KtmbCostData>();
+    ktmbCost.HasIndex(x => new { x.Direction, x.EffectiveAt });
 
     var payments = modelBuilder.Entity<PaymentData>();
     payments.HasIndex(x => x.ExternalReference);

--- a/Domain/Booking/Analysis.cs
+++ b/Domain/Booking/Analysis.cs
@@ -3,9 +3,12 @@ using Domain.Timings;
 
 namespace Domain.Booking;
 
-// Sales/revenue analysis for the admin "Analysis" page. All figures are
-// GROSS and internal: Airwallex's own gateway fees are not stored anywhere
-// (no API for them yet), so they are deliberately out of scope.
+// Sales/revenue analysis for the admin "Analysis" page. Revenue figures are
+// GROSS; cost figures are what leaves BunnyBooker's pocket: the KTMB ticket
+// cost (admin-configured, effective-dated per direction) and Airwallex's own
+// gateway fees (captured after the fact by the gateway-fee sync). Internal
+// fees (deposit/withdrawal/priority/termination) are revenue TO BunnyBooker
+// and are deliberately excluded from the cost side of net.
 public record BookingAnalysisQuery
 {
   // SGT calendar-date range (inclusive), same convention as booking_stats:
@@ -18,7 +21,8 @@ public record BookingAnalysisQuery
 
 // One completed-revenue row: bookings completed on this SGT date, for this
 // departure slot. GrossRevenue = the booking cost collected at completion
-// (BookingReserve -> BunnyBooker).
+// (BookingReserve -> BunnyBooker); KtmbCost = the sum of each booking's
+// effective KTMB ticket cost at its CompletedAt (0 when none configured).
 public record BookingAnalysisRow
 {
   // SGT date of CompletedAt (matches booking_stats' SGT date convention)
@@ -31,6 +35,8 @@ public record BookingAnalysisRow
   public required int TicketsCompleted { get; init; }
 
   public required decimal GrossRevenue { get; init; }
+
+  public required decimal KtmbCost { get; init; }
 }
 
 // Airwallex deposits captured in the range: how many intents captured money
@@ -58,15 +64,115 @@ public record InternalFees
   public required decimal Termination { get; init; }
 }
 
+// how many captured payment intents in range already have gateway fee rows
+// — fees post with delay, so the UI can show sync coverage
+public record GatewayFeeCoverage
+{
+  public required int PaymentsWithFee { get; init; }
+
+  public required int PaymentsTotal { get; init; }
+}
+
+// Airwallex's own fees in the range (from the synced gateway-fee rows),
+// bucketed by which direction the money moved
+public record GatewayFeeSummary
+{
+  // fees on captured payment intents (money in)
+  public required decimal Payments { get; init; }
+
+  // fees on payout transfers + card refunds (money out)
+  public required decimal Payouts { get; init; }
+
+  public required GatewayFeeCoverage Coverage { get; init; }
+}
+
+// per-direction slice of the completed rows (summary- and month-level)
+public record DirectionBreakdown
+{
+  public required TrainDirection Direction { get; init; }
+
+  public required int Tickets { get; init; }
+
+  public required decimal Gross { get; init; }
+
+  public required decimal KtmbCost { get; init; }
+}
+
+// One SGT calendar month of the range.
+//
+// NET FORMULA: Net = Gross − KtmbCost − GatewayPaymentFees −
+// GatewayPayoutFees. InternalFees is BunnyBooker's own fee REVENUE in the
+// month (deposit + withdrawal + net priority + net termination) — it is
+// reported for context but deliberately NOT part of the cost side.
+public record MonthlyAnalysisRow
+{
+  // "MM-yyyy" (SGT calendar month)
+  public required string Month { get; init; }
+
+  public required decimal Gross { get; init; }
+
+  public required decimal KtmbCost { get; init; }
+
+  public required decimal GatewayPaymentFees { get; init; }
+
+  public required decimal GatewayPayoutFees { get; init; }
+
+  public required decimal InternalFees { get; init; }
+
+  public required decimal Net { get; init; }
+
+  public required DirectionBreakdown[] ByDirection { get; init; }
+}
+
+// month-keyed external sums the data layer feeds the monthly rollup
+public record MonthlyExternalSums
+{
+  public required decimal GatewayPaymentFees { get; init; }
+
+  public required decimal GatewayPayoutFees { get; init; }
+
+  public required decimal InternalFees { get; init; }
+}
+
+// one pricing component's aggregate over the range — ranks which policies /
+// discounts / the priority boost make or lose money. Kind: "policy" (signed
+// delta as configured), "discount" (negative), "priorityFee" (positive, from
+// the PriorityFee column of completed bookings).
+public record PriceComponentSummary
+{
+  public required string Kind { get; init; }
+
+  public required string Name { get; init; }
+
+  public required int TimesApplied { get; init; }
+
+  public required decimal TotalDelta { get; init; }
+}
+
+// breakdown persistence started with this release — old bookings have no
+// stored breakdown and are excluded from Components, never guessed
+public record ComponentsCoverage
+{
+  public required int WithBreakdown { get; init; }
+
+  public required int Total { get; init; }
+}
+
 public record BookingAnalysisSummary
 {
   public required int TotalTickets { get; init; }
 
   public required decimal TotalGross { get; init; }
 
+  public required decimal TotalKtmbCost { get; init; }
+
   public required DepositSummary Deposits { get; init; }
 
   public required InternalFees InternalFees { get; init; }
+
+  public required GatewayFeeSummary GatewayFees { get; init; }
+
+  public required DirectionBreakdown[] ByDirection { get; init; }
 }
 
 public record BookingAnalysis
@@ -74,6 +180,12 @@ public record BookingAnalysis
   public required IEnumerable<BookingAnalysisRow> Rows { get; init; }
 
   public required BookingAnalysisSummary Summary { get; init; }
+
+  public required MonthlyAnalysisRow[] Monthly { get; init; }
+
+  public required PriceComponentSummary[] Components { get; init; }
+
+  public required ComponentsCoverage ComponentsCoverage { get; init; }
 }
 
 // The raw range-scoped sums the data layer computes DB-side; the pure
@@ -101,12 +213,14 @@ public static class BookingAnalysisCalculator
   public static BookingAnalysisSummary Summarize(
     IReadOnlyCollection<BookingAnalysisRow> rows,
     DepositSummary deposits,
-    BookingAnalysisLedgerSums sums
+    BookingAnalysisLedgerSums sums,
+    GatewayFeeSummary gatewayFees
   ) =>
     new()
     {
       TotalTickets = rows.Sum(r => r.TicketsCompleted),
       TotalGross = rows.Sum(r => r.GrossRevenue),
+      TotalKtmbCost = rows.Sum(r => r.KtmbCost),
       Deposits = deposits,
       InternalFees = new InternalFees
       {
@@ -115,10 +229,127 @@ public static class BookingAnalysisCalculator
         Priority = sums.PriorityFeesCharged - sums.PriorityFeesRefunded,
         Termination = sums.TerminatedGross - sums.TerminationRefunds,
       },
+      GatewayFees = gatewayFees,
+      ByDirection = ByDirection(rows),
     };
+
+  // per-direction totals over the given rows, stable direction order
+  public static DirectionBreakdown[] ByDirection(IEnumerable<BookingAnalysisRow> rows) =>
+    rows.GroupBy(r => r.Direction)
+      .OrderBy(g => g.Key)
+      .Select(g => new DirectionBreakdown
+      {
+        Direction = g.Key,
+        Tickets = g.Sum(r => r.TicketsCompleted),
+        Gross = g.Sum(r => r.GrossRevenue),
+        KtmbCost = g.Sum(r => r.KtmbCost),
+      })
+      .ToArray();
+
+  public static string MonthKey(DateOnly date) => date.ToString("MM-yyyy");
+
+  // One row per SGT calendar month that has activity (completed bookings or
+  // gateway/internal fee movement). Net = Gross − KtmbCost − gateway fees;
+  // internal fees are revenue and excluded from the cost side.
+  public static MonthlyAnalysisRow[] MonthlyRollup(
+    IReadOnlyCollection<BookingAnalysisRow> rows,
+    IReadOnlyDictionary<string, MonthlyExternalSums> external
+  )
+  {
+    var byMonth = rows.GroupBy(r => MonthKey(r.Date)).ToDictionary(g => g.Key, g => g.ToArray());
+    var months = byMonth
+      .Keys.Concat(external.Keys)
+      .Distinct()
+      // "MM-yyyy" sorts chronologically on (yyyy, MM)
+      .OrderBy(m => m[3..])
+      .ThenBy(m => m[..2])
+      .ToArray();
+
+    return months
+      .Select(m =>
+      {
+        var monthRows = byMonth.GetValueOrDefault(m, []);
+        var ext =
+          external.GetValueOrDefault(m)
+          ?? new MonthlyExternalSums
+          {
+            GatewayPaymentFees = 0m,
+            GatewayPayoutFees = 0m,
+            InternalFees = 0m,
+          };
+        var gross = monthRows.Sum(r => r.GrossRevenue);
+        var ktmb = monthRows.Sum(r => r.KtmbCost);
+        return new MonthlyAnalysisRow
+        {
+          Month = m,
+          Gross = gross,
+          KtmbCost = ktmb,
+          GatewayPaymentFees = ext.GatewayPaymentFees,
+          GatewayPayoutFees = ext.GatewayPayoutFees,
+          InternalFees = ext.InternalFees,
+          Net = gross - ktmb - ext.GatewayPaymentFees - ext.GatewayPayoutFees,
+          ByDirection = ByDirection(monthRows),
+        };
+      })
+      .ToArray();
+  }
+}
+
+// ---- boost ledger (GET Booking/analysis/boosts) ----
+
+public record BookingBoostQuery
+{
+  public DateOnly? After { get; init; }
+
+  public DateOnly? Before { get; init; }
+
+  public required int Limit { get; init; }
+
+  public required int Skip { get; init; }
+}
+
+// one prioritized booking. BoostedAt: PrioritizedAt when stamped (rows from
+// this release onward); older boosts fall back to the booking's CreatedAt —
+// the best persisted proxy (the prioritize flow historically stamped no
+// timestamp). GrantedBy: the caller's sub when someone other than the owner
+// (an admin) prioritized the booking — stamped from this release onward,
+// null before; a free self-boost via FreeTarget role match stays null.
+public record BookingBoost
+{
+  public required Guid BookingId { get; init; }
+
+  public required string UserId { get; init; }
+
+  // email when known, else username — same identity precedence the admin
+  // user lists use
+  public required string UserIdentity { get; init; }
+
+  public required DateOnly Date { get; init; }
+
+  public required TimeOnly Time { get; init; }
+
+  public required TrainDirection Direction { get; init; }
+
+  // the fee charged; null when the boost was free (nothing to refund)
+  public required decimal? Fee { get; init; }
+
+  public required bool Free { get; init; }
+
+  public required DateTime BoostedAt { get; init; }
+
+  public required string? GrantedBy { get; init; }
+}
+
+public record BookingBoostPage
+{
+  public required int Total { get; init; }
+
+  public required BookingBoost[] Items { get; init; }
 }
 
 public interface IBookingAnalysisRepository
 {
   Task<Result<BookingAnalysis>> Analyze(BookingAnalysisQuery query);
+
+  Task<Result<BookingBoostPage>> Boosts(BookingBoostQuery query);
 }

--- a/Domain/Booking/IService.cs
+++ b/Domain/Booking/IService.cs
@@ -17,7 +17,14 @@ public interface IBookingService
 
   Task<Result<Booking?>> Get(string? userId, Guid id);
 
-  Task<Result<BookingPrincipal>> Create(string userId, decimal cost, BookingRecord record);
+  // breakdown = the price composition behind cost, persisted for component
+  // analytics (null when the caller has no materialized quote)
+  Task<Result<BookingPrincipal>> Create(
+    string userId,
+    decimal cost,
+    BookingRecord record,
+    BookingPriceBreakdown? breakdown = null
+  );
 
   Task<Result<BookingPrincipal?>> Update(string? userId, Guid id, BookingRecord record);
 
@@ -82,6 +89,8 @@ public interface IBookingService
     string[]? callerTokenRoles = null
   );
 
-  // charge the priority fee and move the booking to the front of its queue
-  Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id);
+  // charge the priority fee and move the booking to the front of its queue;
+  // callerSub = the invoking user's sub, persisted as the granter when it is
+  // not the booking owner (admin-granted boost attribution)
+  Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, string? callerSub = null);
 }

--- a/Domain/Booking/KtmbCost.cs
+++ b/Domain/Booking/KtmbCost.cs
@@ -1,0 +1,73 @@
+using CSharp_Result;
+using Domain.Timings;
+
+namespace Domain.Booking;
+
+// What BunnyBooker pays KTMB per ticket, per direction — an insert-only,
+// effective-dated queue exactly like the withdrawal Fee queue: the newest
+// row whose EffectiveAt has passed (per direction) is the live cost, future
+// rows are the queue, and with no effective row the cost is ZERO (analysis
+// then reports net without a KTMB component rather than guessing).
+public record KtmbCostChange
+{
+  public required Guid Id { get; init; }
+
+  public required TrainDirection Direction { get; init; }
+
+  public required decimal Cost { get; init; }
+
+  public required DateTime EffectiveAt { get; init; }
+
+  public required DateTime CreatedAt { get; init; }
+}
+
+// current cost per direction + the queued future changes, for the admin UI
+public record KtmbCostView
+{
+  // one entry per direction, 0m when never configured
+  public required IReadOnlyDictionary<TrainDirection, decimal> Current { get; init; }
+
+  public required KtmbCostChange[] Upcoming { get; init; }
+}
+
+public interface IKtmbCostRepository
+{
+  // the full queue (the table is tiny — a handful of admin-entered rows)
+  Task<Result<IEnumerable<KtmbCostChange>>> List();
+
+  Task<Result<KtmbCostChange>> Add(TrainDirection direction, decimal cost, DateTime? effectiveAt);
+}
+
+// Pure effective-dating math, shared by the endpoint and the unit tests.
+// The analysis SQL implements the same newest-effective-first rule DB-side
+// (per booking CompletedAt); this is the single in-memory source of truth.
+public static class KtmbCostSchedule
+{
+  // the cost effective at a given instant for a direction; 0 when none
+  public static decimal EffectiveCost(
+    IEnumerable<KtmbCostChange> changes,
+    TrainDirection direction,
+    DateTime at
+  ) =>
+    changes
+      .Where(x => x.Direction == direction && x.EffectiveAt <= at)
+      .OrderByDescending(x => x.EffectiveAt)
+      .ThenByDescending(x => x.CreatedAt)
+      .ThenByDescending(x => x.Id)
+      .Select(x => x.Cost)
+      .FirstOrDefault();
+
+  public static KtmbCostView View(IEnumerable<KtmbCostChange> changes, DateTime now)
+  {
+    var all = changes.ToArray();
+    return new KtmbCostView
+    {
+      Current = new Dictionary<TrainDirection, decimal>
+      {
+        [TrainDirection.JToW] = EffectiveCost(all, TrainDirection.JToW, now),
+        [TrainDirection.WToJ] = EffectiveCost(all, TrainDirection.WToJ, now),
+      },
+      Upcoming = all.Where(x => x.EffectiveAt > now).OrderBy(x => x.EffectiveAt).ToArray(),
+    };
+  }
+}

--- a/Domain/Booking/Model.cs
+++ b/Domain/Booking/Model.cs
@@ -161,7 +161,42 @@ public record BookingCount
   public required TimeOnly Time { get; init; }
 
   public required TrainDirection Direction { get; init; }
+
+  // total pending bookings in the slot (Priority + Normal — kept as the
+  // backward-compatible field old argon clients read)
   public required int TicketsNeeded { get; init; }
+
+  // the split behind TicketsNeeded: priority-boosted bookings (front of the
+  // purchase queue) vs the normal queue
+  public required int Priority { get; init; }
+
+  public required int Normal { get; init; }
+}
+
+// One pricing component applied at purchase: a cost policy's signed delta
+// (vs the base cost) or a discount's negative delta (vs the subtotal)
+public record BookingPriceLine
+{
+  // "policy" | "discount"
+  public required string Kind { get; init; }
+
+  public required string Name { get; init; }
+
+  public required decimal Delta { get; init; }
+}
+
+// The price breakdown captured at purchase, so analytics can rank which
+// policies/discounts make or lose money. BaseCost + policy lines = the
+// subtotal; subtotal + discount lines ≈ Final (Final additionally floors at
+// 0 and rounds to the stored precision). Persisted from the release that
+// introduced it — older bookings have none.
+public record BookingPriceBreakdown
+{
+  public required decimal BaseCost { get; init; }
+
+  public required BookingPriceLine[] Lines { get; init; }
+
+  public required decimal Final { get; init; }
 }
 
 // Cheap single-booking probe of the ticket file reference: HasRef = the

--- a/Domain/Booking/Repository.cs
+++ b/Domain/Booking/Repository.cs
@@ -20,7 +20,14 @@ public interface IBookingRepository
 
   Task<Result<Booking?>> Get(string? userId, Guid id);
 
-  Task<Result<BookingPrincipal>> Create(string userId, Guid transactionId, BookingRecord record);
+  // breakdown = the price composition captured at purchase; null for flows
+  // that have no quote to persist (older callers, duplicated bookings)
+  Task<Result<BookingPrincipal>> Create(
+    string userId,
+    Guid transactionId,
+    BookingRecord record,
+    BookingPriceBreakdown? breakdown
+  );
 
   Task<Result<BookingPrincipal?>> Update(
     string? userId,
@@ -32,10 +39,17 @@ public interface IBookingRepository
 
   Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly Time);
 
-  // marks the booking priority (front of its queue) and snapshots the fee
-  // charged (null = FREE boost, nothing charged so nothing to refund); null
-  // result when the booking does not exist (or is not visible to userId)
-  Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee);
+  // marks the booking priority (front of its queue), snapshots the fee
+  // charged (null = FREE boost, nothing charged so nothing to refund), stamps
+  // PrioritizedAt and — when someone other than the owner (an admin) invoked
+  // it — the granter's sub for boost-ledger attribution; null result when the
+  // booking does not exist (or is not visible to userId)
+  Task<Result<BookingPrincipal?>> Prioritize(
+    string? userId,
+    Guid id,
+    decimal? fee,
+    string? grantedBy
+  );
 
   // bumps the recovery retry counter by one; null when the booking does not
   // exist. Runs inside the caller's RecoverRevert transaction so the counter

--- a/Domain/Booking/Service.cs
+++ b/Domain/Booking/Service.cs
@@ -744,7 +744,7 @@ public class BookingService(
           },
           exception =>
           {
-            logger.LogError(exception, "Failed to notify booking completed");
+            logger.LogError(exception, "Failed to notify booking cancelled");
             return new Unit();
           }), Errors.MapNone)
       .Then(BookingPrincipal? (x) => x.Principal, Errors.MapNone);

--- a/Domain/Booking/Service.cs
+++ b/Domain/Booking/Service.cs
@@ -66,7 +66,12 @@ public class BookingService(
   }
 
   // When user creates a booking
-  public Task<Result<BookingPrincipal>> Create(string userId, decimal cost, BookingRecord record)
+  public Task<Result<BookingPrincipal>> Create(
+    string userId,
+    decimal cost,
+    BookingRecord record,
+    BookingPriceBreakdown? breakdown = null
+  )
   {
     // Defense in depth: API Purchase checks before pricing, and this domain
     // boundary checks again before opening a transaction or touching a wallet.
@@ -93,7 +98,7 @@ public class BookingService(
             .ThenAwait(w =>
               transactionRepo.Create(w.Id, transactionGenerator.CreateBooking(cost, record))
             )
-            .ThenAwait(x => repo.Create(userId, x.Id, record))
+            .ThenAwait(x => repo.Create(userId, x.Id, record, breakdown))
       )
       .DoAwait(DoType.Ignore, _ => cdcRepository.Add("create"));
   }
@@ -451,14 +456,14 @@ public class BookingService(
       )
       .NullToError(id.ToString())
       .DoAwait(DoType.Ignore, _ => cdcRepository.Add("reserve"))
-      .DoAwait(DoType.Ignore, x =>notificationService.NotifyBookingCompleted(x)
+      .DoAwait(DoType.Ignore, x => notificationService.NotifyBookingCompleted(x)
           .Match(s => s,
             exception =>
             {
               logger.LogError(exception, "Failed to notify booking completed (no-collect)");
               return new Unit();
             }), Errors.MapNone)
-      .Then(BookingPrincipal? (x) => x.Principal , Errors.MapNone);
+      .Then(BookingPrincipal? (x) => x.Principal, Errors.MapNone);
   }
 
   public Task<Result<BookingPrincipal?>> Complete(Guid id,
@@ -540,15 +545,15 @@ public class BookingService(
       )
       .NullToError(id.ToString())
       .DoAwait(DoType.Ignore, _ => cdcRepository.Add("reserve"))
-      .DoAwait(DoType.Ignore, x =>notificationService.NotifyBookingCompleted(x)
-          .Match(s => s, 
+      .DoAwait(DoType.Ignore, x => notificationService.NotifyBookingCompleted(x)
+          .Match(s => s,
             exception =>
             {
               logger.LogError(exception, "Failed to notify booking completed");
               return new Unit();
             }), Errors.MapNone)
-      .Then(BookingPrincipal? (x) => x.Principal , Errors.MapNone);
-      
+      .Then(BookingPrincipal? (x) => x.Principal, Errors.MapNone);
+
   }
 
   // AttachTicket repairs the ticket artefacts of an already-Completed booking
@@ -731,18 +736,18 @@ public class BookingService(
       )
       .NullToError(id.ToString())
       .DoAwait(DoType.Ignore, _ => cdcRepository.Add("reserve"))
-      .DoAwait(DoType.Ignore, x =>notificationService.NotifyBookingCancelled(x)
+      .DoAwait(DoType.Ignore, x => notificationService.NotifyBookingCancelled(x)
         .Match(s =>
           {
             logger.LogInformation("Notify booking cancelled successfully");
             return s;
-          }, 
+          },
           exception =>
           {
             logger.LogError(exception, "Failed to notify booking completed");
             return new Unit();
           }), Errors.MapNone)
-      .Then(BookingPrincipal? (x) => x.Principal , Errors.MapNone);
+      .Then(BookingPrincipal? (x) => x.Principal, Errors.MapNone);
   }
 
   // When the recoverer confirms the user already holds this ticket via another
@@ -818,7 +823,7 @@ public class BookingService(
       )
       .NullToError(id.ToString())
       .DoAwait(DoType.Ignore, _ => cdcRepository.Add("reserve"))
-      .DoAwait(DoType.Ignore, x =>notificationService.NotifyBookingDuplicate(x)
+      .DoAwait(DoType.Ignore, x => notificationService.NotifyBookingDuplicate(x)
         .Match(s =>
           {
             logger.LogInformation("Notify booking duplicate successfully");
@@ -829,7 +834,7 @@ public class BookingService(
             logger.LogError(exception, "Failed to notify booking duplicate");
             return new Unit();
           }), Errors.MapNone)
-      .Then(BookingPrincipal? (x) => x.Principal , Errors.MapNone);
+      .Then(BookingPrincipal? (x) => x.Principal, Errors.MapNone);
   }
 
   // When users cancel the tickets after booking succeeded
@@ -1118,7 +1123,11 @@ public class BookingService(
   // RepeatableRead transaction so the guard read, the fee collection from
   // Usable, the ledger row and the priority flag can never diverge — an
   // insufficient balance rolls everything back and surfaces as its own error.
-  public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id)
+  public Task<Result<BookingPrincipal?>> Prioritize(
+    string? userId,
+    Guid id,
+    string? callerSub = null
+  )
   {
     return transaction
       .Start(
@@ -1180,8 +1189,18 @@ public class BookingService(
             )
             // flag the booking + snapshot the charged fee for the refund
             // path; a FREE boost snapshots null (nothing was charged, so
-            // there is nothing to refund — the refund path must stay silent)
-            .ThenAwait(t => repo.Prioritize(userId, id, t.e.Free ? null : t.e.Fee))
+            // there is nothing to refund — the refund path must stay silent).
+            // grantedBy = the caller's sub only when they are NOT the owner
+            // (an admin boosting someone else's booking) — boost-ledger
+            // attribution; a self-boost (free or paid) stays unattributed
+            .ThenAwait(t =>
+              repo.Prioritize(
+                userId,
+                id,
+                t.e.Free ? null : t.e.Fee,
+                callerSub != null && callerSub != t.b.Principal.UserId ? callerSub : null
+              )
+            )
             .NullToError(id.ToString())
       )
       .DoAwait(DoType.Ignore, _ => cdcRepository.Add("update"))

--- a/Domain/Cost/CostCalculator.cs
+++ b/Domain/Cost/CostCalculator.cs
@@ -1,11 +1,22 @@
 using CSharp_Result;
 using Domain.Booking;
+using Domain.Discount;
 
 namespace Domain.Cost;
 
 public class CostCalculator(ICostService service) : ICostCalculator
 {
   public Task<Result<decimal>> BookingCost(string userId, string[] roles, BookingRecord record)
+  {
+    return this.BookingCostDetail(userId, roles, record).Then(x => x.Final, Errors.MapNone);
+  }
+
+  // the full breakdown behind BookingCost, for callers that persist it
+  public Task<Result<MaterializedCost>> BookingCostDetail(
+    string userId,
+    string[] roles,
+    BookingRecord record
+  )
   {
     // booking-aware: pricing policies match on the booking's date/time/direction
     var spec = new BookingCostSpec
@@ -14,6 +25,38 @@ public class CostCalculator(ICostService service) : ICostCalculator
       Time = record.Time,
       Direction = record.Direction,
     };
-    return service.Materialize(userId, roles, spec).Then(x => x.Final, Errors.MapNone);
+    return service.Materialize(userId, roles, spec);
   }
+}
+
+// Derives the persisted per-booking price breakdown from a materialized
+// price. Discount deltas mirror DiscountCalculator exactly: each discount is
+// resolved against the SUBTOTAL (not the running total) — percentage =
+// Amount × Subtotal, flat = Amount — and stored negative. The stored lines
+// therefore satisfy BaseCost + Σpolicy = Subtotal and Subtotal + Σdiscount ≈
+// Final (Final additionally floors at 0 and rounds to numeric(16,8)).
+public static class PriceBreakdownFactory
+{
+  public static BookingPriceBreakdown ToBreakdown(this MaterializedCost cost) =>
+    new()
+    {
+      BaseCost = cost.Cost,
+      Lines = cost
+        .PolicyLines.Select(l => new BookingPriceLine
+        {
+          Kind = "policy",
+          Name = l.Name,
+          Delta = l.Delta,
+        })
+        .Concat(
+          cost.Discounts.Select(d => new BookingPriceLine
+          {
+            Kind = "discount",
+            Name = d.Name,
+            Delta = -(d.Type == DiscountType.Percentage ? d.Amount * cost.Subtotal : d.Amount),
+          })
+        )
+        .ToArray(),
+      Final = cost.Final,
+    };
 }

--- a/Domain/Cost/ICostCalculator.cs
+++ b/Domain/Cost/ICostCalculator.cs
@@ -6,4 +6,11 @@ namespace Domain.Cost;
 public interface ICostCalculator
 {
   Task<Result<decimal>> BookingCost(string userId, string[] roles, BookingRecord record);
+
+  // the full breakdown behind BookingCost, for callers that persist it
+  Task<Result<MaterializedCost>> BookingCostDetail(
+    string userId,
+    string[] roles,
+    BookingRecord record
+  );
 }

--- a/Domain/Payment/GatewayFee.cs
+++ b/Domain/Payment/GatewayFee.cs
@@ -1,0 +1,231 @@
+using CSharp_Result;
+using Microsoft.Extensions.Logging;
+
+namespace Domain.Payment;
+
+// Airwallex's own per-movement fees ("financial transactions"), captured
+// after the fact for the admin Analysis page. Each row is one gateway
+// financial transaction keyed by its FinancialTransactionId (the idempotent
+// upsert key); SourceId ties it back to the object that moved the money —
+// a payment intent, a payout transfer or a card refund.
+public enum GatewayFeeSourceType : byte
+{
+  // a captured payment intent (PaymentData.ExternalReference)
+  Payment = 0,
+
+  // a PayNow payout transfer (WithdrawalData.ConfirmationNumber)
+  Transfer = 1,
+
+  // a card-refund fragment (WithdrawalRefundData.AirwallexRefundId)
+  Refund = 2,
+}
+
+// pure business data of one gateway financial transaction
+public record GatewayFeeRecord
+{
+  // the intent/transfer/refund id the gateway reported this row against
+  public required string SourceId { get; init; }
+
+  public required GatewayFeeSourceType SourceType { get; init; }
+
+  // the gateway's financial transaction id — globally unique, the upsert key
+  public required string FinancialTransactionId { get; init; }
+
+  public required decimal Amount { get; init; }
+
+  public required decimal Fee { get; init; }
+
+  public required decimal Net { get; init; }
+
+  public required string Currency { get; init; }
+
+  public required DateTime TransactedAt { get; init; }
+}
+
+// one fee line as the gateway reports it (source-type-agnostic — the caller
+// knows which source it asked about)
+public record GatewayFeeLine
+{
+  public required string FinancialTransactionId { get; init; }
+
+  public required decimal Amount { get; init; }
+
+  public required decimal Fee { get; init; }
+
+  public required decimal Net { get; init; }
+
+  public required string Currency { get; init; }
+
+  public required DateTime TransactedAt { get; init; }
+}
+
+// a money movement in range that has no fee rows yet — the sync worklist
+public record PendingFeeSource
+{
+  public required string SourceId { get; init; }
+
+  public required GatewayFeeSourceType SourceType { get; init; }
+}
+
+public record GatewayFeeSyncQuery
+{
+  // inclusive SGT calendar dates (same convention as the analysis range);
+  // null = unbounded
+  public DateOnly? After { get; init; }
+
+  public DateOnly? Before { get; init; }
+}
+
+public record GatewayFeeSyncResult
+{
+  // sources that gained (or refreshed) fee rows this call
+  public required int Synced { get; init; }
+
+  // sources still without fee data — the gateway had no rows yet (fees post
+  // with delay) or the lookup failed; retry on a later sync
+  public required string[] Missing { get; init; }
+
+  // more pending sources exist beyond the per-call bound — call again
+  public required bool HasMore { get; init; }
+}
+
+public interface IGatewayFeeRepository
+{
+  // money movements in the (UTC instant) range that have no fee rows yet,
+  // at most max entries
+  Task<Result<IEnumerable<PendingFeeSource>>> ListPendingSources(
+    DateTime after,
+    DateTime before,
+    int max
+  );
+
+  // idempotent by FinancialTransactionId: existing rows are refreshed,
+  // unseen rows inserted (see GatewayFeePlanner). Returns rows written.
+  Task<Result<int>> Upsert(IEnumerable<GatewayFeeRecord> records);
+}
+
+// fee lines for one source id, straight from the gateway; empty = the
+// gateway has no financial transactions for it yet (they post with delay)
+public interface IGatewayFeeSource
+{
+  Task<Result<IEnumerable<GatewayFeeLine>>> BySource(string sourceId);
+}
+
+public interface IGatewayFeeSyncService
+{
+  Task<Result<GatewayFeeSyncResult>> Sync(GatewayFeeSyncQuery query);
+}
+
+// Pure upsert planning, shared by the repository and the unit tests: rows
+// whose FinancialTransactionId is already stored become updates, unseen ids
+// become inserts, and duplicate ids within one batch collapse to the last
+// occurrence — so replaying the same gateway response is a no-op-shaped
+// refresh, never a duplicate row.
+public static class GatewayFeePlanner
+{
+  public static (GatewayFeeRecord[] ToInsert, GatewayFeeRecord[] ToUpdate) Plan(
+    IReadOnlyCollection<string> existingIds,
+    IEnumerable<GatewayFeeRecord> incoming
+  )
+  {
+    var deduped = incoming
+      .GroupBy(x => x.FinancialTransactionId)
+      .Select(g => g.Last())
+      .ToArray();
+    var existing = existingIds.ToHashSet();
+    return (
+      deduped.Where(x => !existing.Contains(x.FinancialTransactionId)).ToArray(),
+      deduped.Where(x => existing.Contains(x.FinancialTransactionId)).ToArray()
+    );
+  }
+}
+
+// Sync driver: list the movements in range that still lack fee rows, ask the
+// gateway for each one's financial transactions and upsert what it returns.
+// A source with no rows yet (gateway fees post with delay) or a failed
+// lookup stays in Missing and is retried by a later sync — one flaky source
+// never fails the batch.
+public class GatewayFeeSyncService(
+  IGatewayFeeRepository repo,
+  IGatewayFeeSource gateway,
+  ILogger<GatewayFeeSyncService> logger
+) : IGatewayFeeSyncService
+{
+  // bound the per-call work so an admin backfilling months of history gets
+  // fast, resumable batches instead of one giant request
+  public const int MaxSourcesPerSync = 200;
+
+  public async Task<Result<GatewayFeeSyncResult>> Sync(GatewayFeeSyncQuery query)
+  {
+    var sgt = TimeZoneInfo.FindSystemTimeZoneById("Asia/Singapore");
+    // inclusive SGT dates -> half-open UTC instant range [after, before)
+    var afterUtc =
+      query.After?.ToDateTime(TimeOnly.MinValue, DateTimeKind.Unspecified) is { } a
+        ? TimeZoneInfo.ConvertTimeToUtc(a, sgt)
+        : DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc);
+    var beforeUtc =
+      query.Before?.AddDays(1).ToDateTime(TimeOnly.MinValue, DateTimeKind.Unspecified) is { } b
+        ? TimeZoneInfo.ConvertTimeToUtc(b, sgt)
+        : DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc);
+
+    var pending = await repo.ListPendingSources(afterUtc, beforeUtc, MaxSourcesPerSync + 1);
+    if (!pending.IsSuccess())
+      return pending.FailureOrDefault();
+
+    var all = pending.SuccessOrDefault().ToArray();
+    var hasMore = all.Length > MaxSourcesPerSync;
+    var batch = all.Take(MaxSourcesPerSync).ToArray();
+
+    var synced = 0;
+    var missing = new List<string>();
+    foreach (var source in batch)
+    {
+      var lines = await gateway.BySource(source.SourceId);
+      if (!lines.IsSuccess())
+      {
+        // transient gateway trouble: leave the source for the next sync
+        logger.LogWarning(
+          "Gateway fee lookup failed for {SourceType} '{SourceId}': {Error}",
+          source.SourceType,
+          source.SourceId,
+          lines.FailureOrDefault().Message
+        );
+        missing.Add(source.SourceId);
+        continue;
+      }
+
+      var records = lines
+        .SuccessOrDefault()
+        .Select(l => new GatewayFeeRecord
+        {
+          SourceId = source.SourceId,
+          SourceType = source.SourceType,
+          FinancialTransactionId = l.FinancialTransactionId,
+          Amount = l.Amount,
+          Fee = l.Fee,
+          Net = l.Net,
+          Currency = l.Currency,
+          TransactedAt = l.TransactedAt,
+        })
+        .ToArray();
+      if (records.Length == 0)
+      {
+        // fees post with delay — not yet available, stays pending
+        missing.Add(source.SourceId);
+        continue;
+      }
+
+      var wrote = await repo.Upsert(records);
+      if (!wrote.IsSuccess())
+        return wrote.FailureOrDefault();
+      synced++;
+    }
+
+    return new GatewayFeeSyncResult
+    {
+      Synced = synced,
+      Missing = missing.ToArray(),
+      HasMore = hasMore,
+    };
+  }
+}

--- a/UnitTest/Bookings/BookingAnalysisCalculatorTests.cs
+++ b/UnitTest/Bookings/BookingAnalysisCalculatorTests.cs
@@ -6,21 +6,27 @@ namespace UnitTest.Bookings;
 
 // The pure summary math behind GET Booking/analysis: totals are sums over
 // the per-day rows; priority fees are net of refunds; termination fees are
-// the collected cost of terminated bookings minus what was refunded.
+// the collected cost of terminated bookings minus what was refunded; gateway
+// fees and the per-direction split pass through from their own aggregations;
+// the monthly rollup nets gross against KTMB cost and gateway fees only
+// (internal fees are revenue, never subtracted).
 public class BookingAnalysisCalculatorTests
 {
   private static BookingAnalysisRow Row(
     int tickets,
     decimal gross,
-    TrainDirection direction = TrainDirection.JToW
+    TrainDirection direction = TrainDirection.JToW,
+    decimal ktmb = 0m,
+    DateOnly? date = null
   ) =>
     new()
     {
-      Date = new DateOnly(2026, 7, 1),
+      Date = date ?? new DateOnly(2026, 7, 1),
       Direction = direction,
       Time = new TimeOnly(8, 30),
       TicketsCompleted = tickets,
       GrossRevenue = gross,
+      KtmbCost = ktmb,
     };
 
   private static readonly DepositSummary NoDeposits = new() { Count = 0, Captured = 0m };
@@ -35,29 +41,41 @@ public class BookingAnalysisCalculatorTests
     TerminationRefunds = 0m,
   };
 
+  private static readonly GatewayFeeSummary NoGatewayFees = new()
+  {
+    Payments = 0m,
+    Payouts = 0m,
+    Coverage = new GatewayFeeCoverage { PaymentsWithFee = 0, PaymentsTotal = 0 },
+  };
+
+  private static readonly Dictionary<string, MonthlyExternalSums> NoExternal = new();
+
   [Fact]
   public void Totals_sum_across_rows()
   {
     var rows = new[]
     {
-      Row(3, 42m),
-      Row(2, 28m, TrainDirection.WToJ),
-      Row(5, 80m),
+      Row(3, 42m, ktmb: 30m),
+      Row(2, 28m, TrainDirection.WToJ, ktmb: 20m),
+      Row(5, 80m, ktmb: 50m),
     };
 
-    var s = BookingAnalysisCalculator.Summarize(rows, NoDeposits, ZeroSums);
+    var s = BookingAnalysisCalculator.Summarize(rows, NoDeposits, ZeroSums, NoGatewayFees);
 
     s.TotalTickets.Should().Be(10);
     s.TotalGross.Should().Be(150m);
+    s.TotalKtmbCost.Should().Be(100m);
   }
 
   [Fact]
   public void Empty_rows_produce_zero_totals()
   {
-    var s = BookingAnalysisCalculator.Summarize([], NoDeposits, ZeroSums);
+    var s = BookingAnalysisCalculator.Summarize([], NoDeposits, ZeroSums, NoGatewayFees);
 
     s.TotalTickets.Should().Be(0);
     s.TotalGross.Should().Be(0m);
+    s.TotalKtmbCost.Should().Be(0m);
+    s.ByDirection.Should().BeEmpty();
   }
 
   [Fact]
@@ -65,7 +83,7 @@ public class BookingAnalysisCalculatorTests
   {
     var deposits = new DepositSummary { Count = 7, Captured = 350.5m };
 
-    var s = BookingAnalysisCalculator.Summarize([], deposits, ZeroSums);
+    var s = BookingAnalysisCalculator.Summarize([], deposits, ZeroSums, NoGatewayFees);
 
     s.Deposits.Count.Should().Be(7);
     s.Deposits.Captured.Should().Be(350.5m);
@@ -76,7 +94,7 @@ public class BookingAnalysisCalculatorTests
   {
     var sums = ZeroSums with { DepositFees = 12.5m, WithdrawalFees = 4m };
 
-    var s = BookingAnalysisCalculator.Summarize([], NoDeposits, sums);
+    var s = BookingAnalysisCalculator.Summarize([], NoDeposits, sums, NoGatewayFees);
 
     s.InternalFees.Deposit.Should().Be(12.5m);
     s.InternalFees.Withdrawal.Should().Be(4m);
@@ -89,7 +107,7 @@ public class BookingAnalysisCalculatorTests
     // net is what BunnyBooker actually kept
     var sums = ZeroSums with { PriorityFeesCharged = 50m, PriorityFeesRefunded = 20m };
 
-    var s = BookingAnalysisCalculator.Summarize([], NoDeposits, sums);
+    var s = BookingAnalysisCalculator.Summarize([], NoDeposits, sums, NoGatewayFees);
 
     s.InternalFees.Priority.Should().Be(30m);
   }
@@ -101,15 +119,56 @@ public class BookingAnalysisCalculatorTests
     // is the terminated bookings' collected cost minus that refund
     var sums = ZeroSums with { TerminatedGross = 100m, TerminationRefunds = 60m };
 
-    var s = BookingAnalysisCalculator.Summarize([], NoDeposits, sums);
+    var s = BookingAnalysisCalculator.Summarize([], NoDeposits, sums, NoGatewayFees);
 
     s.InternalFees.Termination.Should().Be(40m);
   }
 
   [Fact]
+  public void Gateway_fees_pass_through_unchanged()
+  {
+    var gateway = new GatewayFeeSummary
+    {
+      Payments = 12.34m,
+      Payouts = 5.67m,
+      Coverage = new GatewayFeeCoverage { PaymentsWithFee = 8, PaymentsTotal = 10 },
+    };
+
+    var s = BookingAnalysisCalculator.Summarize([], NoDeposits, ZeroSums, gateway);
+
+    s.GatewayFees.Payments.Should().Be(12.34m);
+    s.GatewayFees.Payouts.Should().Be(5.67m);
+    s.GatewayFees.Coverage.PaymentsWithFee.Should().Be(8);
+    s.GatewayFees.Coverage.PaymentsTotal.Should().Be(10);
+  }
+
+  [Fact]
+  public void By_direction_splits_tickets_gross_and_ktmb()
+  {
+    var rows = new[]
+    {
+      Row(3, 42m, ktmb: 30m),
+      Row(2, 28m, TrainDirection.WToJ, ktmb: 16m),
+      Row(5, 80m, ktmb: 50m),
+    };
+
+    var s = BookingAnalysisCalculator.Summarize(rows, NoDeposits, ZeroSums, NoGatewayFees);
+
+    s.ByDirection.Should().HaveCount(2);
+    var jtow = s.ByDirection.Single(d => d.Direction == TrainDirection.JToW);
+    jtow.Tickets.Should().Be(8);
+    jtow.Gross.Should().Be(122m);
+    jtow.KtmbCost.Should().Be(80m);
+    var wtoj = s.ByDirection.Single(d => d.Direction == TrainDirection.WToJ);
+    wtoj.Tickets.Should().Be(2);
+    wtoj.Gross.Should().Be(28m);
+    wtoj.KtmbCost.Should().Be(16m);
+  }
+
+  [Fact]
   public void Full_summary_combines_all_parts()
   {
-    var rows = new[] { Row(4, 64m) };
+    var rows = new[] { Row(4, 64m, ktmb: 40m) };
     var deposits = new DepositSummary { Count = 2, Captured = 100m };
     var sums = new BookingAnalysisLedgerSums
     {
@@ -121,15 +180,129 @@ public class BookingAnalysisCalculatorTests
       TerminationRefunds = 8m,
     };
 
-    var s = BookingAnalysisCalculator.Summarize(rows, deposits, sums);
+    var s = BookingAnalysisCalculator.Summarize(rows, deposits, sums, NoGatewayFees);
 
     s.TotalTickets.Should().Be(4);
     s.TotalGross.Should().Be(64m);
+    s.TotalKtmbCost.Should().Be(40m);
     s.Deposits.Count.Should().Be(2);
     s.Deposits.Captured.Should().Be(100m);
     s.InternalFees.Deposit.Should().Be(1m);
     s.InternalFees.Withdrawal.Should().Be(2m);
     s.InternalFees.Priority.Should().Be(20m);
     s.InternalFees.Termination.Should().Be(8m);
+  }
+
+  // ---- monthly rollup ----
+
+  [Fact]
+  public void Monthly_net_is_gross_minus_ktmb_and_gateway_fees()
+  {
+    var rows = new[] { Row(10, 200m, ktmb: 130m, date: new DateOnly(2026, 7, 5)) };
+    var external = new Dictionary<string, MonthlyExternalSums>
+    {
+      ["07-2026"] = new()
+      {
+        GatewayPaymentFees = 6m,
+        GatewayPayoutFees = 4m,
+        InternalFees = 25m,
+      },
+    };
+
+    var m = BookingAnalysisCalculator.MonthlyRollup(rows, external);
+
+    m.Should().HaveCount(1);
+    m[0].Month.Should().Be("07-2026");
+    m[0].Gross.Should().Be(200m);
+    m[0].KtmbCost.Should().Be(130m);
+    m[0].GatewayPaymentFees.Should().Be(6m);
+    m[0].GatewayPayoutFees.Should().Be(4m);
+    // internal fees are revenue TO us: reported, NOT subtracted
+    m[0].InternalFees.Should().Be(25m);
+    m[0].Net.Should().Be(200m - 130m - 6m - 4m);
+  }
+
+  [Fact]
+  public void Monthly_rollup_buckets_by_calendar_month_and_sorts_chronologically()
+  {
+    var rows = new[]
+    {
+      Row(1, 20m, date: new DateOnly(2026, 8, 1)),
+      Row(1, 10m, date: new DateOnly(2026, 7, 31)),
+      Row(1, 30m, date: new DateOnly(2025, 12, 31)),
+    };
+
+    var m = BookingAnalysisCalculator.MonthlyRollup(rows, NoExternal);
+
+    m.Select(x => x.Month).Should().Equal("12-2025", "07-2026", "08-2026");
+    m.Single(x => x.Month == "07-2026").Gross.Should().Be(10m);
+    m.Single(x => x.Month == "08-2026").Gross.Should().Be(20m);
+  }
+
+  [Fact]
+  public void Monthly_rollup_emits_fee_only_months_with_zero_gross()
+  {
+    // a month with gateway/internal fee movement but no completed bookings
+    // must still be reported (negative net = pure cost month)
+    var external = new Dictionary<string, MonthlyExternalSums>
+    {
+      ["06-2026"] = new()
+      {
+        GatewayPaymentFees = 3m,
+        GatewayPayoutFees = 1m,
+        InternalFees = 0m,
+      },
+    };
+
+    var m = BookingAnalysisCalculator.MonthlyRollup([], external);
+
+    m.Should().HaveCount(1);
+    m[0].Month.Should().Be("06-2026");
+    m[0].Gross.Should().Be(0m);
+    m[0].Net.Should().Be(-4m);
+    m[0].ByDirection.Should().BeEmpty();
+  }
+
+  [Fact]
+  public void Monthly_rollup_carries_the_direction_split_per_month()
+  {
+    var rows = new[]
+    {
+      Row(2, 30m, ktmb: 20m, date: new DateOnly(2026, 7, 1)),
+      Row(1, 15m, TrainDirection.WToJ, ktmb: 8m, date: new DateOnly(2026, 7, 2)),
+      Row(4, 60m, ktmb: 40m, date: new DateOnly(2026, 8, 1)),
+    };
+
+    var m = BookingAnalysisCalculator.MonthlyRollup(rows, NoExternal);
+
+    var july = m.Single(x => x.Month == "07-2026");
+    july.ByDirection.Should().HaveCount(2);
+    july.ByDirection.Single(d => d.Direction == TrainDirection.JToW).Gross.Should().Be(30m);
+    july.ByDirection.Single(d => d.Direction == TrainDirection.WToJ).KtmbCost.Should().Be(8m);
+    var august = m.Single(x => x.Month == "08-2026");
+    august.ByDirection.Should().HaveCount(1);
+    august.ByDirection.Single().Tickets.Should().Be(4);
+  }
+
+  [Fact]
+  public void Zero_ktmb_rows_net_against_gateway_fees_only()
+  {
+    // KTMB cost never configured -> every row carries 0 and net = gross −
+    // gateway fees (documented response behavior)
+    var rows = new[] { Row(5, 100m, date: new DateOnly(2026, 7, 1)) };
+    var external = new Dictionary<string, MonthlyExternalSums>
+    {
+      ["07-2026"] = new()
+      {
+        GatewayPaymentFees = 2m,
+        GatewayPayoutFees = 1m,
+        InternalFees = 0m,
+      },
+    };
+
+    var m = BookingAnalysisCalculator.MonthlyRollup(rows, external);
+
+    m[0].KtmbCost.Should().Be(0m);
+    m[0].Net.Should().Be(97m);
   }
 }

--- a/UnitTest/Bookings/BookingCountSplitTests.cs
+++ b/UnitTest/Bookings/BookingCountSplitTests.cs
@@ -1,0 +1,64 @@
+using App.Modules.Bookings.API.V1;
+using Domain.Booking;
+using Domain.Timings;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// The queue-count split behind GET Booking/counts: TicketsNeeded stays the
+// backward-compatible total (old argon reads it) while Priority/Normal carry
+// the split for the new /schedules queue badges.
+public class BookingCountSplitTests
+{
+  private static BookingCount Count(int total, int priority) =>
+    new()
+    {
+      Date = new DateOnly(2026, 7, 20),
+      Time = new TimeOnly(8, 30),
+      Direction = TrainDirection.JToW,
+      TicketsNeeded = total,
+      Priority = priority,
+      Normal = total - priority,
+    };
+
+  [Fact]
+  public void Split_parts_sum_to_the_total()
+  {
+    var c = Count(7, 2);
+
+    (c.Priority + c.Normal).Should().Be(c.TicketsNeeded);
+  }
+
+  [Fact]
+  public void Res_carries_total_and_split_consistently()
+  {
+    var res = Count(7, 2).ToRes();
+
+    // old argon keeps reading TicketsNeeded; new argon reads the split
+    res.TicketsNeeded.Should().Be(7);
+    res.Priority.Should().Be(2);
+    res.Normal.Should().Be(5);
+    res.Date.Should().Be("20-07-2026");
+    res.Time.Should().Be("08:30:00");
+    res.Direction.Should().Be("JToW");
+  }
+
+  [Fact]
+  public void All_priority_slot_has_zero_normal()
+  {
+    var res = Count(3, 3).ToRes();
+
+    res.Priority.Should().Be(3);
+    res.Normal.Should().Be(0);
+    res.TicketsNeeded.Should().Be(3);
+  }
+
+  [Fact]
+  public void No_priority_slot_has_zero_priority()
+  {
+    var res = Count(4, 0).ToRes();
+
+    res.Priority.Should().Be(0);
+    res.Normal.Should().Be(4);
+  }
+}

--- a/UnitTest/Bookings/BookingServiceAttachTicketTests.cs
+++ b/UnitTest/Bookings/BookingServiceAttachTicketTests.cs
@@ -267,13 +267,13 @@ public class BookingServiceAttachTicketTests
     public Task<Result<IEnumerable<BookingPrincipal>>> RefundList(DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 
-    public Task<Result<BookingPrincipal>> Create(string userId, Guid transactionId, BookingRecord record) =>
+    public Task<Result<BookingPrincipal>> Create(string userId, Guid transactionId, BookingRecord record, BookingPriceBreakdown? breakdown = null) =>
       throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 
-    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee) =>
+    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee, string? grantedBy = null) =>
       throw new NotImplementedException();
 
     public Task<Result<Unit?>> Delete(string? userId, Guid id) =>

--- a/UnitTest/Bookings/BookingServiceBuyingGuardTests.cs
+++ b/UnitTest/Bookings/BookingServiceBuyingGuardTests.cs
@@ -208,13 +208,13 @@ public class BookingServiceBuyingGuardTests
     public Task<Result<IEnumerable<BookingPrincipal>>> RefundList(DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 
-    public Task<Result<BookingPrincipal>> Create(string userId, Guid transactionId, BookingRecord record) =>
+    public Task<Result<BookingPrincipal>> Create(string userId, Guid transactionId, BookingRecord record, BookingPriceBreakdown? breakdown = null) =>
       throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 
-    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee) =>
+    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee, string? grantedBy = null) =>
       throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>

--- a/UnitTest/Bookings/BookingServiceCompleteNoCollectTests.cs
+++ b/UnitTest/Bookings/BookingServiceCompleteNoCollectTests.cs
@@ -203,13 +203,13 @@ public class BookingServiceCompleteNoCollectTests
     public Task<Result<IEnumerable<BookingPrincipal>>> RefundList(DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 
-    public Task<Result<BookingPrincipal>> Create(string userId, Guid transactionId, BookingRecord record) =>
+    public Task<Result<BookingPrincipal>> Create(string userId, Guid transactionId, BookingRecord record, BookingPriceBreakdown? breakdown = null) =>
       throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 
-    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee) =>
+    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee, string? grantedBy = null) =>
       throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>

--- a/UnitTest/Bookings/BookingServicePrioritizeTests.cs
+++ b/UnitTest/Bookings/BookingServicePrioritizeTests.cs
@@ -150,6 +150,44 @@ public class BookingServicePrioritizeTests
     result.SuccessOrDefault()!.Priority.Should().BeTrue();
   }
 
+  [Fact]
+  public async Task Self_boost_is_never_attributed_to_a_granter()
+  {
+    var b = BookingWith(BookStatus.Pending);
+    var (service, repo, _, _) = Make(b, allowlisted: true);
+
+    // the caller IS the owner — no admin attribution
+    var result = await service.Prioritize("user-1", b.Principal.Id, callerSub: "user-1");
+
+    result.IsSuccess().Should().BeTrue();
+    repo.LastGrantedBy.Should().BeNull();
+  }
+
+  [Fact]
+  public async Task Admin_boosting_someone_elses_booking_is_attributed()
+  {
+    var b = BookingWith(BookStatus.Pending);
+    var (service, repo, _, _) = Make(b, allowlisted: true);
+
+    // an admin (userId = null bypasses ownership) boosts user-1's booking
+    var result = await service.Prioritize(null, b.Principal.Id, callerSub: "admin-9");
+
+    result.IsSuccess().Should().BeTrue();
+    repo.LastGrantedBy.Should().Be("admin-9");
+  }
+
+  [Fact]
+  public async Task Legacy_callers_without_a_sub_stay_unattributed()
+  {
+    var b = BookingWith(BookStatus.Pending);
+    var (service, repo, _, _) = Make(b, allowlisted: true);
+
+    var result = await service.Prioritize("user-1", b.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    repo.LastGrantedBy.Should().BeNull();
+  }
+
   [Theory]
   [InlineData(BookStatus.Buying)]
   [InlineData(BookStatus.Completed)]
@@ -707,6 +745,7 @@ public class BookingServicePrioritizeTests
 
     public int PrioritizeCalls { get; private set; }
     public decimal? LastPrioritizeFee { get; private set; }
+    public string? LastGrantedBy { get; private set; }
     public List<BookingStatus> StatusWrites { get; } = [];
 
     private Booking? Current()
@@ -747,10 +786,11 @@ public class BookingServicePrioritizeTests
       return Task.FromResult((Result<BookingPrincipal?>)Current()!.Principal);
     }
 
-    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee)
+    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee, string? grantedBy = null)
     {
       PrioritizeCalls++;
       LastPrioritizeFee = fee;
+      LastGrantedBy = grantedBy;
       priorityOverride = true;
       feeOverride = fee;
       return Task.FromResult((Result<BookingPrincipal?>)Current()!.Principal);
@@ -777,7 +817,8 @@ public class BookingServicePrioritizeTests
     public Task<Result<BookingPrincipal>> Create(
       string userId,
       Guid transactionId,
-      BookingRecord record
+      BookingRecord record,
+      BookingPriceBreakdown? breakdown = null
     ) => throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> Reserve(

--- a/UnitTest/Bookings/BookingServiceRecoverRevertTests.cs
+++ b/UnitTest/Bookings/BookingServiceRecoverRevertTests.cs
@@ -280,13 +280,13 @@ public class BookingServiceRecoverRevertTests
     public Task<Result<IEnumerable<BookingPrincipal>>> RefundList(DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 
-    public Task<Result<BookingPrincipal>> Create(string userId, Guid transactionId, BookingRecord record) =>
+    public Task<Result<BookingPrincipal>> Create(string userId, Guid transactionId, BookingRecord record, BookingPriceBreakdown? breakdown = null) =>
       throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 
-    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee) =>
+    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee, string? grantedBy = null) =>
       throw new NotImplementedException();
 
     public Task<Result<Unit?>> Delete(string? userId, Guid id) =>

--- a/UnitTest/Bookings/BookingServiceRevertGuardTests.cs
+++ b/UnitTest/Bookings/BookingServiceRevertGuardTests.cs
@@ -341,13 +341,13 @@ public class BookingServiceRevertGuardTests
     public Task<Result<IEnumerable<BookingPrincipal>>> RefundList(DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 
-    public Task<Result<BookingPrincipal>> Create(string userId, Guid transactionId, BookingRecord record) =>
+    public Task<Result<BookingPrincipal>> Create(string userId, Guid transactionId, BookingRecord record, BookingPriceBreakdown? breakdown = null) =>
       throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 
-    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee) =>
+    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee, string? grantedBy = null) =>
       throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>

--- a/UnitTest/Bookings/BookingServiceTerminateTests.cs
+++ b/UnitTest/Bookings/BookingServiceTerminateTests.cs
@@ -305,7 +305,7 @@ public class BookingServiceTerminateTests
       return Task.FromResult((Result<BookingPrincipal?>)Current().Principal);
     }
 
-    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee) =>
+    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee, string? grantedBy = null) =>
       throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>
@@ -329,7 +329,8 @@ public class BookingServiceTerminateTests
     public Task<Result<BookingPrincipal>> Create(
       string userId,
       Guid transactionId,
-      BookingRecord record
+      BookingRecord record,
+      BookingPriceBreakdown? breakdown = null
     ) => throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> Reserve(

--- a/UnitTest/Bookings/BookingServiceTicketHealthTests.cs
+++ b/UnitTest/Bookings/BookingServiceTicketHealthTests.cs
@@ -195,13 +195,13 @@ public class BookingServiceTicketHealthTests
     public Task<Result<IEnumerable<BookingPrincipal>>> RefundList(DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 
-    public Task<Result<BookingPrincipal>> Create(string userId, Guid transactionId, BookingRecord record) =>
+    public Task<Result<BookingPrincipal>> Create(string userId, Guid transactionId, BookingRecord record, BookingPriceBreakdown? breakdown = null) =>
       throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 
-    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee) =>
+    public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee, string? grantedBy = null) =>
       throw new NotImplementedException();
 
     public Task<Result<Unit?>> Delete(string? userId, Guid id) =>

--- a/UnitTest/Bookings/KtmbCostScheduleTests.cs
+++ b/UnitTest/Bookings/KtmbCostScheduleTests.cs
@@ -1,0 +1,148 @@
+using Domain.Booking;
+using Domain.Timings;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// The effective-dating rule behind the KTMB ticket cost queue: per
+// direction, the newest row whose EffectiveAt has passed wins; future rows
+// queue; no configured row = cost 0. The analysis SQL implements the same
+// rule DB-side — this pure schedule is the in-memory source of truth.
+public class KtmbCostScheduleTests
+{
+  private static readonly DateTime Now = new(2026, 7, 10, 12, 0, 0, DateTimeKind.Utc);
+
+  private static KtmbCostChange Change(
+    TrainDirection direction,
+    decimal cost,
+    DateTime effectiveAt,
+    DateTime? createdAt = null
+  ) =>
+    new()
+    {
+      Id = Guid.NewGuid(),
+      Direction = direction,
+      Cost = cost,
+      EffectiveAt = effectiveAt,
+      CreatedAt = createdAt ?? effectiveAt,
+    };
+
+  [Fact]
+  public void No_configured_rows_cost_zero()
+  {
+    KtmbCostSchedule.EffectiveCost([], TrainDirection.JToW, Now).Should().Be(0m);
+
+    var view = KtmbCostSchedule.View([], Now);
+    view.Current[TrainDirection.JToW].Should().Be(0m);
+    view.Current[TrainDirection.WToJ].Should().Be(0m);
+    view.Upcoming.Should().BeEmpty();
+  }
+
+  [Fact]
+  public void Newest_effective_row_wins()
+  {
+    var changes = new[]
+    {
+      Change(TrainDirection.JToW, 10m, Now.AddDays(-10)),
+      Change(TrainDirection.JToW, 12m, Now.AddDays(-1)),
+    };
+
+    KtmbCostSchedule.EffectiveCost(changes, TrainDirection.JToW, Now).Should().Be(12m);
+  }
+
+  [Fact]
+  public void Directions_are_independent()
+  {
+    var changes = new[]
+    {
+      Change(TrainDirection.JToW, 10m, Now.AddDays(-1)),
+      Change(TrainDirection.WToJ, 7m, Now.AddDays(-1)),
+    };
+
+    KtmbCostSchedule.EffectiveCost(changes, TrainDirection.JToW, Now).Should().Be(10m);
+    KtmbCostSchedule.EffectiveCost(changes, TrainDirection.WToJ, Now).Should().Be(7m);
+  }
+
+  [Fact]
+  public void One_direction_configured_leaves_the_other_at_zero()
+  {
+    var changes = new[] { Change(TrainDirection.JToW, 10m, Now.AddDays(-1)) };
+
+    var view = KtmbCostSchedule.View(changes, Now);
+
+    view.Current[TrainDirection.JToW].Should().Be(10m);
+    view.Current[TrainDirection.WToJ].Should().Be(0m);
+  }
+
+  [Fact]
+  public void Future_rows_queue_and_do_not_apply_yet()
+  {
+    var future = Change(TrainDirection.JToW, 15m, Now.AddDays(2));
+    var changes = new[] { Change(TrainDirection.JToW, 10m, Now.AddDays(-1)), future };
+
+    var view = KtmbCostSchedule.View(changes, Now);
+
+    view.Current[TrainDirection.JToW].Should().Be(10m);
+    view.Upcoming.Should().ContainSingle(x => x.Id == future.Id);
+  }
+
+  [Fact]
+  public void A_queued_row_takes_over_once_its_instant_passes()
+  {
+    var changes = new[]
+    {
+      Change(TrainDirection.JToW, 10m, Now.AddDays(-10)),
+      Change(TrainDirection.JToW, 15m, Now.AddDays(2)),
+    };
+
+    // the exact effective instant is inclusive (EffectiveAt <= at)
+    KtmbCostSchedule
+      .EffectiveCost(changes, TrainDirection.JToW, Now.AddDays(2))
+      .Should()
+      .Be(15m);
+  }
+
+  [Fact]
+  public void Bookings_are_costed_at_their_own_completion_instant()
+  {
+    // the analysis costs each booking at ITS CompletedAt, not at "now": a
+    // booking completed before a price change keeps the old cost
+    var changes = new[]
+    {
+      Change(TrainDirection.JToW, 10m, new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc)),
+      Change(TrainDirection.JToW, 12m, new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc)),
+    };
+
+    var june = new DateTime(2026, 6, 15, 0, 0, 0, DateTimeKind.Utc);
+    var july = new DateTime(2026, 7, 15, 0, 0, 0, DateTimeKind.Utc);
+    KtmbCostSchedule.EffectiveCost(changes, TrainDirection.JToW, june).Should().Be(10m);
+    KtmbCostSchedule.EffectiveCost(changes, TrainDirection.JToW, july).Should().Be(12m);
+  }
+
+  [Fact]
+  public void Same_effective_instant_ties_break_on_newest_created()
+  {
+    var effective = Now.AddDays(-1);
+    var changes = new[]
+    {
+      Change(TrainDirection.JToW, 10m, effective, Now.AddDays(-3)),
+      Change(TrainDirection.JToW, 11m, effective, Now.AddDays(-2)),
+    };
+
+    KtmbCostSchedule.EffectiveCost(changes, TrainDirection.JToW, Now).Should().Be(11m);
+  }
+
+  [Fact]
+  public void Upcoming_lists_soonest_first_across_directions()
+  {
+    var changes = new[]
+    {
+      Change(TrainDirection.WToJ, 9m, Now.AddDays(5)),
+      Change(TrainDirection.JToW, 15m, Now.AddDays(2)),
+    };
+
+    var view = KtmbCostSchedule.View(changes, Now);
+
+    view.Upcoming.Select(x => x.Cost).Should().Equal(15m, 9m);
+  }
+}

--- a/UnitTest/Costs/PriceBreakdownFactoryTests.cs
+++ b/UnitTest/Costs/PriceBreakdownFactoryTests.cs
@@ -1,0 +1,133 @@
+using Domain.Cost;
+using Domain.Discount;
+using FluentAssertions;
+
+namespace UnitTest.Costs;
+
+// The persisted purchase price breakdown derived from a materialized price:
+// policy lines pass through signed, discount lines mirror
+// DiscountCalculator's math (resolved against the SUBTOTAL) and are stored
+// negative — so component analytics can rank what makes or loses money.
+public class PriceBreakdownFactoryTests
+{
+  private static DiscountRecord Discount(string name, DiscountType type, decimal amount) =>
+    new()
+    {
+      Name = name,
+      Description = string.Empty,
+      Amount = amount,
+      Type = type,
+    };
+
+  [Fact]
+  public void Policy_lines_pass_through_signed()
+  {
+    var cost = new MaterializedCost
+    {
+      Cost = 14m,
+      PolicyLines =
+      [
+        new CostPolicyLine { Name = "Peak surcharge", Delta = 2m },
+        new CostPolicyLine { Name = "Promo", Delta = -1.5m },
+      ],
+      Subtotal = 14.5m,
+      Final = 14.5m,
+      Discounts = [],
+    };
+
+    var b = cost.ToBreakdown();
+
+    b.BaseCost.Should().Be(14m);
+    b.Final.Should().Be(14.5m);
+    b.Lines.Should().HaveCount(2);
+    b.Lines[0].Kind.Should().Be("policy");
+    b.Lines[0].Delta.Should().Be(2m);
+    b.Lines[1].Delta.Should().Be(-1.5m);
+    // stored invariant: base + policy lines = subtotal
+    (b.BaseCost + b.Lines.Sum(l => l.Delta)).Should().Be(14.5m);
+  }
+
+  [Fact]
+  public void Flat_discounts_store_their_negative_amount()
+  {
+    var cost = new MaterializedCost
+    {
+      Cost = 14m,
+      PolicyLines = [],
+      Subtotal = 14m,
+      Final = 11m,
+      Discounts = [Discount("Loyalty", DiscountType.Flat, 3m)],
+    };
+
+    var b = cost.ToBreakdown();
+
+    var line = b.Lines.Single();
+    line.Kind.Should().Be("discount");
+    line.Name.Should().Be("Loyalty");
+    line.Delta.Should().Be(-3m);
+  }
+
+  [Fact]
+  public void Percentage_discounts_resolve_against_the_subtotal()
+  {
+    // mirrors DiscountCalculator: percentage discounts multiply the
+    // SUBTOTAL, not the running total
+    var cost = new MaterializedCost
+    {
+      Cost = 14m,
+      PolicyLines = [new CostPolicyLine { Name = "Peak", Delta = 6m }],
+      Subtotal = 20m,
+      Final = 18m,
+      Discounts = [Discount("Members", DiscountType.Percentage, 0.1m)],
+    };
+
+    var b = cost.ToBreakdown();
+
+    var discount = b.Lines.Single(l => l.Kind == "discount");
+    discount.Delta.Should().Be(-2m); // 0.1 × 20
+    // subtotal + discount deltas = final (before the >= 0 floor)
+    (cost.Subtotal + b.Lines.Where(l => l.Kind == "discount").Sum(l => l.Delta))
+      .Should()
+      .Be(cost.Final);
+  }
+
+  [Fact]
+  public void Multiple_discounts_each_resolve_against_the_same_subtotal()
+  {
+    var cost = new MaterializedCost
+    {
+      Cost = 10m,
+      PolicyLines = [],
+      Subtotal = 10m,
+      Final = 6m,
+      Discounts =
+      [
+        Discount("A", DiscountType.Percentage, 0.2m),
+        Discount("B", DiscountType.Flat, 2m),
+      ],
+    };
+
+    var b = cost.ToBreakdown();
+
+    b.Lines.Select(l => l.Delta).Should().Equal(-2m, -2m);
+  }
+
+  [Fact]
+  public void No_components_yield_an_empty_line_list()
+  {
+    var cost = new MaterializedCost
+    {
+      Cost = 14m,
+      PolicyLines = [],
+      Subtotal = 14m,
+      Final = 14m,
+      Discounts = [],
+    };
+
+    var b = cost.ToBreakdown();
+
+    b.Lines.Should().BeEmpty();
+    b.BaseCost.Should().Be(14m);
+    b.Final.Should().Be(14m);
+  }
+}

--- a/UnitTest/Payments/GatewayFeeSyncTests.cs
+++ b/UnitTest/Payments/GatewayFeeSyncTests.cs
@@ -1,0 +1,211 @@
+using CSharp_Result;
+using Domain.Payment;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace UnitTest.Payments;
+
+// The gateway-fee capture pipeline: upsert planning is idempotent by
+// FinancialTransactionId (replaying the same gateway response refreshes, it
+// never duplicates), and the sync driver treats empty gateway answers as
+// "not yet available" (stays missing, retried later) while bounding the
+// per-call work.
+public class GatewayFeeSyncTests
+{
+  private static GatewayFeeRecord Record(string ftId, string sourceId = "int_1", decimal fee = 1m) =>
+    new()
+    {
+      SourceId = sourceId,
+      SourceType = GatewayFeeSourceType.Payment,
+      FinancialTransactionId = ftId,
+      Amount = 100m,
+      Fee = fee,
+      Net = 100m - fee,
+      Currency = "SGD",
+      TransactedAt = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc),
+    };
+
+  // ---- GatewayFeePlanner (pure upsert planning) ----
+
+  [Fact]
+  public void Unseen_ids_become_inserts()
+  {
+    var (insert, update) = GatewayFeePlanner.Plan([], [Record("ft_1"), Record("ft_2")]);
+
+    insert.Should().HaveCount(2);
+    update.Should().BeEmpty();
+  }
+
+  [Fact]
+  public void Known_ids_become_updates_never_duplicates()
+  {
+    // the same FinancialTransactionId synced twice = refresh, not a new row
+    var (insert, update) = GatewayFeePlanner.Plan(
+      ["ft_1"],
+      [Record("ft_1", fee: 2m), Record("ft_2")]
+    );
+
+    insert.Should().ContainSingle(x => x.FinancialTransactionId == "ft_2");
+    update.Should().ContainSingle(x => x.FinancialTransactionId == "ft_1");
+    update[0].Fee.Should().Be(2m);
+  }
+
+  [Fact]
+  public void Duplicate_ids_within_one_batch_collapse_to_the_last()
+  {
+    var (insert, update) = GatewayFeePlanner.Plan(
+      [],
+      [Record("ft_1", fee: 1m), Record("ft_1", fee: 3m)]
+    );
+
+    insert.Should().ContainSingle();
+    insert[0].Fee.Should().Be(3m);
+    update.Should().BeEmpty();
+  }
+
+  [Fact]
+  public void Replaying_an_already_synced_batch_is_all_updates()
+  {
+    var batch = new[] { Record("ft_1"), Record("ft_2") };
+
+    var (insert, update) = GatewayFeePlanner.Plan(["ft_1", "ft_2"], batch);
+
+    insert.Should().BeEmpty();
+    update.Should().HaveCount(2);
+  }
+
+  // ---- GatewayFeeSyncService (driver) ----
+
+  private sealed class FakeRepo : IGatewayFeeRepository
+  {
+    public List<PendingFeeSource> Pending { get; init; } = [];
+    public List<GatewayFeeRecord> Upserted { get; } = [];
+    public int UpsertCalls { get; private set; }
+
+    public Task<Result<IEnumerable<PendingFeeSource>>> ListPendingSources(
+      DateTime after,
+      DateTime before,
+      int max
+    ) =>
+      Task.FromResult(
+        this.Pending.Take(max).ToArray().AsEnumerable().ToResult()
+      );
+
+    public Task<Result<int>> Upsert(IEnumerable<GatewayFeeRecord> records)
+    {
+      this.UpsertCalls++;
+      var r = records.ToArray();
+      this.Upserted.AddRange(r);
+      return Task.FromResult((Result<int>)r.Length);
+    }
+  }
+
+  private sealed class FakeGateway(Func<string, Result<IEnumerable<GatewayFeeLine>>> answer)
+    : IGatewayFeeSource
+  {
+    public Task<Result<IEnumerable<GatewayFeeLine>>> BySource(string sourceId) =>
+      Task.FromResult(answer(sourceId));
+  }
+
+  private static PendingFeeSource Source(string id, GatewayFeeSourceType type) =>
+    new() { SourceId = id, SourceType = type };
+
+  private static GatewayFeeLine Line(string ftId, decimal fee = 0.5m) =>
+    new()
+    {
+      FinancialTransactionId = ftId,
+      Amount = 10m,
+      Fee = fee,
+      Net = 10m - fee,
+      Currency = "SGD",
+      TransactedAt = new DateTime(2026, 7, 2, 0, 0, 0, DateTimeKind.Utc),
+    };
+
+  private static GatewayFeeSyncService Service(FakeRepo repo, FakeGateway gateway) =>
+    new(repo, gateway, NullLogger<GatewayFeeSyncService>.Instance);
+
+  [Fact]
+  public async Task Sources_with_fee_lines_are_synced_and_tagged_with_their_source()
+  {
+    var repo = new FakeRepo
+    {
+      Pending = [Source("int_1", GatewayFeeSourceType.Payment)],
+    };
+    var gateway = new FakeGateway(_ =>
+      new[] { Line("ft_1") }.AsEnumerable().ToResult()
+    );
+
+    var r = await Service(repo, gateway).Sync(new GatewayFeeSyncQuery());
+
+    r.SuccessOrDefault().Synced.Should().Be(1);
+    r.SuccessOrDefault().Missing.Should().BeEmpty();
+    r.SuccessOrDefault().HasMore.Should().BeFalse();
+    repo.Upserted.Should().ContainSingle();
+    repo.Upserted[0].SourceId.Should().Be("int_1");
+    repo.Upserted[0].SourceType.Should().Be(GatewayFeeSourceType.Payment);
+    repo.Upserted[0].FinancialTransactionId.Should().Be("ft_1");
+  }
+
+  [Fact]
+  public async Task Empty_gateway_answer_stays_missing_and_writes_nothing()
+  {
+    // gateway fees post with delay: no rows yet is a normal answer — the
+    // source is reported missing and retried on a later sync
+    var repo = new FakeRepo
+    {
+      Pending = [Source("int_1", GatewayFeeSourceType.Payment)],
+    };
+    var gateway = new FakeGateway(_ =>
+      Array.Empty<GatewayFeeLine>().AsEnumerable().ToResult()
+    );
+
+    var r = await Service(repo, gateway).Sync(new GatewayFeeSyncQuery());
+
+    r.SuccessOrDefault().Synced.Should().Be(0);
+    r.SuccessOrDefault().Missing.Should().Equal("int_1");
+    repo.UpsertCalls.Should().Be(0);
+  }
+
+  [Fact]
+  public async Task A_failing_source_stays_missing_without_failing_the_batch()
+  {
+    var repo = new FakeRepo
+    {
+      Pending =
+      [
+        Source("bad", GatewayFeeSourceType.Transfer),
+        Source("good", GatewayFeeSourceType.Payment),
+      ],
+    };
+    var gateway = new FakeGateway(id =>
+      id == "bad"
+        ? new HttpRequestException("boom")
+        : new[] { Line("ft_ok") }.AsEnumerable().ToResult()
+    );
+
+    var r = await Service(repo, gateway).Sync(new GatewayFeeSyncQuery());
+
+    r.SuccessOrDefault().Synced.Should().Be(1);
+    r.SuccessOrDefault().Missing.Should().Equal("bad");
+  }
+
+  [Fact]
+  public async Task Work_is_bounded_and_overflow_reports_has_more()
+  {
+    var repo = new FakeRepo
+    {
+      Pending = Enumerable
+        .Range(0, GatewayFeeSyncService.MaxSourcesPerSync + 5)
+        .Select(i => Source($"int_{i}", GatewayFeeSourceType.Payment))
+        .ToList(),
+    };
+    var gateway = new FakeGateway(id =>
+      new[] { Line($"ft_{id}") }.AsEnumerable().ToResult()
+    );
+
+    var r = await Service(repo, gateway).Sync(new GatewayFeeSyncQuery());
+
+    r.SuccessOrDefault().Synced.Should().Be(GatewayFeeSyncService.MaxSourcesPerSync);
+    r.SuccessOrDefault().HasMore.Should().BeTrue();
+  }
+}


### PR DESCRIPTION
## Summary

Six analysis-page features on one branch (all additive, backward compatible):

### 1. Airwallex gateway-fee capture (monthly)
- `AirWallexClient.ListFinancialTransactionsBySource`: `GET api/v1/financial_transactions?source_id=&page_num=&page_size=100`, follows `has_more`. DTO (`AirwallexFinancialTransactionRes`) is permissive: `id, source_id, transaction_type, status, amount, fee, net, currency, created_at`, extras ignored, non-id fields defaulted.
- New `GatewayFees` table: `SourceId` (indexed), `SourceType` (0 Payment / 1 Transfer / 2 Refund), `FinancialTransactionId` (unique — idempotent upsert key), `Amount/Fee/Net (16,8)`, `Currency`, `TransactedAt` (indexed), `CreatedAt`.
- `POST api/v1/Payment/gateway-fees/sync?After=&Before=` (AdminOrTin, dd-MM-yyyy inclusive SGT dates): scans captured intents + completed PayNow transfers + settled card-refund fragments in range that lack fee rows, pulls each source's financial transactions, upserts. Returns `{synced, missing[], hasMore}` — empty gateway answers (fees post with delay) and per-source failures stay in `missing` and are retried on a later sync; work bounded at 200 sources per call.

### 2. KTMB ticket cost settings
- New `KtmbCosts` table: insert-only, effective-dated per direction (exactly the withdrawal Fee queue pattern). Booking cost = newest row with `EffectiveAt <= CompletedAt` and matching direction; none configured = 0.
- `GET api/v1/Booking/ktmb-cost/current` (AdminOrTin) → both directions' current cost + queued changes; `POST api/v1/Booking/ktmb-cost` (OnlyAdmin) `{direction, cost, effectiveAt?}`.

### 3. Analysis response (GET api/v1/Booking/analysis)
- Rows gain `ktmbCost` (SQL LATERAL costs each booking at the rate effective at ITS CompletedAt).
- Summary gains `totalKtmbCost`, `gatewayFees {payments, payouts, coverage{paymentsWithFee, paymentsTotal}}` and `byDirection [{direction, tickets, gross, ktmbCost}]`.
- New `monthly` array (SGT calendar months, "MM-yyyy"): `{month, gross, ktmbCost, gatewayPaymentFees, gatewayPayoutFees, internalFees, net, byDirection}` where **net = gross − ktmbCost − gatewayPaymentFees − gatewayPayoutFees** (internal fees are revenue TO us — reported, never subtracted).
- New `components` array `[{kind: policy|discount|priorityFee, name, timesApplied, totalDelta}]` + `componentsCoverage {withBreakdown, total}`.

### 4. Price-breakdown persistence (investigation answer: zinc did NOT persist it)
Purchases now store the quote composition (base cost, policy/discount lines, final) as owned JSON on `Bookings.PriceBreakdown`. Old bookings stay NULL and are excluded from `components` (coverage tells the UI).

### 5. Boost ledger
`GET api/v1/Booking/analysis/boosts?After=&Before=&Limit=&Skip=` (OnlyAdmin, Limit default 50 max 200) → `{total, items:[{bookingId, userId, userIdentity, date, time, direction, fee, free, boostedAt, grantedBy}]}`.
- `boostedAt`: new `PrioritizedAt` stamp; pre-release boosts fall back to `CreatedAt` (documented proxy — the flow never stamped a timestamp before).
- `grantedBy`: new nullable `PrioritizedBy` column, stamped when the prioritize caller's sub ≠ the booking owner (admin grant). Old rows and self-boosts stay null — the pre-existing data cannot distinguish admin-granted free boosts from FreeTarget self-boosts, so nothing is invented.

### 6. Queue priority split
`GET api/v1/Booking/counts[...]` rows gain `priority` and `normal`; `ticketsNeeded` stays as the total for old argon clients. Single repo `Count` method feeds both endpoints (only consumers).

## Migration
`20260712195219_AddGatewayFeesKtmbCostsAndBoostAudit` — creates `GatewayFees` + `KtmbCosts`, adds nullable `Bookings.PriceBreakdown/PrioritizedAt/PrioritizedBy`. Fully additive.

## Tests
506 passing (was ~470): fee-sync upsert idempotency + driver behavior, monthly aggregation math incl. the net formula, KTMB effective-dating (per direction, queued future, none-configured, per-completion-instant costing), counts split, price-breakdown factory, boost attribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added admin tools to view boost activity and manage current or scheduled KTMB ticket costs.
  - Expanded booking analysis with KTMB costs, gateway fees, monthly trends, direction breakdowns, pricing components, and priority/normal ticket counts.
  - Added gateway-fee synchronization and reporting.
  - Booking purchases now validate expected price quotes and retain detailed price breakdowns.
  - Admin-granted boosts now record attribution.

- **Bug Fixes**
  - Improved cost and fee calculations for more accurate revenue and net reporting.
  - Added reliable handling for missing or delayed gateway fee data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->