### PR TITLE
feat(booking): priority policies and per-timeslot slot cap

### DIFF
--- a/App/Migrations/20260713210128_AddPriorityPoliciesAndSlotCap.Designer.cs
+++ b/App/Migrations/20260713210128_AddPriorityPoliciesAndSlotCap.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using App.StartUp.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace App.Migrations
 {
     [DbContext(typeof(MainDbContext))]
-    partial class MainDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260713210128_AddPriorityPoliciesAndSlotCap")]
+    partial class AddPriorityPoliciesAndSlotCap
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/App/Migrations/20260713210128_AddPriorityPoliciesAndSlotCap.cs
+++ b/App/Migrations/20260713210128_AddPriorityPoliciesAndSlotCap.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace App.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPriorityPoliciesAndSlotCap : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Policies",
+                table: "PrioritySettings",
+                type: "jsonb",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "SlotCap",
+                table: "PrioritySettings",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Policies",
+                table: "PrioritySettings");
+
+            migrationBuilder.DropColumn(
+                name: "SlotCap",
+                table: "PrioritySettings");
+        }
+    }
+}

--- a/App/Modules/Bookings/API/V1/BookingController.cs
+++ b/App/Modules/Bookings/API/V1/BookingController.cs
@@ -548,6 +548,31 @@ public class BookingController(
     return this.ReturnResult(x);
   }
 
+  // booking-scoped eligibility: hour-bounded policies (hours to the
+  // timeslot's departure) and the per-timeslot slot cap apply — powers the
+  // prioritize dialog with "N priority slots left". Users may only check
+  // their own bookings (same guard as GET {id}/queue); the caller's JWT
+  // roles are authoritative for targeting only when they query their own
+  // scope (userId set), matching how pricing treats roles
+  [Authorize, HttpGet("{id:guid}/priority/eligibility")]
+  public async Task<ActionResult<PriorityEligibilityRes>> BookingPriorityEligibility(
+    Guid id,
+    string? userId
+  )
+  {
+    var tokenRoles =
+      userId != null && userId == this.Sub()
+        ? helper.FieldToScope(this.HttpContext.User, AuthRoles.Field).ToArray()
+        : null;
+    var x = await this.GuardOrAnyAsync(userId, AuthRoles.Field, AuthRoles.Admin)
+      .ThenAwait(_ => service.BookingPriorityEligibility(userId, id, tokenRoles))
+      .Then(e => e?.ToRes(), Errors.MapAll);
+    return this.ReturnNullableResult(
+      x,
+      new EntityNotFound("Booking not found", typeof(Booking), id.ToString())
+    );
+  }
+
   // the priority settings in effect right now (defaults when never configured)
   [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("priority/settings")]
   public async Task<ActionResult<PrioritySettingsRes>> GetPrioritySettings()

--- a/App/Modules/Bookings/API/V1/BookingMapper.cs
+++ b/App/Modules/Bookings/API/V1/BookingMapper.cs
@@ -275,13 +275,25 @@ public static class BookingMapper
       r.WindowStartSgt?.ToStandardTimeFormat(),
       r.WindowEndSgt?.ToStandardTimeFormat(),
       r.FreeTarget?.ToRes(),
-      r.AccessTarget?.ToRes()
+      r.AccessTarget?.ToRes(),
+      r.Policies.Select(p => p.ToRes()).ToList(),
+      r.SlotCap
+    );
+
+  public static PriorityPolicyRes ToRes(this PriorityPolicyRecord p) =>
+    new(
+      p.Name,
+      p.Allow,
+      p.Target?.ToRes(),
+      p.MinHoursToDeparture,
+      p.MaxHoursToDeparture,
+      p.FeeOverride
     );
 
   public static PriorityAccessRes ToRes(this PriorityAccess a) => new(a.UserId, a.CreatedAt);
 
   public static PriorityEligibilityRes ToRes(this PriorityEligibility e) =>
-    new(e.Eligible, e.Fee, e.Free);
+    new(e.Eligible, e.Fee, e.Free, e.SlotCap, e.SlotsLeft);
 
   public static PrioritySettingsRecord ToDomain(this SetPrioritySettingsReq req) =>
     new()
@@ -292,5 +304,18 @@ public static class BookingMapper
       WindowEndSgt = req.WindowEndSgt?.ToTime(),
       FreeTarget = req.FreeTarget?.ToDomain(),
       AccessTarget = req.AccessTarget?.ToDomain(),
+      Policies = req.Policies?.Select(p => p.ToDomain()).ToList() ?? [],
+      SlotCap = req.SlotCap,
+    };
+
+  public static PriorityPolicyRecord ToDomain(this PriorityPolicyReq req) =>
+    new()
+    {
+      Name = req.Name,
+      Allow = req.Allow,
+      Target = req.Target?.ToDomain(),
+      MinHoursToDeparture = req.MinHoursToDeparture,
+      MaxHoursToDeparture = req.MaxHoursToDeparture,
+      FeeOverride = req.FeeOverride,
     };
 }

--- a/App/Modules/Bookings/API/V1/BookingModel.cs
+++ b/App/Modules/Bookings/API/V1/BookingModel.cs
@@ -271,7 +271,22 @@ public record SetPrioritySettingsReq(
   string? WindowStartSgt,
   string? WindowEndSgt,
   DiscountTargetReq? FreeTarget = null,
-  DiscountTargetReq? AccessTarget = null
+  DiscountTargetReq? AccessTarget = null,
+  List<PriorityPolicyReq>? Policies = null,
+  int? SlotCap = null
+);
+
+// One rule in the ordered policy chain (evaluated before AccessTarget/
+// AllowAll, first match wins): applies when Target matches (null = everyone)
+// AND hours-to-departure is inside [Min, Max) (null = unbounded); decides
+// Allow (optionally at FeeOverride) or deny.
+public record PriorityPolicyReq(
+  string Name,
+  bool Allow,
+  DiscountTargetReq? Target = null,
+  decimal? MinHoursToDeparture = null,
+  decimal? MaxHoursToDeparture = null,
+  decimal? FeeOverride = null
 );
 
 // RESP
@@ -281,11 +296,29 @@ public record PrioritySettingsRes(
   string? WindowStartSgt,
   string? WindowEndSgt,
   DiscountTargetRes? FreeTarget,
-  DiscountTargetRes? AccessTarget
+  DiscountTargetRes? AccessTarget,
+  List<PriorityPolicyRes> Policies,
+  int? SlotCap
+);
+
+public record PriorityPolicyRes(
+  string Name,
+  bool Allow,
+  DiscountTargetRes? Target,
+  decimal? MinHoursToDeparture,
+  decimal? MaxHoursToDeparture,
+  decimal? FeeOverride
 );
 
 public record PriorityAccessRes(string UserId, DateTime CreatedAt);
 
 // may the calling user prioritize right now, at what fee, and free for them
-// (Free => Fee is 0)
-public record PriorityEligibilityRes(bool Eligible, decimal Fee, bool Free);
+// (Free => Fee is 0). SlotCap/SlotsLeft only on the booking-scoped endpoint
+// (and SlotCap configured); null otherwise.
+public record PriorityEligibilityRes(
+  bool Eligible,
+  decimal Fee,
+  bool Free,
+  int? SlotCap = null,
+  int? SlotsLeft = null
+);

--- a/App/Modules/Bookings/API/V1/BookingValidator.cs
+++ b/App/Modules/Bookings/API/V1/BookingValidator.cs
@@ -173,5 +173,47 @@ public class SetPrioritySettingsReqValidator : AbstractValidator<SetPrioritySett
     this.RuleFor(x => x.AccessTarget)!
       .SetValidator(new DiscountTargetReqValidator()!)
       .When(x => x.AccessTarget != null);
+    this.RuleFor(x => x.SlotCap)
+      .GreaterThanOrEqualTo(1)
+      .LessThanOrEqualTo(10_000)
+      .When(x => x.SlotCap != null)
+      .WithMessage("SlotCap must be between 1 and 10000");
+    this.RuleForEach(x => x.Policies)
+      .SetValidator(new PriorityPolicyReqValidator())
+      .When(x => x.Policies != null);
+  }
+}
+
+public class PriorityPolicyReqValidator : AbstractValidator<PriorityPolicyReq>
+{
+  public PriorityPolicyReqValidator()
+  {
+    this.RuleFor(x => x.Name).NotEmpty().MaximumLength(128);
+    this.RuleFor(x => x.Target)!
+      .SetValidator(new DiscountTargetReqValidator()!)
+      .When(x => x.Target != null);
+    this.RuleFor(x => x.MinHoursToDeparture)
+      .GreaterThanOrEqualTo(0)
+      .When(x => x.MinHoursToDeparture != null)
+      .WithMessage("MinHoursToDeparture must be >= 0");
+    this.RuleFor(x => x.MaxHoursToDeparture)
+      .GreaterThan(0)
+      .When(x => x.MaxHoursToDeparture != null)
+      .WithMessage("MaxHoursToDeparture must be > 0");
+    // an empty interval can never apply — reject the typo
+    this.RuleFor(x => x.MaxHoursToDeparture)
+      .Must(
+        (req, max) => max == null || req.MinHoursToDeparture == null || max > req.MinHoursToDeparture
+      )
+      .WithMessage("MaxHoursToDeparture must be greater than MinHoursToDeparture");
+    this.RuleFor(x => x.FeeOverride)
+      .GreaterThanOrEqualTo(0)
+      .LessThanOrEqualTo(10_000)
+      .When(x => x.FeeOverride != null)
+      .WithMessage("FeeOverride must be between 0 and 10000");
+    // FeeOverride on a deny rule is dead configuration — surface the mistake
+    this.RuleFor(x => x.FeeOverride)
+      .Must((req, fee) => fee == null || req.Allow)
+      .WithMessage("FeeOverride only applies to Allow rules");
   }
 }

--- a/App/Modules/Bookings/Data/BookingRepository.cs
+++ b/App/Modules/Bookings/Data/BookingRepository.cs
@@ -545,6 +545,41 @@ public class BookingRepository(
     }
   }
 
+  public async Task<Result<int>> CountSlotPriority(
+    TrainDirection direction,
+    DateOnly date,
+    TimeOnly time
+  )
+  {
+    try
+    {
+      // same queued statuses as the queue itself — completed/cancelled
+      // boosts free their slot up again
+      return await db.Bookings.CountAsync(x =>
+        x.Direction == direction.ToData()
+        && x.Date == date
+        && x.Time == time
+        && x.Priority
+        && (
+          x.Status == (byte)BookStatus.Pending
+          || x.Status == (byte)BookStatus.Buying
+          || x.Status == (byte)BookStatus.Recovering
+        )
+      );
+    }
+    catch (Exception e)
+    {
+      logger.LogError(
+        e,
+        "Failed to count slot priority '{direction}' '{Date}' '{Time}'",
+        direction,
+        date,
+        time
+      );
+      return e;
+    }
+  }
+
   public async Task<Result<BookingPrincipal?>> Prioritize(
     string? userId,
     Guid id,

--- a/App/Modules/Bookings/Data/PriorityData.cs
+++ b/App/Modules/Bookings/Data/PriorityData.cs
@@ -31,6 +31,29 @@ public class PrioritySettingsData
   // Who MAY prioritize at all — when set it takes precedence over
   // AllowAll/PriorityAccessData; null = legacy behavior unchanged
   public DiscountTargetData? AccessTarget { get; set; }
+
+  // Ordered policy chain (see Domain.Booking.PriorityPolicyRecord) — owned
+  // JSON list; NULL/empty = no policies, legacy gate only
+  public List<PriorityPolicyData>? Policies { get; set; }
+
+  // Max priority bookings per timeslot; NULL = uncapped
+  public int? SlotCap { get; set; }
+}
+
+// One policy rule inside PrioritySettingsData.Policies (owned JSON)
+public class PriorityPolicyData
+{
+  public string Name { get; set; } = string.Empty;
+
+  public bool Allow { get; set; }
+
+  public DiscountTargetData? Target { get; set; }
+
+  public decimal? MinHoursToDeparture { get; set; }
+
+  public decimal? MaxHoursToDeparture { get; set; }
+
+  public decimal? FeeOverride { get; set; }
 }
 
 // A user allowed to prioritize bookings (when AllowAll is off)

--- a/App/Modules/Bookings/Data/PriorityRepository.cs
+++ b/App/Modules/Bookings/Data/PriorityRepository.cs
@@ -137,6 +137,19 @@ public static class PriorityDataMapper
       WindowEndSgt = data.WindowEndSgt,
       FreeTarget = data.FreeTarget?.ToTarget(),
       AccessTarget = data.AccessTarget?.ToTarget(),
+      Policies = data.Policies?.Select(p => p.ToRecord()).ToList() ?? [],
+      SlotCap = data.SlotCap,
+    };
+
+  public static PriorityPolicyRecord ToRecord(this PriorityPolicyData data) =>
+    new()
+    {
+      Name = data.Name,
+      Allow = data.Allow,
+      Target = data.Target?.ToTarget(),
+      MinHoursToDeparture = data.MinHoursToDeparture,
+      MaxHoursToDeparture = data.MaxHoursToDeparture,
+      FeeOverride = data.FeeOverride,
     };
 
   public static PrioritySettingsPrincipal ToPrincipal(this PrioritySettingsData data) =>
@@ -162,6 +175,21 @@ public static class PriorityDataMapper
     data.WindowEndSgt = record.WindowEndSgt;
     data.FreeTarget = record.FreeTarget?.ToData();
     data.AccessTarget = record.AccessTarget?.ToData();
+    data.Policies = record.Policies.Count == 0
+      ? null
+      : record.Policies.Select(p => p.ToData()).ToList();
+    data.SlotCap = record.SlotCap;
     return data;
   }
+
+  public static PriorityPolicyData ToData(this PriorityPolicyRecord record) =>
+    new()
+    {
+      Name = record.Name,
+      Allow = record.Allow,
+      Target = record.Target?.ToData(),
+      MinHoursToDeparture = record.MinHoursToDeparture,
+      MaxHoursToDeparture = record.MaxHoursToDeparture,
+      FeeOverride = record.FeeOverride,
+    };
 }

--- a/App/StartUp/Database/MainDbContext.cs
+++ b/App/StartUp/Database/MainDbContext.cs
@@ -211,6 +211,16 @@ public class MainDbContext(
         d.OwnsMany(dt => dt.Matches);
       }
     );
+    // the ordered policy chain: one JSON array column, each rule optionally
+    // carrying its own target blob (same shape as the two targets above)
+    prioritySettings.OwnsMany(
+      x => x.Policies,
+      p =>
+      {
+        p.ToJson();
+        p.OwnsOne(x => x.Target, t => t.OwnsMany(dt => dt.Matches));
+      }
+    );
 
     var withdrawal = modelBuilder.Entity<WithdrawalData>();
     // existing rows predate the method column and are all PayNow transfers

--- a/Domain/Booking/IService.cs
+++ b/Domain/Booking/IService.cs
@@ -83,9 +83,19 @@ public interface IBookingService
 
   // may this user prioritize a booking right now, at what fee, and is the
   // boost free for them; callerTokenRoles = the target user's own JWT roles
-  // when they are the caller (null = fall back to the persisted Roles mirror)
+  // when they are the caller (null = fall back to the persisted Roles mirror).
+  // No booking in scope: hour-bounded policies are skipped, SlotsLeft null.
   Task<Result<PriorityEligibility>> PriorityEligibility(
     string userId,
+    string[]? callerTokenRoles = null
+  );
+
+  // booking-scoped flavor: hour-bounded policies apply (hours to the
+  // timeslot's departure) and the per-timeslot slot cap is counted; null
+  // when the booking does not exist (or is not visible to userId)
+  Task<Result<PriorityEligibility?>> BookingPriorityEligibility(
+    string? userId,
+    Guid id,
     string[]? callerTokenRoles = null
   );
 

--- a/Domain/Booking/Priority.cs
+++ b/Domain/Booking/Priority.cs
@@ -30,6 +30,16 @@ public record PrioritySettingsRecord
   // null = legacy behavior (allowlisted OR AllowAll) unchanged.
   public DiscountTarget? AccessTarget { get; init; }
 
+  // Ordered policy chain evaluated BEFORE AccessTarget/AllowAll: the first
+  // rule whose conditions all match decides (see PriorityPolicyRecord); no
+  // matching rule falls through to the legacy gate. Empty = no policies.
+  public IReadOnlyList<PriorityPolicyRecord> Policies { get; init; } = [];
+
+  // Max priority bookings per timeslot (direction+date+time), counted over
+  // the queued statuses; null = uncapped. Gives buyers predictability: a
+  // boost can never be diluted below 1-in-SlotCap odds.
+  public int? SlotCap { get; init; }
+
   public static readonly PrioritySettingsRecord Default = new()
   {
     Fee = 10m,
@@ -38,7 +48,34 @@ public record PrioritySettingsRecord
     WindowEndSgt = null,
     FreeTarget = null,
     AccessTarget = null,
+    Policies = [],
+    SlotCap = null,
   };
+}
+
+// One rule in the ordered priority policy chain. A rule APPLIES when every
+// set condition matches (unset = wildcard): Target (same shape as discount
+// targeting, matched against the user's id and pricing roles) and the
+// hours-to-departure interval [Min, Max). The first applying rule decides:
+// Allow (optionally at FeeOverride instead of the base fee) or deny.
+// Examples — "boosting only opens inside 48h": deny rule with Min=48;
+// "VIPs may boost anytime, everyone else only outside 6h": allow rule with
+// Target=vip, then deny rule with Max=6.
+public record PriorityPolicyRecord
+{
+  public required string Name { get; init; }
+
+  public required bool Allow { get; init; }
+
+  public DiscountTarget? Target { get; init; }
+
+  public decimal? MinHoursToDeparture { get; init; }
+
+  public decimal? MaxHoursToDeparture { get; init; }
+
+  // Allow rules only: charge this instead of the base fee (FreeTarget still
+  // wins and makes the boost free)
+  public decimal? FeeOverride { get; init; }
 }
 
 public record PrioritySettingsPrincipal
@@ -60,7 +97,8 @@ public record PriorityAccess
 
 // What the eligibility endpoint (and the prioritize guard) answers: may this
 // user prioritize right now, at what fee, and whether the boost is free for
-// them (Free => Fee is 0)
+// them (Free => Fee is 0). SlotCap/SlotsLeft are only known when the check
+// is scoped to a booking (its timeslot); null otherwise or when uncapped.
 public record PriorityEligibility
 {
   public required bool Eligible { get; init; }
@@ -68,6 +106,10 @@ public record PriorityEligibility
   public required decimal Fee { get; init; }
 
   public required bool Free { get; init; }
+
+  public int? SlotCap { get; init; }
+
+  public int? SlotsLeft { get; init; }
 }
 
 // Pure eligibility rules, shared by the endpoint, the prioritize guard and
@@ -103,6 +145,42 @@ public static class PriorityRules
         ? Discount.TargetMatcher.Matches(settings.AccessTarget, userId, roles ?? [])
         : allowlisted || settings.AllowAll;
     return access && WindowOpen(settings.WindowStartSgt, settings.WindowEndSgt, nowSgt);
+  }
+
+  // Full evaluation: the SGT window gates everything; then the policy chain
+  // runs first-match-wins; no matching rule falls through to Eligible()'s
+  // legacy gate. hoursToDeparture = null means "no booking in scope" (the
+  // generic eligibility endpoint) — hour-bounded rules are then SKIPPED, so
+  // the generic answer only reflects rules that hold for every timeslot.
+  public static (bool Eligible, decimal Fee) Decide(
+    bool allowlisted,
+    PrioritySettingsRecord settings,
+    TimeOnly nowSgt,
+    decimal? hoursToDeparture,
+    string userId,
+    string[] roles
+  )
+  {
+    if (!WindowOpen(settings.WindowStartSgt, settings.WindowEndSgt, nowSgt))
+      return (false, settings.Fee);
+
+    foreach (var p in settings.Policies)
+    {
+      if (p.Target != null && !Discount.TargetMatcher.Matches(p.Target, userId, roles))
+        continue;
+      if (p.MinHoursToDeparture != null || p.MaxHoursToDeparture != null)
+      {
+        if (hoursToDeparture == null)
+          continue;
+        if (p.MinHoursToDeparture != null && hoursToDeparture < p.MinHoursToDeparture)
+          continue;
+        if (p.MaxHoursToDeparture != null && hoursToDeparture >= p.MaxHoursToDeparture)
+          continue;
+      }
+      return (p.Allow, p.Allow ? p.FeeOverride ?? settings.Fee : settings.Fee);
+    }
+
+    return (Eligible(allowlisted, settings, nowSgt, userId, roles), settings.Fee);
   }
 
   // Is the boost free for this user: FreeTarget matched against the user's

--- a/Domain/Booking/Repository.cs
+++ b/Domain/Booking/Repository.cs
@@ -39,6 +39,10 @@ public interface IBookingRepository
 
   Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly Time);
 
+  // priority bookings currently queued (Pending/Buying/Recovering) in the
+  // timeslot — the numerator SlotCap is checked against
+  Task<Result<int>> CountSlotPriority(TrainDirection direction, DateOnly date, TimeOnly time);
+
   // marks the booking priority (into the queue's priority group, which is
   // ordered by boost time — PrioritizedAt), snapshots the fee
   // charged (null = FREE boost, nothing charged so nothing to refund), stamps

--- a/Domain/Booking/Service.cs
+++ b/Domain/Booking/Service.cs
@@ -1070,6 +1070,46 @@ public class BookingService(
     string[]? callerTokenRoles = null
   )
   {
+    // no booking in scope: hour-bounded policies are skipped and the slot
+    // cap cannot be counted (SlotsLeft = null)
+    return this.PriorityContext(userId, callerTokenRoles)
+      .Then(t => Evaluate(t, userId, null, null), Errors.MapNone);
+  }
+
+  // booking-scoped eligibility: hour-bounded policies apply (hours until the
+  // timeslot departs) and the slot cap is counted; null when the booking does
+  // not exist (or is not visible to userId)
+  public Task<Result<PriorityEligibility?>> BookingPriorityEligibility(
+    string? userId,
+    Guid id,
+    string[]? callerTokenRoles = null
+  )
+  {
+    return repo.Get(userId, id)
+      .ThenAwait(b =>
+      {
+        if (b == null)
+          return Task.FromResult((Result<PriorityEligibility?>)(PriorityEligibility?)null);
+        return this.PriorityContext(b.Principal.UserId, callerTokenRoles)
+          .ThenAwait(t =>
+            this.SlotsLeft(t.s, b.Principal.Record)
+              .Then(slotsLeft => (t, slotsLeft), Errors.MapNone)
+          )
+          .Then(
+            PriorityEligibility? (x) =>
+              Evaluate(x.t, b.Principal.UserId, HoursToDeparture(b.Principal.Record), x.slotsLeft),
+            Errors.MapNone
+          );
+      });
+  }
+
+  // settings + allowlist membership + the pricing roles targeting matches on
+  // (JWT roles when the caller is the target, else the persisted mirror)
+  private Task<Result<(PrioritySettingsRecord s, bool allowed, string[] roles)>> PriorityContext(
+    string userId,
+    string[]? callerTokenRoles
+  )
+  {
     return prioritySettingsRepo
       .GetCurrent()
       .Then(s => s?.Record ?? PrioritySettingsRecord.Default, Errors.MapNone)
@@ -1078,8 +1118,13 @@ public class BookingService(
       )
       .ThenAwait(t =>
       {
-        // targets untouched: skip the user lookup, roles are never consulted
-        if (t.s.FreeTarget == null && t.s.AccessTarget == null)
+        // targets untouched anywhere (base gates or policy rules): skip the
+        // user lookup, roles are never consulted
+        if (
+          t.s.FreeTarget == null
+          && t.s.AccessTarget == null
+          && t.s.Policies.All(p => p.Target == null)
+        )
           return Task.FromResult(
             (Result<(PrioritySettingsRecord s, bool allowed, string[] roles)>)(t.s, t.allowed, [])
           );
@@ -1098,24 +1143,59 @@ public class BookingService(
               ),
             Errors.MapNone
           );
-      })
-      .Then(
-        t =>
-        {
-          var singapore = TimeZoneInfo.FindSystemTimeZoneById("Singapore");
-          var nowSgt = TimeOnly.FromDateTime(
-            TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, singapore)
-          );
-          var free = PriorityRules.Free(t.s, userId, t.roles);
-          return new PriorityEligibility
-          {
-            Eligible = PriorityRules.Eligible(t.allowed, t.s, nowSgt, userId, t.roles),
-            Fee = free ? 0m : t.s.Fee,
-            Free = free,
-          };
-        },
-        Errors.MapNone
-      );
+      });
+  }
+
+  // hours until the timeslot departs, in SGT (negative once departed)
+  private static decimal HoursToDeparture(BookingRecord r)
+  {
+    var singapore = TimeZoneInfo.FindSystemTimeZoneById("Singapore");
+    var nowSgt = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, singapore);
+    return (decimal)(r.Date.ToDateTime(r.Time) - nowSgt).TotalHours;
+  }
+
+  // remaining priority slots in the booking's timeslot; null = uncapped
+  private Task<Result<int?>> SlotsLeft(PrioritySettingsRecord s, BookingRecord r)
+  {
+    if (s.SlotCap == null)
+      return Task.FromResult((Result<int?>)(int?)null);
+    return repo.CountSlotPriority(r.Direction, r.Date, r.Time)
+      .Then(int? (c) => Math.Max(0, s.SlotCap.Value - c), Errors.MapNone);
+  }
+
+  // the single evaluation path shared by both eligibility flavors and the
+  // prioritize guard: policy chain (Decide), free targeting, slot cap
+  private static PriorityEligibility Evaluate(
+    (PrioritySettingsRecord s, bool allowed, string[] roles) t,
+    string userId,
+    decimal? hoursToDeparture,
+    int? slotsLeft
+  )
+  {
+    var singapore = TimeZoneInfo.FindSystemTimeZoneById("Singapore");
+    var nowSgt = TimeOnly.FromDateTime(
+      TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, singapore)
+    );
+    var free = PriorityRules.Free(t.s, userId, t.roles);
+    var (eligible, fee) = PriorityRules.Decide(
+      t.allowed,
+      t.s,
+      nowSgt,
+      hoursToDeparture,
+      userId,
+      t.roles
+    );
+    // a full priority queue blocks everyone, however eligible otherwise
+    if (slotsLeft == 0)
+      eligible = false;
+    return new PriorityEligibility
+    {
+      Eligible = eligible,
+      Fee = free ? 0m : fee,
+      Free = free,
+      SlotCap = t.s.SlotCap,
+      SlotsLeft = slotsLeft,
+    };
   }
 
   // Moves a booking to the front of its timeslot's purchase queue. Guarded
@@ -1151,17 +1231,31 @@ public class BookingService(
                 return Task.FromResult((Result<int>)r);
               }
             )
-            // guard: the booking's owner must be eligible right now (their
-            // pricing roles decide free/access targeting; the owner's JWT is
-            // absent here, so the persisted Roles mirror is used)
+            // guard: the booking's owner must be eligible right now — the
+            // full booking-scoped evaluation: policy chain (with hours to
+            // this timeslot's departure), free/access targeting on the
+            // owner's pricing roles (their JWT is absent here, so the
+            // persisted Roles mirror is used) and the per-timeslot slot cap
             .ThenAwait(b =>
-              this.PriorityEligibility(b.Principal.UserId)
-                .ThenAwait(e =>
+              this.PriorityContext(b.Principal.UserId, null)
+                .ThenAwait(t =>
+                  this.SlotsLeft(t.s, b.Principal.Record)
+                    .Then(slotsLeft => (t, slotsLeft), Errors.MapNone)
+                )
+                .ThenAwait(x =>
                 {
+                  var e = Evaluate(
+                    x.t,
+                    b.Principal.UserId,
+                    HoursToDeparture(b.Principal.Record),
+                    x.slotsLeft
+                  );
                   if (e.Eligible)
                     return Task.FromResult((Result<(Booking b, PriorityEligibility e)>)(b, e));
                   var r = new InvalidBookingOperationException(
-                    "Prioritize requires the booking's owner to be eligible (allowlisted or allow-all, within the availability window)",
+                    x.slotsLeft == 0
+                      ? "Prioritize requires a free priority slot — this timeslot's priority queue is full"
+                      : "Prioritize requires the booking's owner to be eligible (priority policies/allowlist, within the availability window)",
                     b.Principal.Status.Status,
                     BookingOperations.Prioritize
                   );

--- a/UnitTest/Bookings/BookingServiceAttachTicketTests.cs
+++ b/UnitTest/Bookings/BookingServiceAttachTicketTests.cs
@@ -273,6 +273,9 @@ public class BookingServiceAttachTicketTests
     public Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 
+    public Task<Result<int>> CountSlotPriority(TrainDirection direction, DateOnly date, TimeOnly time) =>
+      Task.FromResult((Result<int>)0);
+
     public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee, string? grantedBy = null) =>
       throw new NotImplementedException();
 

--- a/UnitTest/Bookings/BookingServiceBuyingGuardTests.cs
+++ b/UnitTest/Bookings/BookingServiceBuyingGuardTests.cs
@@ -214,6 +214,9 @@ public class BookingServiceBuyingGuardTests
     public Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 
+    public Task<Result<int>> CountSlotPriority(TrainDirection direction, DateOnly date, TimeOnly time) =>
+      Task.FromResult((Result<int>)0);
+
     public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee, string? grantedBy = null) =>
       throw new NotImplementedException();
 

--- a/UnitTest/Bookings/BookingServiceCompleteNoCollectTests.cs
+++ b/UnitTest/Bookings/BookingServiceCompleteNoCollectTests.cs
@@ -209,6 +209,9 @@ public class BookingServiceCompleteNoCollectTests
     public Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 
+    public Task<Result<int>> CountSlotPriority(TrainDirection direction, DateOnly date, TimeOnly time) =>
+      Task.FromResult((Result<int>)0);
+
     public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee, string? grantedBy = null) =>
       throw new NotImplementedException();
 

--- a/UnitTest/Bookings/BookingServicePrioritizeTests.cs
+++ b/UnitTest/Bookings/BookingServicePrioritizeTests.cs
@@ -256,6 +256,51 @@ public class BookingServicePrioritizeTests
   }
 
   [Fact]
+  public async Task Prioritize_full_slot_cap_is_rejected_and_moves_no_money()
+  {
+    var b = BookingWith(BookStatus.Pending);
+    var settings = PrioritySettingsRecord.Default with { AllowAll = true, SlotCap = 2 };
+    var (service, repo, wallet, txn) = Make(b, settings);
+    repo.SlotPriorityCount = 2;
+
+    var result = await service.Prioritize("user-1", b.Principal.Id);
+
+    result.IsSuccess().Should().BeFalse("the timeslot's priority queue is full");
+    wallet.CollectCalls.Should().Be(0);
+    txn.Records.Should().BeEmpty();
+    repo.PrioritizeCalls.Should().Be(0);
+  }
+
+  [Fact]
+  public async Task Prioritize_under_the_slot_cap_succeeds()
+  {
+    var b = BookingWith(BookStatus.Pending);
+    var settings = PrioritySettingsRecord.Default with { AllowAll = true, SlotCap = 2 };
+    var (service, repo, wallet, _) = Make(b, settings);
+    repo.SlotPriorityCount = 1;
+
+    var result = await service.Prioritize("user-1", b.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    wallet.CollectCalls.Should().Be(1);
+    repo.PrioritizeCalls.Should().Be(1);
+  }
+
+  [Fact]
+  public async Task Prioritize_uncapped_ignores_the_slot_count()
+  {
+    var b = BookingWith(BookStatus.Pending);
+    var settings = PrioritySettingsRecord.Default with { AllowAll = true, SlotCap = null };
+    var (service, repo, _, _) = Make(b, settings);
+    repo.SlotPriorityCount = 500;
+
+    var result = await service.Prioritize("user-1", b.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    repo.PrioritizeCalls.Should().Be(1);
+  }
+
+  [Fact]
   public async Task Prioritize_outside_the_window_is_rejected()
   {
     // pin a 1-hour window that deterministically excludes "now" regardless of
@@ -826,6 +871,16 @@ public class BookingServicePrioritizeTests
       DateOnly date,
       TimeOnly time
     ) => throw new NotImplementedException();
+
+    // how many priority boosts already occupy the timeslot — the SlotCap
+    // guard's input, settable per test
+    public int SlotPriorityCount { get; set; }
+
+    public Task<Result<int>> CountSlotPriority(
+      TrainDirection direction,
+      DateOnly date,
+      TimeOnly time
+    ) => Task.FromResult((Result<int>)this.SlotPriorityCount);
 
     public Task<Result<Unit?>> Delete(string? userId, Guid id) =>
       throw new NotImplementedException();

--- a/UnitTest/Bookings/BookingServiceRecoverRevertTests.cs
+++ b/UnitTest/Bookings/BookingServiceRecoverRevertTests.cs
@@ -286,6 +286,9 @@ public class BookingServiceRecoverRevertTests
     public Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 
+    public Task<Result<int>> CountSlotPriority(TrainDirection direction, DateOnly date, TimeOnly time) =>
+      Task.FromResult((Result<int>)0);
+
     public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee, string? grantedBy = null) =>
       throw new NotImplementedException();
 

--- a/UnitTest/Bookings/BookingServiceRevertGuardTests.cs
+++ b/UnitTest/Bookings/BookingServiceRevertGuardTests.cs
@@ -347,6 +347,9 @@ public class BookingServiceRevertGuardTests
     public Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 
+    public Task<Result<int>> CountSlotPriority(TrainDirection direction, DateOnly date, TimeOnly time) =>
+      Task.FromResult((Result<int>)0);
+
     public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee, string? grantedBy = null) =>
       throw new NotImplementedException();
 

--- a/UnitTest/Bookings/BookingServiceTerminateTests.cs
+++ b/UnitTest/Bookings/BookingServiceTerminateTests.cs
@@ -339,6 +339,12 @@ public class BookingServiceTerminateTests
       TimeOnly time
     ) => throw new NotImplementedException();
 
+    public Task<Result<int>> CountSlotPriority(
+      TrainDirection direction,
+      DateOnly date,
+      TimeOnly time
+    ) => Task.FromResult((Result<int>)0);
+
     public Task<Result<Unit?>> Delete(string? userId, Guid id) =>
       throw new NotImplementedException();
 

--- a/UnitTest/Bookings/BookingServiceTicketHealthTests.cs
+++ b/UnitTest/Bookings/BookingServiceTicketHealthTests.cs
@@ -201,6 +201,9 @@ public class BookingServiceTicketHealthTests
     public Task<Result<BookingPrincipal?>> Reserve(TrainDirection direction, DateOnly date, TimeOnly time) =>
       throw new NotImplementedException();
 
+    public Task<Result<int>> CountSlotPriority(TrainDirection direction, DateOnly date, TimeOnly time) =>
+      Task.FromResult((Result<int>)0);
+
     public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee, string? grantedBy = null) =>
       throw new NotImplementedException();
 

--- a/UnitTest/Bookings/PriorityPolicyTests.cs
+++ b/UnitTest/Bookings/PriorityPolicyTests.cs
@@ -1,0 +1,159 @@
+using Domain.Booking;
+using Domain.Discount;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// The policy chain (PriorityRules.Decide): first matching rule wins, target
+// and hours-to-departure conditions, fee overrides, fallback to the legacy
+// gate, and the null-hours (no booking in scope) semantics
+public class PriorityPolicyTests
+{
+  private static readonly TimeOnly Noon = new(12, 0);
+
+  private static DiscountTarget Role(string role) =>
+    new()
+    {
+      MatchMode = DiscountMatchMode.Any,
+      Matches = [new DiscountMatch { Type = DiscountMatchType.Role, Value = role }],
+    };
+
+  private static PriorityPolicyRecord Rule(
+    bool allow,
+    DiscountTarget? target = null,
+    decimal? minHours = null,
+    decimal? maxHours = null,
+    decimal? feeOverride = null
+  ) =>
+    new()
+    {
+      Name = "rule",
+      Allow = allow,
+      Target = target,
+      MinHoursToDeparture = minHours,
+      MaxHoursToDeparture = maxHours,
+      FeeOverride = feeOverride,
+    };
+
+  private static PrioritySettingsRecord Settings(
+    bool allowAll = false,
+    IReadOnlyList<PriorityPolicyRecord>? policies = null,
+    TimeOnly? start = null,
+    TimeOnly? end = null
+  ) =>
+    new()
+    {
+      Fee = 10m,
+      AllowAll = allowAll,
+      WindowStartSgt = start,
+      WindowEndSgt = end,
+      Policies = policies ?? [],
+    };
+
+  [Fact]
+  public void No_policies_falls_back_to_legacy_gate()
+  {
+    PriorityRules.Decide(false, Settings(), Noon, 24m, "u1", []).Eligible.Should().BeFalse();
+    PriorityRules
+      .Decide(false, Settings(allowAll: true), Noon, 24m, "u1", [])
+      .Eligible.Should()
+      .BeTrue();
+    PriorityRules.Decide(true, Settings(), Noon, 24m, "u1", []).Eligible.Should().BeTrue();
+  }
+
+  [Fact]
+  public void Deny_inside_min_hours_blocks_even_allow_all()
+  {
+    // "boosting closes once the departure is under 48h away":
+    // allow when >= 48h, deny everyone else
+    var s = Settings(
+      allowAll: true,
+      policies: [Rule(allow: true, minHours: 48m), Rule(allow: false)]
+    );
+
+    PriorityRules.Decide(false, s, Noon, 72m, "u1", []).Eligible.Should().BeTrue();
+    PriorityRules.Decide(false, s, Noon, 12m, "u1", []).Eligible.Should().BeFalse();
+  }
+
+  [Fact]
+  public void Role_rule_mixes_with_hours()
+  {
+    // VIPs boost anytime; everyone else only outside 6h
+    var s = Settings(
+      allowAll: true,
+      policies: [Rule(allow: true, target: Role("vip")), Rule(allow: false, maxHours: 6m)]
+    );
+
+    PriorityRules.Decide(false, s, Noon, 2m, "u1", ["vip"]).Eligible.Should().BeTrue();
+    PriorityRules.Decide(false, s, Noon, 2m, "u1", ["pleb"]).Eligible.Should().BeFalse();
+    // outside 6h the deny rule no longer applies -> legacy gate (allowAll)
+    PriorityRules.Decide(false, s, Noon, 7m, "u1", ["pleb"]).Eligible.Should().BeTrue();
+  }
+
+  [Fact]
+  public void First_matching_rule_wins()
+  {
+    var s = Settings(
+      allowAll: false,
+      policies: [Rule(allow: true, target: Role("vip")), Rule(allow: false, target: Role("vip"))]
+    );
+
+    PriorityRules.Decide(false, s, Noon, 24m, "u1", ["vip"]).Eligible.Should().BeTrue();
+  }
+
+  [Fact]
+  public void Allow_rule_fee_override_applies_and_deny_keeps_base_fee()
+  {
+    var s = Settings(
+      allowAll: false,
+      policies: [Rule(allow: true, minHours: 48m, feeOverride: 25m)]
+    );
+
+    var far = PriorityRules.Decide(false, s, Noon, 72m, "u1", []);
+    far.Eligible.Should().BeTrue();
+    far.Fee.Should().Be(25m);
+
+    // no rule matches near departure -> legacy gate at the base fee
+    var near = PriorityRules.Decide(false, s, Noon, 12m, "u1", []);
+    near.Eligible.Should().BeFalse();
+    near.Fee.Should().Be(10m);
+  }
+
+  [Fact]
+  public void Hour_bounds_are_half_open()
+  {
+    var s = Settings(policies: [Rule(allow: true, minHours: 24m, maxHours: 48m)]);
+
+    PriorityRules.Decide(false, s, Noon, 24m, "u1", []).Eligible.Should().BeTrue("min inclusive");
+    PriorityRules
+      .Decide(false, s, Noon, 48m, "u1", [])
+      .Eligible.Should()
+      .BeFalse("max exclusive");
+  }
+
+  [Fact]
+  public void Null_hours_skips_hour_bounded_rules_but_applies_unbounded_ones()
+  {
+    var s = Settings(
+      allowAll: true,
+      policies: [Rule(allow: false, maxHours: 6m), Rule(allow: false, target: Role("banned"))]
+    );
+
+    // the hour-bounded deny cannot be evaluated without a booking; the
+    // role-bound one can
+    PriorityRules.Decide(false, s, Noon, null, "u1", []).Eligible.Should().BeTrue();
+    PriorityRules.Decide(false, s, Noon, null, "u1", ["banned"]).Eligible.Should().BeFalse();
+  }
+
+  [Fact]
+  public void Closed_window_blocks_before_any_policy_runs()
+  {
+    var s = Settings(
+      policies: [Rule(allow: true)],
+      start: new TimeOnly(0, 0),
+      end: new TimeOnly(1, 0)
+    );
+
+    PriorityRules.Decide(true, s, Noon, 24m, "u1", []).Eligible.Should().BeFalse();
+  }
+}


### PR DESCRIPTION
## What

Flexible admin control over priority-queue access, composing with the existing targeting:

**Policy chain** (`PrioritySettingsRecord.Policies`, ordered, first match wins):
- Each rule: optional **Target** (same All/Any/None shape as discount targeting — roles + user ids), optional **hours-to-departure interval** `[Min, Max)`, effect **Allow** (optional `FeeOverride`) or **Deny**
- No matching rule → existing behavior (AccessTarget, else allowlist/AllowAll); SGT window still gates everything
- Examples: *boosting closes inside 48h* = allow(min=48) + deny(); *VIPs anytime, others only outside 6h* = allow(target=vip) + deny(max=6)

**Per-timeslot slot cap** (`SlotCap`): max queued priority bookings per direction+date+time — buyers get predictable odds. Full slot ⇒ prioritize rejected ("priority queue is full"), eligibility reports `slotsLeft`.

**API**:
- `POST priority/settings` accepts `policies[]` + `slotCap` (validated: non-empty interval, fee bounds, no FeeOverride on deny)
- New `GET Booking/{id}/priority/eligibility` — booking-scoped: hour policies evaluated against the timeslot's departure, returns `slotCap`/`slotsLeft`
- Generic `GET priority/eligibility` unchanged shape + new nullable fields (hour-bounded rules are skipped without a booking in scope)

**Migration**: `Policies` (jsonb) + `SlotCap` (int, null) on PrioritySettings — additive, existing rows keep behaving exactly as before.

## Testing

- `PriorityPolicyTests` (new): chain ordering, role+hours mixing, half-open bounds, fee override, null-hours semantics, window gating
- `BookingServicePrioritizeTests`: slot-cap full/under/uncapped guard behavior (no money moves on rejection)
- Full suite: **520 passed / 0 failed**; `dotnet format style` clean on touched files