### PR TITLE
feat(booking): unify priority queue into one policy chain

### DIFF
--- a/App/Migrations/20260713215244_UnifyPriorityPolicies.Designer.cs
+++ b/App/Migrations/20260713215244_UnifyPriorityPolicies.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using App.StartUp.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace App.Migrations
 {
     [DbContext(typeof(MainDbContext))]
-    partial class MainDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260713215244_UnifyPriorityPolicies")]
+    partial class UnifyPriorityPolicies
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/App/Migrations/20260713215244_UnifyPriorityPolicies.cs
+++ b/App/Migrations/20260713215244_UnifyPriorityPolicies.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace App.Migrations
+{
+    /// <inheritdoc />
+    public partial class UnifyPriorityPolicies : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/App/Modules/Bookings/API/V1/BookingController.cs
+++ b/App/Modules/Bookings/API/V1/BookingController.cs
@@ -577,9 +577,7 @@ public class BookingController(
   [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("priority/settings")]
   public async Task<ActionResult<PrioritySettingsRes>> GetPrioritySettings()
   {
-    var x = await prioritySettingsRepo
-      .GetCurrent()
-      .Then(s => (s?.Record ?? PrioritySettingsRecord.Default).ToRes(), Errors.MapNone);
+    var x = await prioritySettingsRepo.GetCurrent().Then(s => s.ToRes(), Errors.MapNone);
     return this.ReturnResult(x);
   }
 

--- a/App/Modules/Bookings/API/V1/BookingMapper.cs
+++ b/App/Modules/Bookings/API/V1/BookingMapper.cs
@@ -269,44 +269,29 @@ public static class BookingMapper
 
   // Priority queue (target shapes reuse the Discounts API mapper)
   public static PrioritySettingsRes ToRes(this PrioritySettingsRecord r) =>
-    new(
-      r.Fee,
-      r.AllowAll,
-      r.WindowStartSgt?.ToStandardTimeFormat(),
-      r.WindowEndSgt?.ToStandardTimeFormat(),
-      r.FreeTarget?.ToRes(),
-      r.AccessTarget?.ToRes(),
-      r.Policies.Select(p => p.ToRes()).ToList(),
-      r.SlotCap
-    );
+    new(r.Policies.Select(p => p.ToRes()).ToList());
 
   public static PriorityPolicyRes ToRes(this PriorityPolicyRecord p) =>
     new(
       p.Name,
       p.Allow,
       p.Target?.ToRes(),
+      p.WindowStartSgt?.ToStandardTimeFormat(),
+      p.WindowEndSgt?.ToStandardTimeFormat(),
       p.MinHoursToDeparture,
       p.MaxHoursToDeparture,
-      p.FeeOverride
+      p.FeeKind == PriorityFeeKind.Percent ? "Percent" : "Flat",
+      p.FeeValue,
+      p.SlotCap
     );
 
   public static PriorityAccessRes ToRes(this PriorityAccess a) => new(a.UserId, a.CreatedAt);
 
   public static PriorityEligibilityRes ToRes(this PriorityEligibility e) =>
-    new(e.Eligible, e.Fee, e.Free, e.SlotCap, e.SlotsLeft);
+    new(e.Eligible, e.Fee, e.Free, e.SlotCap, e.SlotsLeft, e.PolicyName);
 
   public static PrioritySettingsRecord ToDomain(this SetPrioritySettingsReq req) =>
-    new()
-    {
-      Fee = req.Fee,
-      AllowAll = req.AllowAll,
-      WindowStartSgt = req.WindowStartSgt?.ToTime(),
-      WindowEndSgt = req.WindowEndSgt?.ToTime(),
-      FreeTarget = req.FreeTarget?.ToDomain(),
-      AccessTarget = req.AccessTarget?.ToDomain(),
-      Policies = req.Policies?.Select(p => p.ToDomain()).ToList() ?? [],
-      SlotCap = req.SlotCap,
-    };
+    new() { Policies = req.Policies.Select(p => p.ToDomain()).ToList() };
 
   public static PriorityPolicyRecord ToDomain(this PriorityPolicyReq req) =>
     new()
@@ -314,8 +299,12 @@ public static class BookingMapper
       Name = req.Name,
       Allow = req.Allow,
       Target = req.Target?.ToDomain(),
+      WindowStartSgt = req.WindowStartSgt?.ToTime(),
+      WindowEndSgt = req.WindowEndSgt?.ToTime(),
       MinHoursToDeparture = req.MinHoursToDeparture,
       MaxHoursToDeparture = req.MaxHoursToDeparture,
-      FeeOverride = req.FeeOverride,
+      FeeKind = req.FeeKind == "Percent" ? PriorityFeeKind.Percent : PriorityFeeKind.Flat,
+      FeeValue = req.FeeValue,
+      SlotCap = req.SlotCap,
     };
 }

--- a/App/Modules/Bookings/API/V1/BookingModel.cs
+++ b/App/Modules/Bookings/API/V1/BookingModel.cs
@@ -258,67 +258,57 @@ public record BookingStatRes(
 
 // Priority queue
 
-// REQ: replace the priority settings (insert-only latest, like Cost).
-// Window times are SGT HH:mm:ss; both null = always available; start > end
-// wraps midnight. Fee 0 disables charging (prioritizing stays free).
-// FreeTarget/AccessTarget use the SAME shape as the Discounts API targets:
-// FreeTarget = who boosts free (fee 0, no ledger row); AccessTarget = who may
-// prioritize at all — when set it takes precedence over AllowAll/the
-// allowlist; null keeps legacy behavior.
-public record SetPrioritySettingsReq(
-  decimal Fee,
-  bool AllowAll,
-  string? WindowStartSgt,
-  string? WindowEndSgt,
-  DiscountTargetReq? FreeTarget = null,
-  DiscountTargetReq? AccessTarget = null,
-  List<PriorityPolicyReq>? Policies = null,
-  int? SlotCap = null
-);
+// REQ: replace the priority settings (insert-only latest, like Cost). THE
+// unified system — one ordered policy list, first matching rule decides;
+// an empty list means nobody may prioritize.
+public record SetPrioritySettingsReq(List<PriorityPolicyReq> Policies);
 
-// One rule in the ordered policy chain (evaluated before AccessTarget/
-// AllowAll, first match wins): applies when Target matches (null = everyone)
-// AND hours-to-departure is inside [Min, Max) (null = unbounded); decides
-// Allow (optionally at FeeOverride) or deny.
+// One rule. Conditions (unset = wildcard): Target (discount-target shape),
+// SGT wall-clock window (HH:mm:ss, may wrap midnight, both bounds or
+// neither), hours-to-departure interval [Min, Max). Decision for Allow
+// rules: FeeKind "Flat" (SGD) or "Percent" (of the booking's charged ticket
+// amount) with FeeValue (0 = free), and an optional per-timeslot SlotCap.
 public record PriorityPolicyReq(
   string Name,
   bool Allow,
   DiscountTargetReq? Target = null,
+  string? WindowStartSgt = null,
+  string? WindowEndSgt = null,
   decimal? MinHoursToDeparture = null,
   decimal? MaxHoursToDeparture = null,
-  decimal? FeeOverride = null
+  string FeeKind = "Flat",
+  decimal FeeValue = 0,
+  int? SlotCap = null
 );
 
 // RESP
-public record PrioritySettingsRes(
-  decimal Fee,
-  bool AllowAll,
-  string? WindowStartSgt,
-  string? WindowEndSgt,
-  DiscountTargetRes? FreeTarget,
-  DiscountTargetRes? AccessTarget,
-  List<PriorityPolicyRes> Policies,
-  int? SlotCap
-);
+public record PrioritySettingsRes(List<PriorityPolicyRes> Policies);
 
 public record PriorityPolicyRes(
   string Name,
   bool Allow,
   DiscountTargetRes? Target,
+  string? WindowStartSgt,
+  string? WindowEndSgt,
   decimal? MinHoursToDeparture,
   decimal? MaxHoursToDeparture,
-  decimal? FeeOverride
+  string FeeKind,
+  decimal FeeValue,
+  int? SlotCap
 );
 
 public record PriorityAccessRes(string UserId, DateTime CreatedAt);
 
-// may the calling user prioritize right now, at what fee, and free for them
-// (Free => Fee is 0). SlotCap/SlotsLeft only on the booking-scoped endpoint
-// (and SlotCap configured); null otherwise.
+// may the calling user prioritize right now, at what fee (null when a
+// percent fee cannot be computed without a booking in scope), and free for
+// them (Free => Fee is 0). SlotCap/SlotsLeft only when the matched rule caps
+// the timeslot (SlotsLeft needs a booking in scope). PolicyName = the rule
+// that decided.
 public record PriorityEligibilityRes(
   bool Eligible,
-  decimal Fee,
+  decimal? Fee,
   bool Free,
   int? SlotCap = null,
-  int? SlotsLeft = null
+  int? SlotsLeft = null,
+  string? PolicyName = null
 );

--- a/App/Modules/Bookings/API/V1/BookingValidator.cs
+++ b/App/Modules/Bookings/API/V1/BookingValidator.cs
@@ -156,31 +156,8 @@ public class SetPrioritySettingsReqValidator : AbstractValidator<SetPrioritySett
 {
   public SetPrioritySettingsReqValidator()
   {
-    this.RuleFor(x => x.Fee)
-      .GreaterThanOrEqualTo(0)
-      .LessThanOrEqualTo(10_000)
-      .WithMessage("Fee must be between 0 and 10000");
-    this.RuleFor(x => x.WindowStartSgt).NullableTimeValid();
-    this.RuleFor(x => x.WindowEndSgt).NullableTimeValid();
-    // a half-open window needs both bounds; a lone bound is ambiguous
-    this.RuleFor(x => x.WindowEndSgt)
-      .Must((req, x) => (x == null) == (req.WindowStartSgt == null))
-      .WithMessage("WindowStartSgt and WindowEndSgt must be set together (or both omitted)");
-    // targets reuse the Discounts API shapes and validation; null = omitted
-    this.RuleFor(x => x.FreeTarget)!
-      .SetValidator(new DiscountTargetReqValidator()!)
-      .When(x => x.FreeTarget != null);
-    this.RuleFor(x => x.AccessTarget)!
-      .SetValidator(new DiscountTargetReqValidator()!)
-      .When(x => x.AccessTarget != null);
-    this.RuleFor(x => x.SlotCap)
-      .GreaterThanOrEqualTo(1)
-      .LessThanOrEqualTo(10_000)
-      .When(x => x.SlotCap != null)
-      .WithMessage("SlotCap must be between 1 and 10000");
-    this.RuleForEach(x => x.Policies)
-      .SetValidator(new PriorityPolicyReqValidator())
-      .When(x => x.Policies != null);
+    this.RuleFor(x => x.Policies).NotNull();
+    this.RuleForEach(x => x.Policies).SetValidator(new PriorityPolicyReqValidator());
   }
 }
 
@@ -192,6 +169,12 @@ public class PriorityPolicyReqValidator : AbstractValidator<PriorityPolicyReq>
     this.RuleFor(x => x.Target)!
       .SetValidator(new DiscountTargetReqValidator()!)
       .When(x => x.Target != null);
+    this.RuleFor(x => x.WindowStartSgt).NullableTimeValid();
+    this.RuleFor(x => x.WindowEndSgt).NullableTimeValid();
+    // a half-open window needs both bounds; a lone bound is ambiguous
+    this.RuleFor(x => x.WindowEndSgt)
+      .Must((req, x) => (x == null) == (req.WindowStartSgt == null))
+      .WithMessage("WindowStartSgt and WindowEndSgt must be set together (or both omitted)");
     this.RuleFor(x => x.MinHoursToDeparture)
       .GreaterThanOrEqualTo(0)
       .When(x => x.MinHoursToDeparture != null)
@@ -206,14 +189,31 @@ public class PriorityPolicyReqValidator : AbstractValidator<PriorityPolicyReq>
         (req, max) => max == null || req.MinHoursToDeparture == null || max > req.MinHoursToDeparture
       )
       .WithMessage("MaxHoursToDeparture must be greater than MinHoursToDeparture");
-    this.RuleFor(x => x.FeeOverride)
+    this.RuleFor(x => x.FeeKind)
+      .Must(k => k is "Flat" or "Percent")
+      .WithMessage("FeeKind must be 'Flat' or 'Percent'");
+    this.RuleFor(x => x.FeeValue)
       .GreaterThanOrEqualTo(0)
+      .WithMessage("FeeValue must be >= 0");
+    this.RuleFor(x => x.FeeValue)
       .LessThanOrEqualTo(10_000)
-      .When(x => x.FeeOverride != null)
-      .WithMessage("FeeOverride must be between 0 and 10000");
-    // FeeOverride on a deny rule is dead configuration — surface the mistake
-    this.RuleFor(x => x.FeeOverride)
-      .Must((req, fee) => fee == null || req.Allow)
-      .WithMessage("FeeOverride only applies to Allow rules");
+      .When(x => x.FeeKind == "Flat")
+      .WithMessage("A flat fee must be at most 10000");
+    this.RuleFor(x => x.FeeValue)
+      .LessThanOrEqualTo(100)
+      .When(x => x.FeeKind == "Percent")
+      .WithMessage("A percent fee must be at most 100");
+    this.RuleFor(x => x.SlotCap)
+      .GreaterThanOrEqualTo(1)
+      .LessThanOrEqualTo(10_000)
+      .When(x => x.SlotCap != null)
+      .WithMessage("SlotCap must be between 1 and 10000");
+    // fee/cap on a deny rule is dead configuration — surface the mistake
+    this.RuleFor(x => x.FeeValue)
+      .Must((req, fee) => req.Allow || fee == 0)
+      .WithMessage("Only Allow rules may charge a fee");
+    this.RuleFor(x => x.SlotCap)
+      .Must((req, cap) => req.Allow || cap == null)
+      .WithMessage("Only Allow rules may set a SlotCap");
   }
 }

--- a/App/Modules/Bookings/Data/PriorityData.cs
+++ b/App/Modules/Bookings/Data/PriorityData.cs
@@ -4,43 +4,40 @@ using Microsoft.EntityFrameworkCore;
 
 namespace App.Modules.Bookings.Data;
 
-// Insert-only priority-queue settings (newest CreatedAt wins, like Costs);
-// with no row the domain defaults apply (fee 10, allowlist-only, no window)
+// Insert-only priority-queue settings (newest CreatedAt wins, like Costs).
+// Post-unification only Policies matters ('[]' = explicit "nobody boosts");
+// Policies IS NULL marks a pre-unification row whose legacy columns below
+// (fee/allow-all/window/targets + the allowlist table) are synthesized into
+// equivalent rules on read.
 public class PrioritySettingsData
 {
   public Guid Id { get; set; }
 
   public DateTime CreatedAt { get; set; }
 
-  // Record
+  // the unified ordered policy chain (owned JSON list)
+  public List<PriorityPolicyData>? Policies { get; set; }
+
+  // ---- LEGACY (pre-unification) — never written anymore, read only to
+  // synthesize rules for old rows ----
   [Precision(16, 8)]
   public decimal Fee { get; set; }
 
-  // true = every user may prioritize; false = allowlisted users only
   public bool AllowAll { get; set; }
 
-  // SGT wall-clock availability window [start, end); both null = always
   public TimeOnly? WindowStartSgt { get; set; }
 
   public TimeOnly? WindowEndSgt { get; set; }
 
-  // Who gets the boost FREE — owned JSON blob, same shape and storage
-  // convention as DiscountData.Target; null = nobody is free
   public DiscountTargetData? FreeTarget { get; set; }
 
-  // Who MAY prioritize at all — when set it takes precedence over
-  // AllowAll/PriorityAccessData; null = legacy behavior unchanged
   public DiscountTargetData? AccessTarget { get; set; }
 
-  // Ordered policy chain (see Domain.Booking.PriorityPolicyRecord) — owned
-  // JSON list; NULL/empty = no policies, legacy gate only
-  public List<PriorityPolicyData>? Policies { get; set; }
-
-  // Max priority bookings per timeslot; NULL = uncapped
   public int? SlotCap { get; set; }
 }
 
-// One policy rule inside PrioritySettingsData.Policies (owned JSON)
+// One rule inside PrioritySettingsData.Policies (owned JSON). Shape mirrors
+// Domain.Booking.PriorityPolicyRecord.
 public class PriorityPolicyData
 {
   public string Name { get; set; } = string.Empty;
@@ -49,14 +46,24 @@ public class PriorityPolicyData
 
   public DiscountTargetData? Target { get; set; }
 
+  public TimeOnly? WindowStartSgt { get; set; }
+
+  public TimeOnly? WindowEndSgt { get; set; }
+
   public decimal? MinHoursToDeparture { get; set; }
 
   public decimal? MaxHoursToDeparture { get; set; }
 
-  public decimal? FeeOverride { get; set; }
+  // "Flat" | "Percent"
+  public string FeeKind { get; set; } = "Flat";
+
+  public decimal FeeValue { get; set; }
+
+  public int? SlotCap { get; set; }
 }
 
-// A user allowed to prioritize bookings (when AllowAll is off)
+// A user allowed to prioritize bookings — LEGACY: read only when
+// synthesizing rules for pre-unification settings rows
 public class PriorityAccessData
 {
   [Key]

--- a/App/Modules/Bookings/Data/PriorityRepository.cs
+++ b/App/Modules/Bookings/Data/PriorityRepository.cs
@@ -3,6 +3,7 @@ using App.StartUp.Database;
 using App.Utility;
 using CSharp_Result;
 using Domain.Booking;
+using Domain.Discount;
 using Microsoft.EntityFrameworkCore;
 
 namespace App.Modules.Bookings.Data;
@@ -12,7 +13,7 @@ public class PrioritySettingsRepository(
   ILogger<PrioritySettingsRepository> logger
 ) : IPrioritySettingsRepository
 {
-  public async Task<Result<PrioritySettingsPrincipal?>> GetCurrent()
+  public async Task<Result<PrioritySettingsRecord>> GetCurrent()
   {
     try
     {
@@ -20,7 +21,21 @@ public class PrioritySettingsRepository(
         .PrioritySettings.OrderByDescending(x => x.CreatedAt)
         .ThenByDescending(x => x.Id)
         .FirstOrDefaultAsync();
-      return r?.ToPrincipal();
+
+      // unified row: '[]' is a legitimate "nobody boosts" configuration
+      if (r?.Policies != null)
+        return new PrioritySettingsRecord
+        {
+          Policies = r.Policies.Select(p => p.ToRecord()).ToList(),
+        };
+
+      // pre-unification row (or none at all): synthesize equivalent rules
+      // from the legacy fields + the allowlist so behavior is unchanged
+      var allowlist = await db.PriorityAccesses.Select(x => x.UserId).ToArrayAsync();
+      return new PrioritySettingsRecord
+      {
+        Policies = PriorityDataMapper.SynthesizeLegacy(r, allowlist),
+      };
     }
     catch (Exception e)
     {
@@ -38,7 +53,12 @@ public class PrioritySettingsRepository(
       data.UpdateData(record);
       var r = db.PrioritySettings.Add(data);
       await db.SaveChangesAsync();
-      return r.Entity.ToPrincipal();
+      return new PrioritySettingsPrincipal
+      {
+        Id = r.Entity.Id,
+        CreatedAt = r.Entity.CreatedAt,
+        Record = record,
+      };
     }
     catch (Exception e)
     {
@@ -128,57 +148,99 @@ public class PriorityAccessRepository(MainDbContext db, ILogger<PriorityAccessRe
 public static class PriorityDataMapper
 {
   // Data -> Domain
-  public static PrioritySettingsRecord ToRecord(this PrioritySettingsData data) =>
-    new()
-    {
-      Fee = data.Fee,
-      AllowAll = data.AllowAll,
-      WindowStartSgt = data.WindowStartSgt,
-      WindowEndSgt = data.WindowEndSgt,
-      FreeTarget = data.FreeTarget?.ToTarget(),
-      AccessTarget = data.AccessTarget?.ToTarget(),
-      Policies = data.Policies?.Select(p => p.ToRecord()).ToList() ?? [],
-      SlotCap = data.SlotCap,
-    };
-
   public static PriorityPolicyRecord ToRecord(this PriorityPolicyData data) =>
     new()
     {
       Name = data.Name,
       Allow = data.Allow,
       Target = data.Target?.ToTarget(),
+      WindowStartSgt = data.WindowStartSgt,
+      WindowEndSgt = data.WindowEndSgt,
       MinHoursToDeparture = data.MinHoursToDeparture,
       MaxHoursToDeparture = data.MaxHoursToDeparture,
-      FeeOverride = data.FeeOverride,
+      FeeKind = data.FeeKind == "Percent" ? PriorityFeeKind.Percent : PriorityFeeKind.Flat,
+      FeeValue = data.FeeValue,
+      SlotCap = data.SlotCap,
     };
 
-  public static PrioritySettingsPrincipal ToPrincipal(this PrioritySettingsData data) =>
-    new()
-    {
-      Id = data.Id,
-      CreatedAt = data.CreatedAt,
-      Record = data.ToRecord(),
-    };
+  // Pre-unification rows -> equivalent unified rules, so old configuration
+  // keeps behaving identically: the free target boosts at no charge, then
+  // whoever had access (access target, else allow-all, else the allowlist)
+  // pays the flat legacy fee; both inherit the legacy window and slot cap.
+  // No settings row at all = the legacy defaults (fee 10, allowlist-only).
+  public static List<PriorityPolicyRecord> SynthesizeLegacy(
+    PrioritySettingsData? data,
+    IReadOnlyList<string> allowlist
+  )
+  {
+    var fee = data?.Fee ?? 10m;
+    var allowAll = data?.AllowAll ?? false;
+    var start = data?.WindowStartSgt;
+    var end = data?.WindowEndSgt;
+    var cap = data?.SlotCap;
+    var rules = new List<PriorityPolicyRecord>();
+
+    if (data?.FreeTarget != null)
+      rules.Add(
+        new PriorityPolicyRecord
+        {
+          Name = "Legacy: free boost",
+          Allow = true,
+          Target = data.FreeTarget.ToTarget(),
+          WindowStartSgt = start,
+          WindowEndSgt = end,
+          FeeKind = PriorityFeeKind.Flat,
+          FeeValue = 0m,
+          SlotCap = cap,
+        }
+      );
+
+    var accessTarget = data?.AccessTarget != null
+      ? data.AccessTarget.ToTarget()
+      : allowAll
+        ? null
+        : allowlist.Count > 0
+          ? new DiscountTarget
+          {
+            MatchMode = DiscountMatchMode.Any,
+            Matches = allowlist
+              .Select(u => new DiscountMatch { Type = DiscountMatchType.UserId, Value = u })
+              .ToList(),
+          }
+          : null;
+
+    // allow-all and access-target rows always get an access rule; a pure
+    // allowlist row only when somebody is actually allowlisted
+    if (data?.AccessTarget != null || allowAll || allowlist.Count > 0)
+      rules.Add(
+        new PriorityPolicyRecord
+        {
+          Name = "Legacy: access",
+          Allow = true,
+          Target = accessTarget,
+          WindowStartSgt = start,
+          WindowEndSgt = end,
+          FeeKind = PriorityFeeKind.Flat,
+          FeeValue = fee,
+          SlotCap = cap,
+        }
+      );
+
+    return rules;
+  }
 
   public static PriorityAccess ToDomain(this PriorityAccessData data) =>
     new() { UserId = data.UserId, CreatedAt = data.CreatedAt };
 
-  // Domain -> Data
+  // Domain -> Data: unified rows persist ONLY the policy list ('[]' when the
+  // admin explicitly cleared it); the legacy columns are left at defaults and
+  // never consulted for rows that carry a non-null Policies value
   public static PrioritySettingsData UpdateData(
     this PrioritySettingsData data,
     PrioritySettingsRecord record
   )
   {
-    data.Fee = record.Fee;
-    data.AllowAll = record.AllowAll;
-    data.WindowStartSgt = record.WindowStartSgt;
-    data.WindowEndSgt = record.WindowEndSgt;
-    data.FreeTarget = record.FreeTarget?.ToData();
-    data.AccessTarget = record.AccessTarget?.ToData();
-    data.Policies = record.Policies.Count == 0
-      ? null
-      : record.Policies.Select(p => p.ToData()).ToList();
-    data.SlotCap = record.SlotCap;
+    data.Policies = record.Policies.Select(p => p.ToData()).ToList();
     return data;
   }
 
@@ -188,8 +250,12 @@ public static class PriorityDataMapper
       Name = record.Name,
       Allow = record.Allow,
       Target = record.Target?.ToData(),
+      WindowStartSgt = record.WindowStartSgt,
+      WindowEndSgt = record.WindowEndSgt,
       MinHoursToDeparture = record.MinHoursToDeparture,
       MaxHoursToDeparture = record.MaxHoursToDeparture,
-      FeeOverride = record.FeeOverride,
+      FeeKind = record.FeeKind == PriorityFeeKind.Percent ? "Percent" : "Flat",
+      FeeValue = record.FeeValue,
+      SlotCap = record.SlotCap,
     };
 }

--- a/Domain/Booking/Priority.cs
+++ b/Domain/Booking/Priority.cs
@@ -3,64 +3,36 @@ using Domain.Discount;
 
 namespace Domain.Booking;
 
-// Admin-editable priority-queue settings (insert-only, newest row wins —
-// same pattern as Cost). With no row the defaults apply.
+// THE priority-queue configuration: one ordered policy list, nothing else.
+// Rules are evaluated top to bottom; the FIRST rule whose conditions all
+// match decides everything (access, fee, slot cap); no matching rule = deny.
+// Insert-only storage, newest row wins (same pattern as Cost). Rows written
+// before unification are synthesized into equivalent rules by the data layer,
+// so legacy fee/allow-all/allowlist/target/window settings keep behaving
+// identically until an admin saves the new shape.
 public record PrioritySettingsRecord
 {
-  public required decimal Fee { get; init; }
+  public required IReadOnlyList<PriorityPolicyRecord> Policies { get; init; }
 
-  // true = every user may prioritize; false = allowlisted users only
-  public required bool AllowAll { get; init; }
-
-  // SGT wall-clock window [WindowStartSgt, WindowEndSgt) in which
-  // prioritizing is available; null = always available. May wrap midnight
-  // (start > end).
-  public required TimeOnly? WindowStartSgt { get; init; }
-
-  public required TimeOnly? WindowEndSgt { get; init; }
-
-  // Who gets the priority boost FREE (fee 0, no ledger row) — matched against
-  // the user's id and PRICING roles (JWT roles ∪ admin-granted ExtraRoles,
-  // the same union discount targeting prices with). null = nobody is free.
-  // Same shape and semantics as discount targeting (All/Any/None).
-  public DiscountTarget? FreeTarget { get; init; }
-
-  // Who MAY use priority at all — richer replacement for AllowAll + the
-  // allowlist. When set it takes PRECEDENCE over AllowAll/PriorityAccessData;
-  // null = legacy behavior (allowlisted OR AllowAll) unchanged.
-  public DiscountTarget? AccessTarget { get; init; }
-
-  // Ordered policy chain evaluated BEFORE AccessTarget/AllowAll: the first
-  // rule whose conditions all match decides (see PriorityPolicyRecord); no
-  // matching rule falls through to the legacy gate. Empty = no policies.
-  public IReadOnlyList<PriorityPolicyRecord> Policies { get; init; } = [];
-
-  // Max priority bookings per timeslot (direction+date+time), counted over
-  // the queued statuses; null = uncapped. Gives buyers predictability: a
-  // boost can never be diluted below 1-in-SlotCap odds.
-  public int? SlotCap { get; init; }
-
-  public static readonly PrioritySettingsRecord Default = new()
-  {
-    Fee = 10m,
-    AllowAll = false,
-    WindowStartSgt = null,
-    WindowEndSgt = null,
-    FreeTarget = null,
-    AccessTarget = null,
-    Policies = [],
-    SlotCap = null,
-  };
+  public static readonly PrioritySettingsRecord Default = new() { Policies = [] };
 }
 
-// One rule in the ordered priority policy chain. A rule APPLIES when every
-// set condition matches (unset = wildcard): Target (same shape as discount
-// targeting, matched against the user's id and pricing roles) and the
-// hours-to-departure interval [Min, Max). The first applying rule decides:
-// Allow (optionally at FeeOverride instead of the base fee) or deny.
-// Examples — "boosting only opens inside 48h": deny rule with Min=48;
-// "VIPs may boost anytime, everyone else only outside 6h": allow rule with
-// Target=vip, then deny rule with Max=6.
+public enum PriorityFeeKind
+{
+  // FeeValue is SGD
+  Flat,
+
+  // FeeValue is a percentage of the booking's charged ticket amount
+  Percent,
+}
+
+// One rule. Conditions (all unset conditions are wildcards):
+// - Target: who (user ids / roles, the discount-target matcher)
+// - WindowStartSgt/WindowEndSgt: SGT wall-clock window (may wrap midnight)
+// - Min/MaxHoursToDeparture: hours until the timeslot departs, [Min, Max)
+// Decision (Allow rules only):
+// - FeeKind/FeeValue: what to charge (flat SGD or % of ticket; 0 = free)
+// - SlotCap: max queued priority bookings in the timeslot (null = uncapped)
 public record PriorityPolicyRecord
 {
   public required string Name { get; init; }
@@ -69,50 +41,42 @@ public record PriorityPolicyRecord
 
   public DiscountTarget? Target { get; init; }
 
+  public TimeOnly? WindowStartSgt { get; init; }
+
+  public TimeOnly? WindowEndSgt { get; init; }
+
   public decimal? MinHoursToDeparture { get; init; }
 
   public decimal? MaxHoursToDeparture { get; init; }
 
-  // Allow rules only: charge this instead of the base fee (FreeTarget still
-  // wins and makes the boost free)
-  public decimal? FeeOverride { get; init; }
+  public PriorityFeeKind FeeKind { get; init; } = PriorityFeeKind.Flat;
+
+  public decimal FeeValue { get; init; }
+
+  public int? SlotCap { get; init; }
 }
 
-public record PrioritySettingsPrincipal
-{
-  public required Guid Id { get; init; }
-
-  public required DateTime CreatedAt { get; init; }
-
-  public required PrioritySettingsRecord Record { get; init; }
-}
-
-// A user allowed to prioritize bookings (when AllowAll is off)
-public record PriorityAccess
-{
-  public required string UserId { get; init; }
-
-  public required DateTime CreatedAt { get; init; }
-}
-
-// What the eligibility endpoint (and the prioritize guard) answers: may this
-// user prioritize right now, at what fee, and whether the boost is free for
-// them (Free => Fee is 0). SlotCap/SlotsLeft are only known when the check
-// is scoped to a booking (its timeslot); null otherwise or when uncapped.
+// What the eligibility endpoints (and the prioritize guard) answer. Fee is
+// null when it cannot be known yet (a percent rule matched without a booking
+// in scope) — never null when Eligible on the booking-scoped path. SlotCap/
+// SlotsLeft only when the matched rule caps the timeslot and a booking is in
+// scope. PolicyName = the matched rule, for admin debugging.
 public record PriorityEligibility
 {
   public required bool Eligible { get; init; }
 
-  public required decimal Fee { get; init; }
+  public required decimal? Fee { get; init; }
 
   public required bool Free { get; init; }
 
   public int? SlotCap { get; init; }
 
   public int? SlotsLeft { get; init; }
+
+  public string? PolicyName { get; init; }
 }
 
-// Pure eligibility rules, shared by the endpoint, the prioritize guard and
+// Pure rule evaluation, shared by the endpoints, the prioritize guard and
 // the unit tests
 public static class PriorityRules
 {
@@ -129,44 +93,23 @@ public static class PriorityRules
       : nowSgt >= start.Value || nowSgt < end.Value;
   }
 
-  // May this user prioritize: AccessTarget (when configured) REPLACES the
-  // legacy allowlist/AllowAll gate; otherwise legacy semantics apply. The SGT
-  // availability window gates both paths.
-  public static bool Eligible(
-    bool allowlisted,
-    PrioritySettingsRecord settings,
-    TimeOnly nowSgt,
-    string userId = "",
-    string[]? roles = null
-  )
-  {
-    var access =
-      settings.AccessTarget != null
-        ? Discount.TargetMatcher.Matches(settings.AccessTarget, userId, roles ?? [])
-        : allowlisted || settings.AllowAll;
-    return access && WindowOpen(settings.WindowStartSgt, settings.WindowEndSgt, nowSgt);
-  }
-
-  // Full evaluation: the SGT window gates everything; then the policy chain
-  // runs first-match-wins; no matching rule falls through to Eligible()'s
-  // legacy gate. hoursToDeparture = null means "no booking in scope" (the
-  // generic eligibility endpoint) — hour-bounded rules are then SKIPPED, so
-  // the generic answer only reflects rules that hold for every timeslot.
-  public static (bool Eligible, decimal Fee) Decide(
-    bool allowlisted,
-    PrioritySettingsRecord settings,
+  // The first rule whose conditions all match, or null (= deny).
+  // hoursToDeparture = null means "no booking in scope" (the generic
+  // eligibility endpoint) — hour-bounded rules are then SKIPPED, so the
+  // generic answer only reflects rules that hold for every timeslot.
+  public static PriorityPolicyRecord? Match(
+    IReadOnlyList<PriorityPolicyRecord> policies,
     TimeOnly nowSgt,
     decimal? hoursToDeparture,
     string userId,
     string[] roles
   )
   {
-    if (!WindowOpen(settings.WindowStartSgt, settings.WindowEndSgt, nowSgt))
-      return (false, settings.Fee);
-
-    foreach (var p in settings.Policies)
+    foreach (var p in policies)
     {
-      if (p.Target != null && !Discount.TargetMatcher.Matches(p.Target, userId, roles))
+      if (!WindowOpen(p.WindowStartSgt, p.WindowEndSgt, nowSgt))
+        continue;
+      if (p.Target != null && !TargetMatcher.Matches(p.Target, userId, roles))
         continue;
       if (p.MinHoursToDeparture != null || p.MaxHoursToDeparture != null)
       {
@@ -177,25 +120,56 @@ public static class PriorityRules
         if (p.MaxHoursToDeparture != null && hoursToDeparture >= p.MaxHoursToDeparture)
           continue;
       }
-      return (p.Allow, p.Allow ? p.FeeOverride ?? settings.Fee : settings.Fee);
+      return p;
     }
-
-    return (Eligible(allowlisted, settings, nowSgt, userId, roles), settings.Fee);
+    return null;
   }
 
-  // Is the boost free for this user: FreeTarget matched against the user's
-  // id and pricing roles; no target = never free
-  public static bool Free(PrioritySettingsRecord settings, string userId, string[] roles) =>
-    settings.FreeTarget != null
-    && Discount.TargetMatcher.Matches(settings.FreeTarget, userId, roles);
+  // The fee an Allow rule charges: flat = the value itself; percent = that
+  // share of the booking's charged ticket amount (null when no booking is in
+  // scope yet), rounded to cents
+  public static decimal? Fee(PriorityPolicyRecord rule, decimal? ticketAmount) =>
+    rule.FeeKind switch
+    {
+      PriorityFeeKind.Flat => rule.FeeValue,
+      PriorityFeeKind.Percent => ticketAmount == null
+        ? null
+        : Math.Round(
+          rule.FeeValue / 100m * Math.Abs(ticketAmount.Value),
+          2,
+          MidpointRounding.AwayFromZero
+        ),
+      _ => null,
+    };
 }
 
 public interface IPrioritySettingsRepository
 {
-  // the newest settings row, or null when none was ever written (defaults apply)
-  Task<Result<PrioritySettingsPrincipal?>> GetCurrent();
+  // the current unified policy list: the newest row's policies, or — for
+  // rows/installations predating unification — rules synthesized from the
+  // legacy fields + allowlist so behavior is unchanged
+  Task<Result<PrioritySettingsRecord>> GetCurrent();
 
   Task<Result<PrioritySettingsPrincipal>> Create(PrioritySettingsRecord record);
+}
+
+public record PrioritySettingsPrincipal
+{
+  public required Guid Id { get; init; }
+
+  public required DateTime CreatedAt { get; init; }
+
+  public required PrioritySettingsRecord Record { get; init; }
+}
+
+// A user allowed to prioritize bookings — LEGACY (pre-unification): consulted
+// only when synthesizing rules from a pre-unification settings row; the
+// endpoints remain for compatibility but the admin UI no longer manages it
+public record PriorityAccess
+{
+  public required string UserId { get; init; }
+
+  public required DateTime CreatedAt { get; init; }
 }
 
 public interface IPriorityAccessRepository

--- a/Domain/Booking/Service.cs
+++ b/Domain/Booking/Service.cs
@@ -1075,7 +1075,7 @@ public class BookingService(
       .Then(
         t =>
         {
-          var match = PriorityRules.Match(t.s.Policies, NowSgt(), null, userId, t.roles);
+          var match = PriorityRules.Match(t.s.Policies, this.NowSgt(), null, userId, t.roles);
           if (match is not { Allow: true })
             return new PriorityEligibility
             {
@@ -1151,17 +1151,19 @@ public class BookingService(
       });
   }
 
-  private static TimeOnly NowSgt()
+  private TimeOnly NowSgt()
   {
     var singapore = TimeZoneInfo.FindSystemTimeZoneById("Singapore");
-    return TimeOnly.FromDateTime(TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, singapore));
+    return TimeOnly.FromDateTime(
+      TimeZoneInfo.ConvertTimeFromUtc(this.Clock.GetUtcNow().UtcDateTime, singapore)
+    );
   }
 
   // hours until the timeslot departs, in SGT (negative once departed)
-  private static decimal HoursToDeparture(BookingRecord r)
+  private decimal HoursToDeparture(BookingRecord r)
   {
     var singapore = TimeZoneInfo.FindSystemTimeZoneById("Singapore");
-    var nowSgt = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, singapore);
+    var nowSgt = TimeZoneInfo.ConvertTimeFromUtc(this.Clock.GetUtcNow().UtcDateTime, singapore);
     return (decimal)(r.Date.ToDateTime(r.Time) - nowSgt).TotalHours;
   }
 
@@ -1177,8 +1179,8 @@ public class BookingService(
     var rec = b.Principal.Record;
     var match = PriorityRules.Match(
       s.Policies,
-      NowSgt(),
-      HoursToDeparture(rec),
+      this.NowSgt(),
+      this.HoursToDeparture(rec),
       b.Principal.UserId,
       roles
     );

--- a/Domain/Booking/Service.cs
+++ b/Domain/Booking/Service.cs
@@ -1054,10 +1054,9 @@ public class BookingService(
       .Then(_ => 0, Errors.MapNone);
   }
 
-  // Eligibility: AccessTarget (when configured) or the legacy allowlist/
-  // AllowAll gate, AND the SGT availability window (when configured) is open
-  // right now. Also carries the fee the user would be charged (0 when the
-  // FreeTarget matches) for pre-submission display.
+  // Eligibility against the unified policy chain: the first rule whose
+  // conditions match decides access, fee (flat or % of the ticket) and the
+  // timeslot's slot cap; no matching rule = deny.
   //
   // Targeting roles = the TARGET user's roles ∪ their admin-granted
   // ExtraRoles, the same union pricing uses (PurchasePricingRoles): when the
@@ -1070,15 +1069,39 @@ public class BookingService(
     string[]? callerTokenRoles = null
   )
   {
-    // no booking in scope: hour-bounded policies are skipped and the slot
-    // cap cannot be counted (SlotsLeft = null)
+    // no booking in scope: hour-bounded rules are skipped, percent fees
+    // cannot be computed (Fee = null) and slot caps cannot be counted
     return this.PriorityContext(userId, callerTokenRoles)
-      .Then(t => Evaluate(t, userId, null, null), Errors.MapNone);
+      .Then(
+        t =>
+        {
+          var match = PriorityRules.Match(t.s.Policies, NowSgt(), null, userId, t.roles);
+          if (match is not { Allow: true })
+            return new PriorityEligibility
+            {
+              Eligible = false,
+              Fee = null,
+              Free = false,
+              PolicyName = match?.Name,
+            };
+          var fee = PriorityRules.Fee(match, null);
+          return new PriorityEligibility
+          {
+            Eligible = true,
+            Fee = fee,
+            Free = fee == 0m,
+            SlotCap = match.SlotCap,
+            PolicyName = match.Name,
+          };
+        },
+        Errors.MapNone
+      );
   }
 
-  // booking-scoped eligibility: hour-bounded policies apply (hours until the
-  // timeslot departs) and the slot cap is counted; null when the booking does
-  // not exist (or is not visible to userId)
+  // booking-scoped eligibility: hour-bounded rules apply (hours until the
+  // timeslot departs), percent fees compute off the booking's charged ticket
+  // amount, and the matched rule's slot cap is counted; null when the booking
+  // does not exist (or is not visible to userId)
   public Task<Result<PriorityEligibility?>> BookingPriorityEligibility(
     string? userId,
     Guid id,
@@ -1091,50 +1114,32 @@ public class BookingService(
         if (b == null)
           return Task.FromResult((Result<PriorityEligibility?>)(PriorityEligibility?)null);
         return this.PriorityContext(b.Principal.UserId, callerTokenRoles)
-          .ThenAwait(t =>
-            this.SlotsLeft(t.s, b.Principal.Record)
-              .Then(slotsLeft => (t, slotsLeft), Errors.MapNone)
-          )
-          .Then(
-            PriorityEligibility? (x) =>
-              Evaluate(x.t, b.Principal.UserId, HoursToDeparture(b.Principal.Record), x.slotsLeft),
-            Errors.MapNone
-          );
+          .ThenAwait(t => this.EvaluateForBooking(t.s, t.roles, b))
+          .Then(PriorityEligibility? (e) => e, Errors.MapNone);
       });
   }
 
-  // settings + allowlist membership + the pricing roles targeting matches on
-  // (JWT roles when the caller is the target, else the persisted mirror)
-  private Task<Result<(PrioritySettingsRecord s, bool allowed, string[] roles)>> PriorityContext(
+  // settings + the pricing roles targeting matches on (JWT roles when the
+  // caller is the target, else the persisted mirror)
+  private Task<Result<(PrioritySettingsRecord s, string[] roles)>> PriorityContext(
     string userId,
     string[]? callerTokenRoles
   )
   {
     return prioritySettingsRepo
       .GetCurrent()
-      .Then(s => s?.Record ?? PrioritySettingsRecord.Default, Errors.MapNone)
       .ThenAwait(s =>
-        priorityAccessRepo.Contains(userId).Then(allowed => (s, allowed), Errors.MapNone)
-      )
-      .ThenAwait(t =>
       {
-        // targets untouched anywhere (base gates or policy rules): skip the
-        // user lookup, roles are never consulted
-        if (
-          t.s.FreeTarget == null
-          && t.s.AccessTarget == null
-          && t.s.Policies.All(p => p.Target == null)
-        )
-          return Task.FromResult(
-            (Result<(PrioritySettingsRecord s, bool allowed, string[] roles)>)(t.s, t.allowed, [])
-          );
+        // no rule targets anyone specific: skip the user lookup, roles are
+        // never consulted
+        if (s.Policies.All(p => p.Target == null))
+          return Task.FromResult((Result<(PrioritySettingsRecord s, string[] roles)>)(s, []));
         return userRepo
           .GetById(userId)
           .Then(
-            (PrioritySettingsRecord s, bool allowed, string[] roles) (u) =>
+            (PrioritySettingsRecord s, string[] roles) (u) =>
               (
-                t.s,
-                t.allowed,
+                s,
                 PurchasePricingRoles.For(
                   callerTokenRoles != null,
                   callerTokenRoles ?? [],
@@ -1146,6 +1151,12 @@ public class BookingService(
       });
   }
 
+  private static TimeOnly NowSgt()
+  {
+    var singapore = TimeZoneInfo.FindSystemTimeZoneById("Singapore");
+    return TimeOnly.FromDateTime(TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, singapore));
+  }
+
   // hours until the timeslot departs, in SGT (negative once departed)
   private static decimal HoursToDeparture(BookingRecord r)
   {
@@ -1154,48 +1165,64 @@ public class BookingService(
     return (decimal)(r.Date.ToDateTime(r.Time) - nowSgt).TotalHours;
   }
 
-  // remaining priority slots in the booking's timeslot; null = uncapped
-  private Task<Result<int?>> SlotsLeft(PrioritySettingsRecord s, BookingRecord r)
-  {
-    if (s.SlotCap == null)
-      return Task.FromResult((Result<int?>)(int?)null);
-    return repo.CountSlotPriority(r.Direction, r.Date, r.Time)
-      .Then(int? (c) => Math.Max(0, s.SlotCap.Value - c), Errors.MapNone);
-  }
-
-  // the single evaluation path shared by both eligibility flavors and the
-  // prioritize guard: policy chain (Decide), free targeting, slot cap
-  private static PriorityEligibility Evaluate(
-    (PrioritySettingsRecord s, bool allowed, string[] roles) t,
-    string userId,
-    decimal? hoursToDeparture,
-    int? slotsLeft
+  // the single booking-scoped evaluation shared by the eligibility endpoint
+  // and the prioritize guard: match the chain, price the fee off the
+  // booking's charged ticket amount, count the matched rule's slot cap
+  private Task<Result<PriorityEligibility>> EvaluateForBooking(
+    PrioritySettingsRecord s,
+    string[] roles,
+    Booking b
   )
   {
-    var singapore = TimeZoneInfo.FindSystemTimeZoneById("Singapore");
-    var nowSgt = TimeOnly.FromDateTime(
-      TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, singapore)
+    var rec = b.Principal.Record;
+    var match = PriorityRules.Match(
+      s.Policies,
+      NowSgt(),
+      HoursToDeparture(rec),
+      b.Principal.UserId,
+      roles
     );
-    var free = PriorityRules.Free(t.s, userId, t.roles);
-    var (eligible, fee) = PriorityRules.Decide(
-      t.allowed,
-      t.s,
-      nowSgt,
-      hoursToDeparture,
-      userId,
-      t.roles
-    );
-    // a full priority queue blocks everyone, however eligible otherwise
-    if (slotsLeft == 0)
-      eligible = false;
-    return new PriorityEligibility
-    {
-      Eligible = eligible,
-      Fee = free ? 0m : fee,
-      Free = free,
-      SlotCap = t.s.SlotCap,
-      SlotsLeft = slotsLeft,
-    };
+    if (match is not { Allow: true })
+      return Task.FromResult(
+        (Result<PriorityEligibility>)new PriorityEligibility
+        {
+          Eligible = false,
+          Fee = null,
+          Free = false,
+          PolicyName = match?.Name,
+        }
+      );
+
+    var fee = PriorityRules.Fee(match, Math.Abs(b.Transaction.Record.Amount));
+    if (match.SlotCap == null)
+      return Task.FromResult(
+        (Result<PriorityEligibility>)new PriorityEligibility
+        {
+          Eligible = true,
+          Fee = fee,
+          Free = fee == 0m,
+          PolicyName = match.Name,
+        }
+      );
+
+    return repo.CountSlotPriority(rec.Direction, rec.Date, rec.Time)
+      .Then(
+        c =>
+        {
+          var slotsLeft = Math.Max(0, match.SlotCap.Value - c);
+          return new PriorityEligibility
+          {
+            // a full priority queue blocks everyone, however eligible
+            Eligible = slotsLeft > 0,
+            Fee = fee,
+            Free = fee == 0m,
+            SlotCap = match.SlotCap,
+            SlotsLeft = slotsLeft,
+            PolicyName = match.Name,
+          };
+        },
+        Errors.MapNone
+      );
   }
 
   // Moves a booking to the front of its timeslot's purchase queue. Guarded
@@ -1238,24 +1265,15 @@ public class BookingService(
             // persisted Roles mirror is used) and the per-timeslot slot cap
             .ThenAwait(b =>
               this.PriorityContext(b.Principal.UserId, null)
-                .ThenAwait(t =>
-                  this.SlotsLeft(t.s, b.Principal.Record)
-                    .Then(slotsLeft => (t, slotsLeft), Errors.MapNone)
-                )
-                .ThenAwait(x =>
+                .ThenAwait(t => this.EvaluateForBooking(t.s, t.roles, b))
+                .ThenAwait(e =>
                 {
-                  var e = Evaluate(
-                    x.t,
-                    b.Principal.UserId,
-                    HoursToDeparture(b.Principal.Record),
-                    x.slotsLeft
-                  );
                   if (e.Eligible)
                     return Task.FromResult((Result<(Booking b, PriorityEligibility e)>)(b, e));
                   var r = new InvalidBookingOperationException(
-                    x.slotsLeft == 0
+                    e.SlotsLeft == 0
                       ? "Prioritize requires a free priority slot — this timeslot's priority queue is full"
-                      : "Prioritize requires the booking's owner to be eligible (priority policies/allowlist, within the availability window)",
+                      : "Prioritize requires a priority policy that allows the booking's owner right now",
                     b.Principal.Status.Status,
                     BookingOperations.Prioritize
                   );
@@ -1264,18 +1282,19 @@ public class BookingService(
             )
             // collect the fee from Usable + ledger row (a zero or free fee
             // books neither — a "SGD 0.00 charged" row would contradict the
-            // fee being disabled/waived)
+            // fee being disabled/waived). On the booking-scoped path an
+            // eligible answer always carries a concrete fee.
             .DoAwait(
               DoType.MapErrors,
               t =>
                 t.e.Fee > 0
                   ? walletRepo
-                    .Collect(t.b.Wallet.Id, t.e.Fee)
+                    .Collect(t.b.Wallet.Id, t.e.Fee.Value)
                     .NullToError(t.b.Wallet.Id.ToString())
                     .ThenAwait(_ =>
                       transactionRepo.Create(
                         t.b.Wallet.Id,
-                        transactionGenerator.PriorityFeeCharge(t.e.Fee, t.b.Principal.Record)
+                        transactionGenerator.PriorityFeeCharge(t.e.Fee.Value, t.b.Principal.Record)
                       )
                     )
                     .Then(_ => 0, Errors.MapNone)

--- a/UnitTest/Bookings/BookingMapperTests.cs
+++ b/UnitTest/Bookings/BookingMapperTests.cs
@@ -48,55 +48,65 @@ public class BookingMapperTests
     ((int)BookStatus.RequireManualIntervention).Should().Be(8);
   }
 
-  // ---- priority settings targets: API <-> domain round trip ----
+  // ---- priority policies: API <-> domain round trip ----
 
   [Fact]
-  public void Priority_settings_targets_round_trip_through_req_and_res()
+  public void Priority_policies_round_trip_through_req_and_res()
   {
     var req = new SetPrioritySettingsReq(
-      Fee: 5m,
-      AllowAll: false,
-      WindowStartSgt: null,
-      WindowEndSgt: null,
-      FreeTarget: new App.Modules.Discounts.API.V1.DiscountTargetReq(
-        "Any",
-        [new App.Modules.Discounts.API.V1.DiscountMatchReq("admin", "Role")]
-      ),
-      AccessTarget: new App.Modules.Discounts.API.V1.DiscountTargetReq(
-        "All",
-        [new App.Modules.Discounts.API.V1.DiscountMatchReq("u1", "UserId")]
-      )
+      [
+        new PriorityPolicyReq(
+          Name: "vip anytime",
+          Allow: true,
+          Target: new App.Modules.Discounts.API.V1.DiscountTargetReq(
+            "Any",
+            [new App.Modules.Discounts.API.V1.DiscountMatchReq("vip", "Role")]
+          ),
+          WindowStartSgt: "14:00:00",
+          WindowEndSgt: "16:00:00",
+          MinHoursToDeparture: 6m,
+          MaxHoursToDeparture: 48m,
+          FeeKind: "Percent",
+          FeeValue: 12.5m,
+          SlotCap: 3
+        ),
+        new PriorityPolicyReq(Name: "deny rest", Allow: false),
+      ]
     );
 
     var domain = req.ToDomain();
-    domain.FreeTarget.Should().NotBeNull();
-    domain.FreeTarget!.MatchMode.Should().Be(Domain.Discount.DiscountMatchMode.Any);
-    domain.FreeTarget.Matches.Should().ContainSingle(m =>
-      m.Type == Domain.Discount.DiscountMatchType.Role && m.Value == "admin"
+    domain.Policies.Should().HaveCount(2);
+    var vip = domain.Policies[0];
+    vip.Allow.Should().BeTrue();
+    vip.Target!.MatchMode.Should().Be(Domain.Discount.DiscountMatchMode.Any);
+    vip.Target.Matches.Should().ContainSingle(m =>
+      m.Type == Domain.Discount.DiscountMatchType.Role && m.Value == "vip"
     );
-    domain.AccessTarget!.MatchMode.Should().Be(Domain.Discount.DiscountMatchMode.All);
+    vip.WindowStartSgt.Should().Be(new TimeOnly(14, 0));
+    vip.WindowEndSgt.Should().Be(new TimeOnly(16, 0));
+    vip.MinHoursToDeparture.Should().Be(6m);
+    vip.MaxHoursToDeparture.Should().Be(48m);
+    vip.FeeKind.Should().Be(PriorityFeeKind.Percent);
+    vip.FeeValue.Should().Be(12.5m);
+    vip.SlotCap.Should().Be(3);
+    domain.Policies[1].Allow.Should().BeFalse();
+    domain.Policies[1].Target.Should().BeNull();
 
     var res = domain.ToRes();
-    res.FreeTarget!.MatchMode.Should().Be("Any");
-    res.FreeTarget.Matches.Should().ContainSingle(m =>
-      m.MatchType == "Role" && m.Value == "admin"
-    );
-    res.AccessTarget!.MatchMode.Should().Be("All");
-    res.AccessTarget.Matches.Should().ContainSingle(m =>
-      m.MatchType == "UserId" && m.Value == "u1"
-    );
+    res.Policies.Should().HaveCount(2);
+    res.Policies[0].FeeKind.Should().Be("Percent");
+    res.Policies[0].WindowStartSgt.Should().Be("14:00:00");
+    res.Policies[0].Target!.MatchMode.Should().Be("Any");
+    res.Policies[0].SlotCap.Should().Be(3);
+    res.Policies[1].Allow.Should().BeFalse();
   }
 
   [Fact]
-  public void Priority_settings_null_targets_stay_null_in_both_directions()
+  public void Priority_policies_empty_list_round_trips_empty()
   {
-    var req = new SetPrioritySettingsReq(10m, true, null, null);
+    var req = new SetPrioritySettingsReq([]);
     var domain = req.ToDomain();
-    domain.FreeTarget.Should().BeNull();
-    domain.AccessTarget.Should().BeNull();
-
-    var res = domain.ToRes();
-    res.FreeTarget.Should().BeNull();
-    res.AccessTarget.Should().BeNull();
+    domain.Policies.Should().BeEmpty();
+    domain.ToRes().Policies.Should().BeEmpty();
   }
 }

--- a/UnitTest/Bookings/BookingServicePrioritizeTests.cs
+++ b/UnitTest/Bookings/BookingServicePrioritizeTests.cs
@@ -127,13 +127,39 @@ public class BookingServicePrioritizeTests
     };
   }
 
+  // ---- policy helpers (the unified system: one ordered rule list) ----
+
+  private static PriorityPolicyRecord Allow(
+    decimal fee = Fee,
+    PriorityFeeKind kind = PriorityFeeKind.Flat,
+    Domain.Discount.DiscountTarget? target = null,
+    int? slotCap = null,
+    TimeOnly? winStart = null,
+    TimeOnly? winEnd = null,
+    string name = "allow"
+  ) =>
+    new()
+    {
+      Name = name,
+      Allow = true,
+      Target = target,
+      FeeKind = kind,
+      FeeValue = fee,
+      SlotCap = slotCap,
+      WindowStartSgt = winStart,
+      WindowEndSgt = winEnd,
+    };
+
+  private static PrioritySettingsRecord Rules(params PriorityPolicyRecord[] policies) =>
+    new() { Policies = policies };
+
   // ---- Prioritize ----
 
   [Fact]
   public async Task Prioritize_pending_eligible_collects_fee_and_books_the_ledger()
   {
     var b = BookingWith(BookStatus.Pending);
-    var (service, repo, wallet, txn) = Make(b, allowlisted: true);
+    var (service, repo, wallet, txn) = Make(b, Rules(Allow()));
 
     var result = await service.Prioritize("user-1", b.Principal.Id);
 
@@ -154,7 +180,7 @@ public class BookingServicePrioritizeTests
   public async Task Self_boost_is_never_attributed_to_a_granter()
   {
     var b = BookingWith(BookStatus.Pending);
-    var (service, repo, _, _) = Make(b, allowlisted: true);
+    var (service, repo, _, _) = Make(b, Rules(Allow()));
 
     // the caller IS the owner — no admin attribution
     var result = await service.Prioritize("user-1", b.Principal.Id, callerSub: "user-1");
@@ -167,7 +193,7 @@ public class BookingServicePrioritizeTests
   public async Task Admin_boosting_someone_elses_booking_is_attributed()
   {
     var b = BookingWith(BookStatus.Pending);
-    var (service, repo, _, _) = Make(b, allowlisted: true);
+    var (service, repo, _, _) = Make(b, Rules(Allow()));
 
     // an admin (userId = null bypasses ownership) boosts user-1's booking
     var result = await service.Prioritize(null, b.Principal.Id, callerSub: "admin-9");
@@ -180,7 +206,7 @@ public class BookingServicePrioritizeTests
   public async Task Legacy_callers_without_a_sub_stay_unattributed()
   {
     var b = BookingWith(BookStatus.Pending);
-    var (service, repo, _, _) = Make(b, allowlisted: true);
+    var (service, repo, _, _) = Make(b, Rules(Allow()));
 
     var result = await service.Prioritize("user-1", b.Principal.Id);
 
@@ -200,7 +226,7 @@ public class BookingServicePrioritizeTests
   public async Task Prioritize_non_pending_is_rejected_and_moves_no_money(BookStatus status)
   {
     var b = BookingWith(status);
-    var (service, repo, wallet, txn) = Make(b, allowlisted: true);
+    var (service, repo, wallet, txn) = Make(b, Rules(Allow()));
 
     var result = await service.Prioritize("user-1", b.Principal.Id);
 
@@ -215,7 +241,7 @@ public class BookingServicePrioritizeTests
   public async Task Prioritize_already_priority_is_rejected_and_never_double_charges()
   {
     var b = BookingWith(BookStatus.Pending, priority: true, priorityFee: Fee);
-    var (service, repo, wallet, txn) = Make(b, allowlisted: true);
+    var (service, repo, wallet, txn) = Make(b, Rules(Allow()));
 
     var result = await service.Prioritize("user-1", b.Principal.Id);
 
@@ -230,7 +256,7 @@ public class BookingServicePrioritizeTests
   public async Task Prioritize_ineligible_owner_is_rejected_and_moves_no_money()
   {
     var b = BookingWith(BookStatus.Pending);
-    var (service, repo, wallet, txn) = Make(b, allowlisted: false);
+    var (service, repo, wallet, txn) = Make(b);
 
     var result = await service.Prioritize("user-1", b.Principal.Id);
 
@@ -245,8 +271,8 @@ public class BookingServicePrioritizeTests
   public async Task Prioritize_allowed_via_allow_all()
   {
     var b = BookingWith(BookStatus.Pending);
-    var settings = PrioritySettingsRecord.Default with { AllowAll = true };
-    var (service, repo, wallet, _) = Make(b, settings, allowlisted: false);
+    var settings = Rules(Allow());
+    var (service, repo, wallet, _) = Make(b, settings);
 
     var result = await service.Prioritize("user-1", b.Principal.Id);
 
@@ -259,7 +285,7 @@ public class BookingServicePrioritizeTests
   public async Task Prioritize_full_slot_cap_is_rejected_and_moves_no_money()
   {
     var b = BookingWith(BookStatus.Pending);
-    var settings = PrioritySettingsRecord.Default with { AllowAll = true, SlotCap = 2 };
+    var settings = Rules(Allow(slotCap: 2));
     var (service, repo, wallet, txn) = Make(b, settings);
     repo.SlotPriorityCount = 2;
 
@@ -275,7 +301,7 @@ public class BookingServicePrioritizeTests
   public async Task Prioritize_under_the_slot_cap_succeeds()
   {
     var b = BookingWith(BookStatus.Pending);
-    var settings = PrioritySettingsRecord.Default with { AllowAll = true, SlotCap = 2 };
+    var settings = Rules(Allow(slotCap: 2));
     var (service, repo, wallet, _) = Make(b, settings);
     repo.SlotPriorityCount = 1;
 
@@ -290,7 +316,7 @@ public class BookingServicePrioritizeTests
   public async Task Prioritize_uncapped_ignores_the_slot_count()
   {
     var b = BookingWith(BookStatus.Pending);
-    var settings = PrioritySettingsRecord.Default with { AllowAll = true, SlotCap = null };
+    var settings = Rules(Allow(slotCap: null));
     var (service, repo, _, _) = Make(b, settings);
     repo.SlotPriorityCount = 500;
 
@@ -308,12 +334,7 @@ public class BookingServicePrioritizeTests
     // the rules, so crossing midnight is fine)
     var nowSgt = TimeOnly.FromDateTime(DateTime.UtcNow.AddHours(8));
     var b = BookingWith(BookStatus.Pending);
-    var settings = PrioritySettingsRecord.Default with
-    {
-      AllowAll = true,
-      WindowStartSgt = nowSgt.AddHours(1),
-      WindowEndSgt = nowSgt.AddHours(2),
-    };
+    var settings = Rules(Allow(winStart: nowSgt.AddHours(1), winEnd: nowSgt.AddHours(2)));
     var (service, _, wallet, txn) = Make(b, settings);
 
     var result = await service.Prioritize("user-1", b.Principal.Id);
@@ -342,7 +363,7 @@ public class BookingServicePrioritizeTests
   public async Task Prioritize_with_insufficient_balance_fails_and_never_flags_the_booking()
   {
     var b = BookingWith(BookStatus.Pending);
-    var (service, repo, wallet, txn) = Make(b, allowlisted: true, walletInsufficient: true);
+    var (service, repo, wallet, txn) = Make(b, Rules(Allow()), walletInsufficient: true);
 
     var result = await service.Prioritize("user-1", b.Principal.Id);
 
@@ -356,7 +377,7 @@ public class BookingServicePrioritizeTests
   public async Task Prioritize_with_zero_fee_flags_without_wallet_or_ledger()
   {
     var b = BookingWith(BookStatus.Pending);
-    var settings = PrioritySettingsRecord.Default with { Fee = 0m, AllowAll = true };
+    var settings = Rules(Allow(fee: 0m));
     var (service, repo, wallet, txn) = Make(b, settings);
 
     var result = await service.Prioritize("user-1", b.Principal.Id);
@@ -365,13 +386,44 @@ public class BookingServicePrioritizeTests
     wallet.CollectCalls.Should().Be(0, "a zero fee moves no money");
     txn.Records.Should().BeEmpty("a 'SGD 0.00 charged' ledger row would be noise");
     repo.PrioritizeCalls.Should().Be(1);
-    repo.LastPrioritizeFee.Should().Be(0m);
+    repo.LastPrioritizeFee.Should().BeNull("a zero fee IS free — nothing charged, nothing to refund");
+  }
+
+  [Fact]
+  public async Task Prioritize_percent_fee_charges_share_of_the_ticket()
+  {
+    var b = BookingWith(BookStatus.Pending);
+    // 25% of the SGD 16 ticket = SGD 4
+    var settings = Rules(Allow(fee: 25m, kind: PriorityFeeKind.Percent));
+    var (service, repo, wallet, txn) = Make(b, settings);
+
+    var result = await service.Prioritize("user-1", b.Principal.Id);
+
+    result.IsSuccess().Should().BeTrue();
+    wallet.CollectCalls.Should().Be(1);
+    wallet.LastCollectAmount.Should().Be(4m);
+    txn.Records.Should().ContainSingle(r => r.Type == TransactionType.PriorityFee);
+    txn.Records[0].Amount.Should().Be(4m);
+    repo.LastPrioritizeFee.Should().Be(4m, "the concrete charged amount is snapshotted");
+  }
+
+  [Fact]
+  public async Task Prioritize_with_no_policies_denies_everyone()
+  {
+    var b = BookingWith(BookStatus.Pending);
+    var (service, repo, wallet, _) = Make(b, Rules());
+
+    var result = await service.Prioritize("user-1", b.Principal.Id);
+
+    result.IsSuccess().Should().BeFalse("an empty chain means nobody may prioritize");
+    wallet.CollectCalls.Should().Be(0);
+    repo.PrioritizeCalls.Should().Be(0);
   }
 
   [Fact]
   public async Task PriorityEligibility_reports_fee_and_defaults()
   {
-    var (service, _, _, _) = Make(null, allowlisted: true);
+    var (service, _, _, _) = Make(null, Rules(Allow()));
 
     var result = await service.PriorityEligibility("user-1");
 
@@ -397,11 +449,7 @@ public class BookingServicePrioritizeTests
   public async Task Prioritize_free_target_match_charges_nothing_and_snapshots_null()
   {
     var b = BookingWith(BookStatus.Pending);
-    var settings = PrioritySettingsRecord.Default with
-    {
-      AllowAll = true,
-      FreeTarget = RoleTarget("admin"),
-    };
+    var settings = Rules(Allow(fee: 0m, target: RoleTarget("admin"), name: "free"), Allow());
     // owner's persisted roles carry admin — matched via the Roles mirror
     var (service, repo, wallet, txn) = Make(
       b,
@@ -422,11 +470,7 @@ public class BookingServicePrioritizeTests
   public async Task Prioritize_free_via_extra_roles_union()
   {
     var b = BookingWith(BookStatus.Pending);
-    var settings = PrioritySettingsRecord.Default with
-    {
-      AllowAll = true,
-      FreeTarget = RoleTarget("vip"),
-    };
+    var settings = Rules(Allow(fee: 0m, target: RoleTarget("vip"), name: "free"), Allow());
     // the role lives in admin-granted ExtraRoles, not the JWT mirror — the
     // union must still match, exactly like pricing
     var (service, repo, wallet, _) = Make(
@@ -446,11 +490,7 @@ public class BookingServicePrioritizeTests
   public async Task Prioritize_free_target_miss_charges_the_fee()
   {
     var b = BookingWith(BookStatus.Pending);
-    var settings = PrioritySettingsRecord.Default with
-    {
-      AllowAll = true,
-      FreeTarget = RoleTarget("admin"),
-    };
+    var settings = Rules(Allow(fee: 0m, target: RoleTarget("admin"), name: "free"), Allow());
     var (service, repo, wallet, txn) = Make(
       b,
       settings,
@@ -484,11 +524,7 @@ public class BookingServicePrioritizeTests
   [Fact]
   public async Task PriorityEligibility_reports_free_and_zero_fee_for_free_target_match()
   {
-    var settings = PrioritySettingsRecord.Default with
-    {
-      AllowAll = true,
-      FreeTarget = RoleTarget("admin"),
-    };
+    var settings = Rules(Allow(fee: 0m, target: RoleTarget("admin"), name: "free"), Allow());
     var (service, _, _, _) = Make(
       null,
       settings,
@@ -506,11 +542,7 @@ public class BookingServicePrioritizeTests
   [Fact]
   public async Task PriorityEligibility_caller_jwt_roles_are_authoritative_for_self()
   {
-    var settings = PrioritySettingsRecord.Default with
-    {
-      AllowAll = true,
-      FreeTarget = RoleTarget("admin"),
-    };
+    var settings = Rules(Allow(fee: 0m, target: RoleTarget("admin"), name: "free"), Allow());
     // persisted mirror has NO admin role, but the caller's own JWT does —
     // JWT wins for self-eligibility (∪ ExtraRoles still applies)
     var (service, _, _, _) = Make(
@@ -528,40 +560,33 @@ public class BookingServicePrioritizeTests
   // ---- access target (service flow) ----
 
   [Fact]
-  public async Task Prioritize_access_target_overrides_allowlist()
+  public async Task Prioritize_targeted_rule_refuses_non_matching_user()
   {
     var b = BookingWith(BookStatus.Pending);
-    var settings = PrioritySettingsRecord.Default with
-    {
-      AccessTarget = RoleTarget("vip"),
-    };
-    // allowlisted, but the access target does not match: refused
+    var settings = Rules(Allow(target: RoleTarget("vip")));
+    // the only rule targets vip and this user is not one: refused (the
+    // legacy allowlist is no longer consulted)
     var (service, repo, wallet, _) = Make(
       b,
       settings,
-      allowlisted: true,
       user: new UserRecord { Username = "tester", Roles = [] }
     );
 
     var result = await service.Prioritize("user-1", b.Principal.Id);
 
-    result.IsSuccess().Should().BeFalse("the access target replaces the allowlist");
+    result.IsSuccess().Should().BeFalse("no rule admits this user");
     wallet.CollectCalls.Should().Be(0);
     repo.PrioritizeCalls.Should().Be(0);
   }
 
   [Fact]
-  public async Task Prioritize_access_target_admits_matching_user_without_allowlist()
+  public async Task Prioritize_targeted_rule_admits_matching_user()
   {
     var b = BookingWith(BookStatus.Pending);
-    var settings = PrioritySettingsRecord.Default with
-    {
-      AccessTarget = RoleTarget("vip"),
-    };
+    var settings = Rules(Allow(target: RoleTarget("vip")));
     var (service, repo, wallet, _) = Make(
       b,
       settings,
-      allowlisted: false,
       user: new UserRecord { Username = "tester", Roles = ["vip"] }
     );
 
@@ -749,19 +774,8 @@ public class BookingServicePrioritizeTests
   private sealed class FakePrioritySettingsRepository(PrioritySettingsRecord? settings)
     : IPrioritySettingsRepository
   {
-    public Task<Result<PrioritySettingsPrincipal?>> GetCurrent() =>
-      Task.FromResult(
-        (Result<PrioritySettingsPrincipal?>)(
-          settings == null
-            ? null
-            : new PrioritySettingsPrincipal
-            {
-              Id = Guid.NewGuid(),
-              CreatedAt = DateTime.UtcNow,
-              Record = settings,
-            }
-        )
-      );
+    public Task<Result<PrioritySettingsRecord>> GetCurrent() =>
+      Task.FromResult((Result<PrioritySettingsRecord>)(settings ?? PrioritySettingsRecord.Default));
 
     public Task<Result<PrioritySettingsPrincipal>> Create(PrioritySettingsRecord record) =>
       throw new NotImplementedException();

--- a/UnitTest/Bookings/PriorityPolicyTests.cs
+++ b/UnitTest/Bookings/PriorityPolicyTests.cs
@@ -4,9 +4,9 @@ using FluentAssertions;
 
 namespace UnitTest.Bookings;
 
-// The policy chain (PriorityRules.Decide): first matching rule wins, target
-// and hours-to-departure conditions, fee overrides, fallback to the legacy
-// gate, and the null-hours (no booking in scope) semantics
+// The unified chain (PriorityRules.Match/Fee): first matching rule wins,
+// target / clock-window / hours conditions, flat vs percent fees, and the
+// null-hours (no booking in scope) semantics
 public class PriorityPolicyTests
 {
   private static readonly TimeOnly Noon = new(12, 0);
@@ -23,137 +23,127 @@ public class PriorityPolicyTests
     DiscountTarget? target = null,
     decimal? minHours = null,
     decimal? maxHours = null,
-    decimal? feeOverride = null
+    TimeOnly? winStart = null,
+    TimeOnly? winEnd = null,
+    PriorityFeeKind kind = PriorityFeeKind.Flat,
+    decimal fee = 10m,
+    int? slotCap = null,
+    string name = "rule"
   ) =>
     new()
     {
-      Name = "rule",
+      Name = name,
       Allow = allow,
       Target = target,
       MinHoursToDeparture = minHours,
       MaxHoursToDeparture = maxHours,
-      FeeOverride = feeOverride,
-    };
-
-  private static PrioritySettingsRecord Settings(
-    bool allowAll = false,
-    IReadOnlyList<PriorityPolicyRecord>? policies = null,
-    TimeOnly? start = null,
-    TimeOnly? end = null
-  ) =>
-    new()
-    {
-      Fee = 10m,
-      AllowAll = allowAll,
-      WindowStartSgt = start,
-      WindowEndSgt = end,
-      Policies = policies ?? [],
+      WindowStartSgt = winStart,
+      WindowEndSgt = winEnd,
+      FeeKind = kind,
+      FeeValue = fee,
+      SlotCap = slotCap,
     };
 
   [Fact]
-  public void No_policies_falls_back_to_legacy_gate()
+  public void Empty_chain_matches_nothing()
   {
-    PriorityRules.Decide(false, Settings(), Noon, 24m, "u1", []).Eligible.Should().BeFalse();
-    PriorityRules
-      .Decide(false, Settings(allowAll: true), Noon, 24m, "u1", [])
-      .Eligible.Should()
-      .BeTrue();
-    PriorityRules.Decide(true, Settings(), Noon, 24m, "u1", []).Eligible.Should().BeTrue();
-  }
-
-  [Fact]
-  public void Deny_inside_min_hours_blocks_even_allow_all()
-  {
-    // "boosting closes once the departure is under 48h away":
-    // allow when >= 48h, deny everyone else
-    var s = Settings(
-      allowAll: true,
-      policies: [Rule(allow: true, minHours: 48m), Rule(allow: false)]
-    );
-
-    PriorityRules.Decide(false, s, Noon, 72m, "u1", []).Eligible.Should().BeTrue();
-    PriorityRules.Decide(false, s, Noon, 12m, "u1", []).Eligible.Should().BeFalse();
-  }
-
-  [Fact]
-  public void Role_rule_mixes_with_hours()
-  {
-    // VIPs boost anytime; everyone else only outside 6h
-    var s = Settings(
-      allowAll: true,
-      policies: [Rule(allow: true, target: Role("vip")), Rule(allow: false, maxHours: 6m)]
-    );
-
-    PriorityRules.Decide(false, s, Noon, 2m, "u1", ["vip"]).Eligible.Should().BeTrue();
-    PriorityRules.Decide(false, s, Noon, 2m, "u1", ["pleb"]).Eligible.Should().BeFalse();
-    // outside 6h the deny rule no longer applies -> legacy gate (allowAll)
-    PriorityRules.Decide(false, s, Noon, 7m, "u1", ["pleb"]).Eligible.Should().BeTrue();
+    PriorityRules.Match([], Noon, 24m, "u1", ["vip"]).Should().BeNull();
   }
 
   [Fact]
   public void First_matching_rule_wins()
   {
-    var s = Settings(
-      allowAll: false,
-      policies: [Rule(allow: true, target: Role("vip")), Rule(allow: false, target: Role("vip"))]
-    );
+    var chain = new[]
+    {
+      Rule(allow: true, target: Role("vip"), name: "first"),
+      Rule(allow: false, target: Role("vip"), name: "second"),
+    };
 
-    PriorityRules.Decide(false, s, Noon, 24m, "u1", ["vip"]).Eligible.Should().BeTrue();
+    PriorityRules.Match(chain, Noon, 24m, "u1", ["vip"])!.Name.Should().Be("first");
   }
 
   [Fact]
-  public void Allow_rule_fee_override_applies_and_deny_keeps_base_fee()
+  public void Deny_inside_the_last_hours_blocks_a_broader_allow()
   {
-    var s = Settings(
-      allowAll: false,
-      policies: [Rule(allow: true, minHours: 48m, feeOverride: 25m)]
-    );
+    // "boosting closes once departure is under 6h away"
+    var chain = new[] { Rule(allow: false, maxHours: 6m), Rule(allow: true) };
 
-    var far = PriorityRules.Decide(false, s, Noon, 72m, "u1", []);
-    far.Eligible.Should().BeTrue();
-    far.Fee.Should().Be(25m);
+    PriorityRules.Match(chain, Noon, 2m, "u1", [])!.Allow.Should().BeFalse();
+    PriorityRules.Match(chain, Noon, 7m, "u1", [])!.Allow.Should().BeTrue();
+  }
 
-    // no rule matches near departure -> legacy gate at the base fee
-    var near = PriorityRules.Decide(false, s, Noon, 12m, "u1", []);
-    near.Eligible.Should().BeFalse();
-    near.Fee.Should().Be(10m);
+  [Fact]
+  public void Role_rules_mix_with_hours()
+  {
+    // VIPs anytime; everyone else only outside 48h
+    var chain = new[]
+    {
+      Rule(allow: true, target: Role("vip"), fee: 0m),
+      Rule(allow: true, minHours: 48m),
+    };
+
+    PriorityRules.Match(chain, Noon, 2m, "u1", ["vip"]).Should().NotBeNull();
+    PriorityRules.Match(chain, Noon, 2m, "u1", []).Should().BeNull();
+    PriorityRules.Match(chain, Noon, 72m, "u1", []).Should().NotBeNull();
   }
 
   [Fact]
   public void Hour_bounds_are_half_open()
   {
-    var s = Settings(policies: [Rule(allow: true, minHours: 24m, maxHours: 48m)]);
+    var chain = new[] { Rule(allow: true, minHours: 24m, maxHours: 48m) };
 
-    PriorityRules.Decide(false, s, Noon, 24m, "u1", []).Eligible.Should().BeTrue("min inclusive");
+    PriorityRules.Match(chain, Noon, 24m, "u1", []).Should().NotBeNull("min inclusive");
+    PriorityRules.Match(chain, Noon, 48m, "u1", []).Should().BeNull("max exclusive");
+  }
+
+  [Fact]
+  public void Clock_window_gates_the_rule_it_is_on()
+  {
+    var chain = new[]
+    {
+      Rule(allow: true, winStart: new TimeOnly(14, 0), winEnd: new TimeOnly(16, 0)),
+      Rule(allow: false),
+    };
+
+    PriorityRules.Match(chain, Noon, 24m, "u1", [])!.Allow.Should().BeFalse("window closed");
     PriorityRules
-      .Decide(false, s, Noon, 48m, "u1", [])
-      .Eligible.Should()
-      .BeFalse("max exclusive");
+      .Match(chain, new TimeOnly(15, 0), 24m, "u1", [])!
+      .Allow.Should()
+      .BeTrue("window open");
   }
 
   [Fact]
   public void Null_hours_skips_hour_bounded_rules_but_applies_unbounded_ones()
   {
-    var s = Settings(
-      allowAll: true,
-      policies: [Rule(allow: false, maxHours: 6m), Rule(allow: false, target: Role("banned"))]
-    );
+    var chain = new[] { Rule(allow: false, maxHours: 6m), Rule(allow: true) };
 
-    // the hour-bounded deny cannot be evaluated without a booking; the
-    // role-bound one can
-    PriorityRules.Decide(false, s, Noon, null, "u1", []).Eligible.Should().BeTrue();
-    PriorityRules.Decide(false, s, Noon, null, "u1", ["banned"]).Eligible.Should().BeFalse();
+    // without a booking in scope the 6h deny cannot be evaluated
+    PriorityRules.Match(chain, Noon, null, "u1", [])!.Allow.Should().BeTrue();
   }
 
   [Fact]
-  public void Closed_window_blocks_before_any_policy_runs()
+  public void Flat_fee_is_the_value_itself()
   {
-    var s = Settings(
-      policies: [Rule(allow: true)],
-      start: new TimeOnly(0, 0),
-      end: new TimeOnly(1, 0)
-    );
+    PriorityRules.Fee(Rule(allow: true, fee: 12.5m), null).Should().Be(12.5m);
+    PriorityRules.Fee(Rule(allow: true, fee: 12.5m), 100m).Should().Be(12.5m);
+  }
 
-    PriorityRules.Decide(true, s, Noon, 24m, "u1", []).Eligible.Should().BeFalse();
+  [Fact]
+  public void Percent_fee_is_a_share_of_the_ticket_rounded_to_cents()
+  {
+    var rule = Rule(allow: true, kind: PriorityFeeKind.Percent, fee: 12.5m);
+
+    PriorityRules.Fee(rule, 45m).Should().Be(5.63m, "12.5% of 45 = 5.625 -> 5.63");
+    PriorityRules.Fee(rule, null).Should().BeNull("unknowable without a booking in scope");
+  }
+
+  [Fact]
+  public void Zero_fee_means_free()
+  {
+    PriorityRules.Fee(Rule(allow: true, fee: 0m), null).Should().Be(0m);
+    PriorityRules
+      .Fee(Rule(allow: true, kind: PriorityFeeKind.Percent, fee: 0m), 45m)
+      .Should()
+      .Be(0m);
   }
 }

--- a/UnitTest/Bookings/PriorityRulesTests.cs
+++ b/UnitTest/Bookings/PriorityRulesTests.cs
@@ -3,101 +3,48 @@ using FluentAssertions;
 
 namespace UnitTest.Bookings;
 
-// The pure eligibility rules: (allowlisted OR AllowAll) AND the SGT
-// availability window (half-open, wrap-around midnight supported)
+// The SGT wall-clock window primitive used by policy rules: half-open
+// [start, end), wrap-around midnight supported, null/equal bounds = always
 public class PriorityRulesTests
 {
-  private static PrioritySettingsRecord Settings(
-    bool allowAll = false,
-    TimeOnly? start = null,
-    TimeOnly? end = null
-  ) =>
-    new()
-    {
-      Fee = 10m,
-      AllowAll = allowAll,
-      WindowStartSgt = start,
-      WindowEndSgt = end,
-    };
-
   private static readonly TimeOnly Noon = new(12, 0);
 
-  // ---- who may prioritize ----
-
   [Fact]
-  public void Not_allowlisted_and_not_allow_all_is_ineligible()
+  public void Null_bounds_are_always_open()
   {
-    PriorityRules.Eligible(false, Settings(), Noon).Should().BeFalse();
+    PriorityRules.WindowOpen(null, null, Noon).Should().BeTrue();
+    PriorityRules.WindowOpen(new TimeOnly(1, 0), null, Noon).Should().BeTrue();
+    PriorityRules.WindowOpen(null, new TimeOnly(1, 0), Noon).Should().BeTrue();
   }
 
   [Fact]
-  public void Allowlisted_user_is_eligible()
+  public void Equal_bounds_mean_all_day_not_never()
   {
-    PriorityRules.Eligible(true, Settings(), Noon).Should().BeTrue();
+    PriorityRules
+      .WindowOpen(new TimeOnly(0, 0), new TimeOnly(0, 0), Noon)
+      .Should()
+      .BeTrue("00:00 -> 00:00 reads as 'all day', not 'never'");
   }
 
   [Fact]
-  public void Allow_all_makes_everyone_eligible()
-  {
-    PriorityRules.Eligible(false, Settings(allowAll: true), Noon).Should().BeTrue();
-  }
-
-  // ---- availability window ----
-
-  [Fact]
-  public void No_window_means_always_available()
-  {
-    PriorityRules.WindowOpen(null, null, new TimeOnly(3, 59)).Should().BeTrue();
-  }
-
-  [Fact]
-  public void Normal_window_is_half_open()
+  public void Plain_window_is_half_open()
   {
     var start = new TimeOnly(9, 0);
     var end = new TimeOnly(17, 0);
-
     PriorityRules.WindowOpen(start, end, new TimeOnly(9, 0)).Should().BeTrue("start inclusive");
     PriorityRules.WindowOpen(start, end, Noon).Should().BeTrue();
     PriorityRules.WindowOpen(start, end, new TimeOnly(17, 0)).Should().BeFalse("end exclusive");
-    PriorityRules.WindowOpen(start, end, new TimeOnly(8, 59)).Should().BeFalse();
-    PriorityRules.WindowOpen(start, end, new TimeOnly(23, 0)).Should().BeFalse();
+    PriorityRules.WindowOpen(start, end, new TimeOnly(3, 0)).Should().BeFalse();
   }
 
   [Fact]
-  public void Wrap_around_midnight_window_covers_both_sides()
+  public void Wrapping_window_crosses_midnight()
   {
     var start = new TimeOnly(22, 0);
     var end = new TimeOnly(2, 0);
-
-    PriorityRules.WindowOpen(start, end, new TimeOnly(23, 30)).Should().BeTrue("before midnight");
-    PriorityRules.WindowOpen(start, end, new TimeOnly(1, 30)).Should().BeTrue("after midnight");
-    PriorityRules.WindowOpen(start, end, new TimeOnly(22, 0)).Should().BeTrue("start inclusive");
+    PriorityRules.WindowOpen(start, end, new TimeOnly(23, 0)).Should().BeTrue();
+    PriorityRules.WindowOpen(start, end, new TimeOnly(1, 0)).Should().BeTrue();
     PriorityRules.WindowOpen(start, end, new TimeOnly(2, 0)).Should().BeFalse("end exclusive");
-    PriorityRules.WindowOpen(start, end, Noon).Should().BeFalse("the gap is closed");
-  }
-
-  [Fact]
-  public void Eligibility_combines_allowlist_and_window()
-  {
-    var inWindow = new TimeOnly(23, 0);
-    var outOfWindow = new TimeOnly(12, 0);
-    var s = Settings(start: new TimeOnly(22, 0), end: new TimeOnly(2, 0));
-
-    PriorityRules.Eligible(true, s, inWindow).Should().BeTrue();
-    PriorityRules.Eligible(true, s, outOfWindow).Should().BeFalse("outside the window");
-    PriorityRules.Eligible(false, s, inWindow).Should().BeFalse("not allowlisted");
-    PriorityRules
-      .Eligible(false, Settings(allowAll: true, start: new TimeOnly(22, 0), end: new TimeOnly(2, 0)), inWindow)
-      .Should()
-      .BeTrue();
-  }
-
-  [Fact]
-  public void Defaults_are_fee_ten_allowlist_only_no_window()
-  {
-    PrioritySettingsRecord.Default.Fee.Should().Be(10m);
-    PrioritySettingsRecord.Default.AllowAll.Should().BeFalse();
-    PrioritySettingsRecord.Default.WindowStartSgt.Should().BeNull();
-    PrioritySettingsRecord.Default.WindowEndSgt.Should().BeNull();
+    PriorityRules.WindowOpen(start, end, Noon).Should().BeFalse();
   }
 }

--- a/UnitTest/Bookings/PriorityTargetingTests.cs
+++ b/UnitTest/Bookings/PriorityTargetingTests.cs
@@ -1,133 +1,116 @@
+using App.Modules.Bookings.Data;
+using App.Modules.Discounts.Data;
 using Domain.Booking;
 using Domain.Discount;
 using FluentAssertions;
 
 namespace UnitTest.Bookings;
 
-// Priority boost targeting: FreeTarget decides who boosts free, AccessTarget
-// (when configured) replaces the legacy allowlist/AllowAll gate. Null targets
-// keep legacy behavior byte-for-byte.
+// Legacy settings rows (pre-unification: fee/allow-all/window/targets +
+// allowlist) must synthesize into unified rules that behave byte-for-byte
+// like the old gates did
 public class PriorityTargetingTests
 {
   private static readonly TimeOnly Noon = new(12, 0);
 
-  private static DiscountTarget Target(DiscountMatchMode mode, params DiscountMatch[] matches) =>
-    new() { MatchMode = mode, Matches = matches };
-
-  private static DiscountMatch Role(string value) =>
-    new() { Type = DiscountMatchType.Role, Value = value };
-
-  private static DiscountMatch UserId(string value) =>
-    new() { Type = DiscountMatchType.UserId, Value = value };
-
-  private static PrioritySettingsRecord Settings(
-    bool allowAll = false,
-    DiscountTarget? free = null,
-    DiscountTarget? access = null,
-    TimeOnly? start = null,
-    TimeOnly? end = null
-  ) =>
-    PrioritySettingsRecord.Default with
+  private static DiscountTargetData RoleTargetData(string role) =>
+    new()
     {
-      AllowAll = allowAll,
-      FreeTarget = free,
-      AccessTarget = access,
-      WindowStartSgt = start,
-      WindowEndSgt = end,
+      MatchMode = "any",
+      Matches = [new DiscountMatchData { Type = "role", Value = role }],
     };
 
-  // ---- FreeTarget: who boosts free ----
+  private static PriorityPolicyRecord? MatchFor(
+    List<PriorityPolicyRecord> rules,
+    string userId,
+    string[] roles
+  ) => PriorityRules.Match(rules, Noon, 24m, userId, roles);
 
   [Fact]
-  public void Null_free_target_means_nobody_is_free()
+  public void No_row_and_empty_allowlist_denies_everyone()
   {
-    PriorityRules.Free(Settings(), "u1", ["admin"]).Should().BeFalse();
+    var rules = PriorityDataMapper.SynthesizeLegacy(null, []);
+    MatchFor(rules, "u1", []).Should().BeNull();
   }
 
   [Fact]
-  public void Free_by_role_match()
+  public void No_row_with_allowlist_admits_exactly_those_users_at_the_default_fee()
   {
-    var s = Settings(free: Target(DiscountMatchMode.Any, Role("admin")));
-    PriorityRules.Free(s, "u1", ["admin"]).Should().BeTrue("admin role boosts free");
-    PriorityRules.Free(s, "u1", ["field"]).Should().BeFalse();
-    PriorityRules.Free(s, "u1", []).Should().BeFalse();
+    var rules = PriorityDataMapper.SynthesizeLegacy(null, ["u1", "u2"]);
+
+    var hit = MatchFor(rules, "u1", []);
+    hit.Should().NotBeNull();
+    hit!.Allow.Should().BeTrue();
+    PriorityRules.Fee(hit, null).Should().Be(10m, "the legacy default fee");
+    MatchFor(rules, "u9", []).Should().BeNull();
   }
 
   [Fact]
-  public void Free_by_user_id_match()
+  public void Allow_all_row_admits_anyone_at_the_row_fee()
   {
-    var s = Settings(free: Target(DiscountMatchMode.Any, UserId("vip-user"), Role("admin")));
-    PriorityRules.Free(s, "vip-user", []).Should().BeTrue("admin-added specific user");
-    PriorityRules.Free(s, "other", []).Should().BeFalse();
+    var data = new PrioritySettingsData { Fee = 15m, AllowAll = true };
+    var rules = PriorityDataMapper.SynthesizeLegacy(data, []);
+
+    var hit = MatchFor(rules, "anyone", []);
+    hit.Should().NotBeNull();
+    PriorityRules.Fee(hit!, null).Should().Be(15m);
   }
 
   [Fact]
-  public void Free_all_mode_requires_every_match()
+  public void Free_target_synthesizes_a_zero_fee_rule_ahead_of_the_access_rule()
   {
-    var s = Settings(free: Target(DiscountMatchMode.All, UserId("u1"), Role("vip")));
-    PriorityRules.Free(s, "u1", ["vip"]).Should().BeTrue();
-    PriorityRules.Free(s, "u1", []).Should().BeFalse();
-    PriorityRules.Free(s, "u2", ["vip"]).Should().BeFalse();
+    var data = new PrioritySettingsData
+    {
+      Fee = 10m,
+      AllowAll = true,
+      FreeTarget = RoleTargetData("vip"),
+    };
+    var rules = PriorityDataMapper.SynthesizeLegacy(data, []);
+
+    var vip = MatchFor(rules, "u1", ["vip"]);
+    PriorityRules.Fee(vip!, null).Should().Be(0m, "free target = free rule");
+    var pleb = MatchFor(rules, "u1", []);
+    PriorityRules.Fee(pleb!, null).Should().Be(10m);
   }
 
   [Fact]
-  public void Free_none_mode_makes_everyone_free()
+  public void Access_target_row_replaces_the_allowlist()
   {
-    var s = Settings(free: Target(DiscountMatchMode.None));
-    PriorityRules.Free(s, "anyone", []).Should().BeTrue();
-  }
+    var data = new PrioritySettingsData { Fee = 10m, AccessTarget = RoleTargetData("vip") };
+    // u1 is allowlisted, but the access target took precedence in the legacy
+    // system — synthesis must preserve that
+    var rules = PriorityDataMapper.SynthesizeLegacy(data, ["u1"]);
 
-  // ---- AccessTarget: who may prioritize at all ----
-
-  [Fact]
-  public void Null_access_target_keeps_legacy_allowlist_semantics()
-  {
-    PriorityRules.Eligible(true, Settings(), Noon, "u1", []).Should().BeTrue("allowlisted");
-    PriorityRules.Eligible(false, Settings(), Noon, "u1", []).Should().BeFalse();
-    PriorityRules
-      .Eligible(false, Settings(allowAll: true), Noon, "u1", [])
-      .Should()
-      .BeTrue("allow-all");
+    MatchFor(rules, "u1", []).Should().BeNull();
+    MatchFor(rules, "u1", ["vip"]).Should().NotBeNull();
   }
 
   [Fact]
-  public void Access_target_takes_precedence_over_allowlist()
+  public void Legacy_window_and_slot_cap_carry_onto_the_synthesized_rules()
   {
-    var s = Settings(access: Target(DiscountMatchMode.Any, Role("vip")));
-    // allowlisted but not in the target: the target wins — refused
-    PriorityRules.Eligible(true, s, Noon, "u1", []).Should().BeFalse();
-    // not allowlisted but in the target: allowed
-    PriorityRules.Eligible(false, s, Noon, "u1", ["vip"]).Should().BeTrue();
+    var data = new PrioritySettingsData
+    {
+      Fee = 10m,
+      AllowAll = true,
+      WindowStartSgt = new TimeOnly(14, 0),
+      WindowEndSgt = new TimeOnly(16, 0),
+      SlotCap = 3,
+    };
+    var rules = PriorityDataMapper.SynthesizeLegacy(data, []);
+
+    // closed at noon, open at 15:00 — and the cap rides along
+    PriorityRules.Match(rules, Noon, 24m, "u1", []).Should().BeNull();
+    var hit = PriorityRules.Match(rules, new TimeOnly(15, 0), 24m, "u1", []);
+    hit.Should().NotBeNull();
+    hit!.SlotCap.Should().Be(3);
   }
 
   [Fact]
-  public void Access_target_takes_precedence_over_allow_all()
+  public void Unified_rows_never_synthesize()
   {
-    var s = Settings(allowAll: true, access: Target(DiscountMatchMode.Any, Role("vip")));
-    PriorityRules.Eligible(false, s, Noon, "u1", []).Should().BeFalse("AllowAll is overridden");
-    PriorityRules.Eligible(false, s, Noon, "u1", ["vip"]).Should().BeTrue();
-  }
-
-  [Fact]
-  public void Access_target_by_user_id()
-  {
-    var s = Settings(access: Target(DiscountMatchMode.Any, UserId("u1")));
-    PriorityRules.Eligible(false, s, Noon, "u1", []).Should().BeTrue();
-    PriorityRules.Eligible(false, s, Noon, "u2", []).Should().BeFalse();
-  }
-
-  [Fact]
-  public void Access_target_still_respects_the_window()
-  {
-    var s = Settings(
-      access: Target(DiscountMatchMode.None),
-      start: new TimeOnly(14, 0),
-      end: new TimeOnly(16, 0)
-    );
-    PriorityRules.Eligible(false, s, new TimeOnly(15, 0), "u1", []).Should().BeTrue();
-    PriorityRules
-      .Eligible(false, s, Noon, "u1", [])
-      .Should()
-      .BeFalse("outside the window even though the target matches");
+    // a row that carries policies (even '[]') is post-unification: the
+    // repository returns them verbatim and never calls synthesis — this test
+    // just pins the '[]' = deny-everyone reading at the rules level
+    PriorityRules.Match([], Noon, 24m, "u1", ["vip"]).Should().BeNull();
   }
 }


### PR DESCRIPTION
## What

Feedback: the priority system had become 4 overlapping mechanisms (fee + allow-all + allowlist + free/access targets + window + policies + cap). It is now **ONE ordered policy list** — each rule:

| field | meaning |
|---|---|
| `target` | who — roles / user ids (discount-target matcher); null = everyone |
| `windowStartSgt`/`EndSgt` | when — SGT clock window (wraps midnight) |
| `min`/`maxHoursToDeparture` | when — hours before departure, `[min, max)` |
| `allow` | allow or deny |
| `feeKind`/`feeValue` | `Flat` SGD or `Percent` of the booking's charged ticket amount; 0 = free |
| `slotCap` | max queued priority bookings per timeslot for this rule |

First matching rule decides; **no match = deny**. `POST priority/settings` now takes just `{ policies: [...] }`.

## Compatibility

- **Zero-migration**: pre-unification settings rows (and installations with no row) synthesize equivalent rules on read from the legacy columns + allowlist — behavior is byte-for-byte until an admin saves the new shape (`[]` = explicit nobody-boosts). Snapshot-sync EF migration is a no-op (policies ride the existing jsonb column).
- Allowlist endpoints remain (legacy), but evaluation and the admin UI no longer use them.
- `PriorityEligibilityRes.fee` is now nullable (percent rule matched without a booking in scope); booking-scoped answers always carry a concrete fee. Adds `policyName` for admin debugging.

## Testing

- `PriorityPolicyTests`: chain ordering, role+hours+window mixing, half-open bounds, flat/percent/zero fees (banker's-rounding guarded)
- `PriorityTargetingTests`: legacy-row synthesis (allow-all, allowlist, free/access targets, window+cap carry-over)
- `BookingServicePrioritizeTests`: percent fee charges 25% of the SGD 16 ticket = SGD 4; empty chain denies; slot cap full/under/uncapped; free = no ledger row
- Full suite: **517 passed / 0 failed**; `dotnet format` clean on touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Priority settings now use an ordered list of policies instead of separate global rules.
  * Policies support flat or percentage fees, time windows, departure-time limits, targeting, and slot caps.
  * Eligibility responses can identify the matching policy and report fees when applicable.
* **Bug Fixes**
  * Improved policy matching, fee calculation, window handling, and slot-availability decisions.
  * Existing priority configurations remain supported through compatibility handling.
* **Tests**
  * Expanded coverage for policy ordering, targeting, time windows, percentage fees, and legacy settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->