### PR TITLE
feat(booking): order priority group by boost time

### DIFF
--- a/App/Modules/Bookings/Data/BookingQueue.cs
+++ b/App/Modules/Bookings/Data/BookingQueue.cs
@@ -2,18 +2,30 @@ using System.Linq.Expressions;
 
 namespace App.Modules.Bookings.Data;
 
-// The purchase-queue ordering in one place: priority first, then oldest
-// CreatedAt, Id as the deterministic tiebreak. Reserve() sorts by these keys
-// and QueuePosition() counts with AheadOf — they must always agree.
+// The purchase-queue ordering in one place: priority first — earliest boost
+// (PrioritizedAt) wins within the priority group, falling back to CreatedAt
+// for boosts that predate the audit column — then oldest CreatedAt, Id as the
+// deterministic tiebreak. Reserve() sorts by these keys and QueuePosition()
+// counts with AheadOf — they must always agree.
 public static class BookingQueue
 {
   // EF-translatable (b's fields are captured constants): x is ahead of b iff
-  // x outranks b on priority, or ties on priority and booked earlier
-  public static Expression<Func<BookingData, bool>> AheadOf(BookingData b) =>
-    x =>
+  // x outranks b on priority, or ties on priority and boosted earlier
+  // (booking age, then Id, break boost-time ties)
+  public static Expression<Func<BookingData, bool>> AheadOf(BookingData b)
+  {
+    var bKey = b.PrioritizedAt ?? b.CreatedAt;
+    return x =>
       (x.Priority && !b.Priority)
       || (
         x.Priority == b.Priority
-        && (x.CreatedAt < b.CreatedAt || (x.CreatedAt == b.CreatedAt && x.Id < b.Id))
+        && (
+          (x.PrioritizedAt ?? x.CreatedAt) < bKey
+          || (
+            (x.PrioritizedAt ?? x.CreatedAt) == bKey
+            && (x.CreatedAt < b.CreatedAt || (x.CreatedAt == b.CreatedAt && x.Id < b.Id))
+          )
+        )
       );
+  }
 }

--- a/App/Modules/Bookings/Data/BookingRepository.cs
+++ b/App/Modules/Bookings/Data/BookingRepository.cs
@@ -158,9 +158,9 @@ public class BookingRepository(
           || x.Status == (byte)BookStatus.Recovering
         )
       );
-      // the buyer works priority-first, then oldest-first (Id as the
-      // deterministic tiebreak) — the predicate must mirror Reserve()'s
-      // ordering exactly or the shown position lies
+      // the buyer works priority-first (earliest boost wins), then
+      // oldest-first (Id as the deterministic tiebreak) — the predicate must
+      // mirror Reserve()'s ordering exactly or the shown position lies
       var ahead = await slot.Where(BookingQueue.AheadOf(b)).CountAsync();
       var total = await slot.CountAsync();
 
@@ -509,8 +509,10 @@ public class BookingRepository(
         time
       );
 
-      // priority first, then oldest-first (Id tiebreak) — must mirror
-      // BookingQueue.AheadOf, which QueuePosition uses to count "ahead"
+      // priority first (earliest boost wins; NULL PrioritizedAt = pre-audit
+      // boost, falls back to CreatedAt), then oldest-first (Id tiebreak) —
+      // must mirror BookingQueue.AheadOf, which QueuePosition uses to count
+      // "ahead"
       var v1 = await db
         .Bookings.Where(x =>
           x.Direction == direction.ToData()
@@ -519,6 +521,7 @@ public class BookingRepository(
           && x.Status == (int)BookStatus.Pending
         )
         .OrderByDescending(x => x.Priority)
+        .ThenBy(x => x.PrioritizedAt ?? x.CreatedAt)
         .ThenBy(x => x.CreatedAt)
         .ThenBy(x => x.Id)
         .FirstOrDefaultAsync();

--- a/Domain/Booking/IService.cs
+++ b/Domain/Booking/IService.cs
@@ -89,7 +89,8 @@ public interface IBookingService
     string[]? callerTokenRoles = null
   );
 
-  // charge the priority fee and move the booking to the front of its queue;
+  // charge the priority fee and move the booking into its queue's priority
+  // group (ahead of every non-priority booking; boost time orders the group);
   // callerSub = the invoking user's sub, persisted as the granter when it is
   // not the booking owner (admin-granted boost attribution)
   Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, string? callerSub = null);

--- a/Domain/Booking/Repository.cs
+++ b/Domain/Booking/Repository.cs
@@ -39,7 +39,8 @@ public interface IBookingRepository
 
   Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly Time);
 
-  // marks the booking priority (front of its queue), snapshots the fee
+  // marks the booking priority (into the queue's priority group, which is
+  // ordered by boost time — PrioritizedAt), snapshots the fee
   // charged (null = FREE boost, nothing charged so nothing to refund), stamps
   // PrioritizedAt and — when someone other than the owner (an admin) invoked
   // it — the granter's sub for boost-ledger attribution; null result when the

--- a/UnitTest/Bookings/BookingQueueTests.cs
+++ b/UnitTest/Bookings/BookingQueueTests.cs
@@ -4,18 +4,25 @@ using FluentAssertions;
 namespace UnitTest.Bookings;
 
 // The queue-position "ahead" predicate must mirror Reserve()'s ordering:
-// priority first, then oldest CreatedAt, Id tiebreak. Compiled and evaluated
-// in memory — the same expression EF translates to SQL.
+// priority first (earliest boost wins, PrioritizedAt falling back to
+// CreatedAt), then oldest CreatedAt, Id tiebreak. Compiled and evaluated in
+// memory — the same expression EF translates to SQL.
 public class BookingQueueTests
 {
   private static readonly DateTime T0 = new(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
 
-  private static BookingData Row(bool priority, DateTime createdAt, Guid? id = null) =>
+  private static BookingData Row(
+    bool priority,
+    DateTime createdAt,
+    Guid? id = null,
+    DateTime? prioritizedAt = null
+  ) =>
     new()
     {
       Id = id ?? Guid.NewGuid(),
       CreatedAt = createdAt,
       Priority = priority,
+      PrioritizedAt = prioritizedAt,
     };
 
   private static bool Ahead(BookingData candidate, BookingData reference) =>
@@ -25,7 +32,7 @@ public class BookingQueueTests
   public void Priority_jumps_ahead_of_non_priority_even_when_created_later()
   {
     var older = Row(priority: false, T0);
-    var newerPriority = Row(priority: true, T0.AddHours(5));
+    var newerPriority = Row(priority: true, T0.AddHours(5), prioritizedAt: T0.AddHours(6));
 
     Ahead(newerPriority, older).Should().BeTrue("priority outranks age");
     Ahead(older, newerPriority).Should().BeFalse("non-priority never outranks priority");
@@ -39,12 +46,45 @@ public class BookingQueueTests
 
     Ahead(older, newer).Should().BeTrue();
     Ahead(newer, older).Should().BeFalse();
+  }
 
-    var olderP = Row(priority: true, T0);
-    var newerP = Row(priority: true, T0.AddMinutes(1));
+  [Fact]
+  public void Earlier_boost_outranks_earlier_booking_within_priority_group()
+  {
+    // booked first but boosted later vs booked later but boosted first —
+    // the boost time decides
+    var bookedFirstBoostedLater = Row(priority: true, T0, prioritizedAt: T0.AddHours(9));
+    var bookedLaterBoostedFirst = Row(
+      priority: true,
+      T0.AddHours(1),
+      prioritizedAt: T0.AddHours(2)
+    );
 
-    Ahead(olderP, newerP).Should().BeTrue("priority ties fall back to age");
-    Ahead(newerP, olderP).Should().BeFalse();
+    Ahead(bookedLaterBoostedFirst, bookedFirstBoostedLater).Should().BeTrue();
+    Ahead(bookedFirstBoostedLater, bookedLaterBoostedFirst).Should().BeFalse();
+  }
+
+  [Fact]
+  public void Pre_audit_boost_falls_back_to_created_at_as_boost_time()
+  {
+    // NULL PrioritizedAt (boosted before the audit column existed) ranks as
+    // if boosted at booking time — ahead of any boost stamped after it
+    var preAudit = Row(priority: true, T0, prioritizedAt: null);
+    var stamped = Row(priority: true, T0.AddMinutes(30), prioritizedAt: T0.AddHours(2));
+
+    Ahead(preAudit, stamped).Should().BeTrue("CreatedAt stands in for the missing boost time");
+    Ahead(stamped, preAudit).Should().BeFalse();
+  }
+
+  [Fact]
+  public void Boost_time_ties_break_by_created_at_then_id()
+  {
+    var boostTime = T0.AddHours(2);
+    var bookedEarlier = Row(priority: true, T0, prioritizedAt: boostTime);
+    var bookedLater = Row(priority: true, T0.AddMinutes(5), prioritizedAt: boostTime);
+
+    Ahead(bookedEarlier, bookedLater).Should().BeTrue("boost-time ties fall back to age");
+    Ahead(bookedLater, bookedEarlier).Should().BeFalse();
   }
 
   [Fact]
@@ -60,26 +100,29 @@ public class BookingQueueTests
   [Fact]
   public void A_booking_is_never_ahead_of_itself()
   {
-    var b = Row(priority: true, T0);
+    var b = Row(priority: true, T0, prioritizedAt: T0.AddHours(1));
     Ahead(b, b).Should().BeFalse();
   }
 
   [Fact]
   public void Predicate_agrees_with_reserves_ordering()
   {
-    // Reserve() sorts: Priority desc, CreatedAt asc, Id asc — for every pair
-    // the predicate must agree with that ordering
+    // Reserve() sorts: Priority desc, (PrioritizedAt ?? CreatedAt) asc,
+    // CreatedAt asc, Id asc — for every pair the predicate must agree with
+    // that ordering
     var rows = new[]
     {
       Row(false, T0),
-      Row(true, T0.AddHours(2)),
+      Row(true, T0.AddHours(2), prioritizedAt: T0.AddHours(8)),
       Row(false, T0.AddHours(1)),
-      Row(true, T0.AddHours(3)),
+      Row(true, T0.AddHours(3), prioritizedAt: T0.AddHours(4)),
+      Row(true, T0.AddMinutes(30)), // pre-audit boost, NULL PrioritizedAt
       Row(false, T0, new Guid("00000000-0000-0000-0000-00000000000a")),
     };
 
     var sorted = rows
       .OrderByDescending(x => x.Priority)
+      .ThenBy(x => x.PrioritizedAt ?? x.CreatedAt)
       .ThenBy(x => x.CreatedAt)
       .ThenBy(x => x.Id)
       .ToArray();


### PR DESCRIPTION
## What

Within a timeslot's purchase queue, priority bookings are now ordered by **when they were boosted** (`PrioritizedAt`) instead of when the booking was created. Non-priority ordering is unchanged (oldest first). Full sort: `Priority desc → (PrioritizedAt ?? CreatedAt) asc → CreatedAt asc → Id asc`, applied identically in `Reserve()` and `BookingQueue.AheadOf` (queue-position display).

## Why

Previously a booking created early but boosted late would jump ahead of customers who paid for priority earlier — booking age, not boost time, decided the order inside the priority group. Now the earlier boost wins.

## Existing data (backfill semantics)

No migration needed: boosts that predate the `PrioritizedAt` audit column (NULL) fall back to `CreatedAt` — exactly the previous ordering key — so pre-audit priority bookings keep their current relative position. Only boosts stamped since the audit column (v1.51.0, yesterday) rank by their true boost time.

## Testing

- `BookingQueueTests` extended: boost-time ordering, NULL fallback, tie-breaks, and the Reserve/AheadOf agreement property test
- Full unit suite: **509 passed / 0 failed** (dotnet 8, Docker)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved booking queue ordering for prioritized bookings using boost time.
  * Prioritized bookings now use their boost time first, with booking age and ID as tie-breakers.
  * Ensured queue position calculations consistently match reservation ordering.
* **Tests**
  * Added coverage for boost-time ordering, fallback behavior, and tie-breaking scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->