### PR TITLE
feat(booking): expose priority/normal split in queue position

### DIFF
--- a/App/Modules/Bookings/API/V1/BookingMapper.cs
+++ b/App/Modules/Bookings/API/V1/BookingMapper.cs
@@ -63,7 +63,7 @@ public static class BookingMapper
     );
 
   public static BookingQueuePositionRes ToRes(this BookingQueuePosition p) =>
-    new(p.Status.ToRes(), p.Position, p.Total);
+    new(p.Status.ToRes(), p.Position, p.Total, p.PriorityTotal, p.NormalTotal);
 
   public static BookingTicketHealthRes ToRes(this BookingTicketHealth h) =>
     new(h.HasRef, h.RefValid);

--- a/App/Modules/Bookings/API/V1/BookingModel.cs
+++ b/App/Modules/Bookings/API/V1/BookingModel.cs
@@ -107,9 +107,15 @@ public record BookingCountRes(
 // total rows matching a search, ignoring Limit/Skip — for real page numbers
 public record SearchCountRes(int Total);
 
-// Position/Total null when the booking is no longer queued; Position is
-// 1-based (1 = next to be bought)
-public record BookingQueuePositionRes(string Status, int? Position, int? Total);
+// Position/Total (and the PriorityTotal/NormalTotal split of Total) null when
+// the booking is no longer queued; Position is 1-based (1 = next to be bought)
+public record BookingQueuePositionRes(
+  string Status,
+  int? Position,
+  int? Total,
+  int? PriorityTotal,
+  int? NormalTotal
+);
 
 // ticket reference health: HasRef = the booking carries a ticket key,
 // RefValid = that key resolves to a real object in block storage

--- a/App/Modules/Bookings/Data/BookingRepository.cs
+++ b/App/Modules/Bookings/Data/BookingRepository.cs
@@ -146,6 +146,8 @@ public class BookingRepository(
           Status = (BookStatus)b.Status,
           Position = null,
           Total = null,
+          PriorityTotal = null,
+          NormalTotal = null,
         };
 
       var slot = db.Bookings.Where(x =>
@@ -163,12 +165,15 @@ public class BookingRepository(
       // mirror Reserve()'s ordering exactly or the shown position lies
       var ahead = await slot.Where(BookingQueue.AheadOf(b)).CountAsync();
       var total = await slot.CountAsync();
+      var priority = await slot.CountAsync(x => x.Priority);
 
       return new BookingQueuePosition
       {
         Status = (BookStatus)b.Status,
         Position = ahead + 1,
         Total = total,
+        PriorityTotal = priority,
+        NormalTotal = total - priority,
       };
     }
     catch (Exception e)

--- a/Domain/Booking/Model.cs
+++ b/Domain/Booking/Model.cs
@@ -209,9 +209,10 @@ public record BookingTicketHealth
   public required bool RefValid { get; init; }
 }
 
-// A booking's place in its timeslot's purchase queue. Position/Total are null
-// when the booking is no longer queued (completed, refunded, cancelled, ...).
-// Position is 1-based: 1 = next to be bought.
+// A booking's place in its timeslot's purchase queue. Position/Total (and the
+// PriorityTotal/NormalTotal split of Total) are null when the booking is no
+// longer queued (completed, refunded, cancelled, ...). Position is 1-based:
+// 1 = next to be bought.
 public record BookingQueuePosition
 {
   public required BookStatus Status { get; init; }
@@ -219,6 +220,10 @@ public record BookingQueuePosition
   public required int? Position { get; init; }
 
   public required int? Total { get; init; }
+
+  public required int? PriorityTotal { get; init; }
+
+  public required int? NormalTotal { get; init; }
 }
 
 public record BookingStatsQuery


### PR DESCRIPTION
## What

`GET Booking/{id}/queue` now also returns `priorityTotal` and `normalTotal` — how many of the queued bookings (Pending/Buying/Recovering) in the booking's timeslot are priority vs standard. Null when the booking is no longer queued, mirroring `position`/`total`.

## Why

The frontend queue widget only shows "Position X of Y"; users can't see how the queue is composed (how many paid boosts are ahead of the pack). Argon will render the split unconditionally once this ships.

Additive, backwards-compatible API change — no migration.

## Testing

Full unit suite: 509 passed / 0 failed (dotnet 8, Docker).