### PR TITLE
fix(booking): slot-aware priority eligibility for the purchase page

### DIFF
--- a/App/Modules/Bookings/API/V1/BookingController.cs
+++ b/App/Modules/Bookings/API/V1/BookingController.cs
@@ -30,6 +30,7 @@ public class BookingController(
   ReserveBookingQueryValidator reserveBookingQueryValidator,
   BookingCountQueryValidator countQueryValidator,
   SetPrioritySettingsReqValidator setPrioritySettingsReqValidator,
+  PriorityEligibilityQueryValidator priorityEligibilityQueryValidator,
   IPrioritySettingsRepository prioritySettingsRepo,
   IPriorityAccessRepository priorityAccessRepo,
   IBookingAnalysisRepository analysisRepo,
@@ -533,17 +534,24 @@ public class BookingController(
   }
 
   // may the CALLING user prioritize a booking right now, at what fee, and
-  // free for them — powers the prioritize button on the booking page. The
-  // caller IS the target, so their JWT roles are authoritative for the
+  // free for them — powers the prioritize button on the booking page and the
+  // boost opt-in on the purchase page. The purchase page sends the slot it
+  // is buying (direction/date/time, Reserve-route formats, all or none) so
+  // hour-bounded policies and the slot cap apply before any booking exists;
+  // without one the answer only reflects rules that hold for every timeslot.
+  // The caller IS the target, so their JWT roles are authoritative for the
   // free/access targeting (∪ ExtraRoles happens in the domain, exactly like
   // pricing)
   [Authorize, HttpGet("priority/eligibility")]
-  public async Task<ActionResult<PriorityEligibilityRes>> PriorityEligibility()
+  public async Task<ActionResult<PriorityEligibilityRes>> PriorityEligibility(
+    [FromQuery] PriorityEligibilityQuery query
+  )
   {
     var sub = this.Sub()!;
     var tokenRoles = helper.FieldToScope(this.HttpContext.User, AuthRoles.Field).ToArray();
-    var x = await service
-      .PriorityEligibility(sub, tokenRoles)
+    var x = await priorityEligibilityQueryValidator
+      .ValidateAsyncResult(query, "Invalid PriorityEligibilityQuery")
+      .ThenAwait(q => service.PriorityEligibility(sub, tokenRoles, q.ToSlot()))
       .Then(e => e.ToRes(), Errors.MapNone);
     return this.ReturnResult(x);
   }

--- a/App/Modules/Bookings/API/V1/BookingMapper.cs
+++ b/App/Modules/Bookings/API/V1/BookingMapper.cs
@@ -5,6 +5,7 @@ using App.Modules.Users.API.V1;
 using App.Utility;
 using Domain.Booking;
 using Domain.Passenger;
+using Domain.Timings;
 
 namespace App.Modules.Bookings.API.V1;
 
@@ -289,6 +290,15 @@ public static class BookingMapper
 
   public static PriorityEligibilityRes ToRes(this PriorityEligibility e) =>
     new(e.Eligible, e.Fee, e.Free, e.SlotCap, e.SlotsLeft, e.PolicyName);
+
+  // null unless the full slot context was sent (the validator rejects a
+  // partial one before this runs)
+  public static (TrainDirection Direction, DateOnly Date, TimeOnly Time)? ToSlot(
+    this PriorityEligibilityQuery q
+  ) =>
+    q.Direction == null || q.Date == null || q.Time == null
+      ? null
+      : (q.Direction.DirectionToDomain(), q.Date.ToDate(), q.Time.ToTime());
 
   public static PrioritySettingsRecord ToDomain(this SetPrioritySettingsReq req) =>
     new() { Policies = req.Policies.Select(p => p.ToDomain()).ToList() };

--- a/App/Modules/Bookings/API/V1/BookingModel.cs
+++ b/App/Modules/Bookings/API/V1/BookingModel.cs
@@ -299,11 +299,22 @@ public record PriorityPolicyRes(
 
 public record PriorityAccessRes(string UserId, DateTime CreatedAt);
 
+// QUERY: optional slot context for the generic eligibility check — the
+// purchase page knows the timeslot about to be bought before any booking
+// exists. All three together (hour-bounded policies + slot cap apply) or
+// none (the old any-timeslot answer); formats match the Reserve route
+// (WToJ|JToW, dd-MM-yyyy, HH:mm:ss).
+public record PriorityEligibilityQuery(
+  string? Direction = null,
+  string? Date = null,
+  string? Time = null
+);
+
 // may the calling user prioritize right now, at what fee (null when a
 // percent fee cannot be computed without a booking in scope), and free for
 // them (Free => Fee is 0). SlotCap/SlotsLeft only when the matched rule caps
-// the timeslot (SlotsLeft needs a booking in scope). PolicyName = the rule
-// that decided.
+// the timeslot (SlotsLeft needs a booking or slot in scope). PolicyName =
+// the rule that decided.
 public record PriorityEligibilityRes(
   bool Eligible,
   decimal? Fee,

--- a/App/Modules/Bookings/API/V1/BookingValidator.cs
+++ b/App/Modules/Bookings/API/V1/BookingValidator.cs
@@ -152,6 +152,23 @@ public class ReserveBookingQueryValidator : AbstractValidator<ReserveBookingQuer
   }
 }
 
+public class PriorityEligibilityQueryValidator : AbstractValidator<PriorityEligibilityQuery>
+{
+  public PriorityEligibilityQueryValidator()
+  {
+    this.RuleFor(x => x.Direction)!.TrainDirectionValid();
+    this.RuleFor(x => x.Date).NullableDateValid();
+    this.RuleFor(x => x.Time).NullableTimeValid();
+    // a partial slot is ambiguous (which timeslot?) — all three or none
+    this.RuleFor(x => x.Time)
+      .Must(
+        (q, _) =>
+          (q.Direction == null) == (q.Date == null) && (q.Date == null) == (q.Time == null)
+      )
+      .WithMessage("Direction, Date and Time must be provided together (or all omitted)");
+  }
+}
+
 public class SetPrioritySettingsReqValidator : AbstractValidator<SetPrioritySettingsReq>
 {
   public SetPrioritySettingsReqValidator()

--- a/Domain/Booking/IService.cs
+++ b/Domain/Booking/IService.cs
@@ -84,10 +84,14 @@ public interface IBookingService
   // may this user prioritize a booking right now, at what fee, and is the
   // boost free for them; callerTokenRoles = the target user's own JWT roles
   // when they are the caller (null = fall back to the persisted Roles mirror).
-  // No booking in scope: hour-bounded policies are skipped, SlotsLeft null.
+  // slot = the timeslot about to be purchased (no booking exists yet): hour-
+  // bounded policies apply against its departure and its slot cap is counted.
+  // No slot: hour-bounded policies are skipped, SlotsLeft null. Either way a
+  // percent fee cannot be computed without a charged ticket (Fee = null).
   Task<Result<PriorityEligibility>> PriorityEligibility(
     string userId,
-    string[]? callerTokenRoles = null
+    string[]? callerTokenRoles = null,
+    (TrainDirection Direction, DateOnly Date, TimeOnly Time)? slot = null
   );
 
   // booking-scoped flavor: hour-bounded policies apply (hours to the

--- a/Domain/Booking/Service.cs
+++ b/Domain/Booking/Service.cs
@@ -1066,36 +1066,61 @@ public class BookingService(
   // fall back to the persisted Descope-synced Roles mirror.
   public Task<Result<PriorityEligibility>> PriorityEligibility(
     string userId,
-    string[]? callerTokenRoles = null
+    string[]? callerTokenRoles = null,
+    (TrainDirection Direction, DateOnly Date, TimeOnly Time)? slot = null
   )
   {
-    // no booking in scope: hour-bounded rules are skipped, percent fees
-    // cannot be computed (Fee = null) and slot caps cannot be counted
+    // no booking in scope. With a slot (the purchase page, before any booking
+    // exists): hour-bounded rules apply against the slot's departure and the
+    // matched rule's slot cap is counted. Without one: hour-bounded rules are
+    // skipped and slot caps cannot be counted. Either way there is no charged
+    // ticket amount yet, so a percent fee cannot be computed (Fee = null)
     return this.PriorityContext(userId, callerTokenRoles)
-      .Then(
-        t =>
-        {
-          var match = PriorityRules.Match(t.s.Policies, this.NowSgt(), null, userId, t.roles);
-          if (match is not { Allow: true })
-            return new PriorityEligibility
+      .ThenAwait(t =>
+      {
+        var hours = slot == null ? (decimal?)null : this.HoursToDeparture(slot.Value.Date, slot.Value.Time);
+        var match = PriorityRules.Match(t.s.Policies, this.NowSgt(), hours, userId, t.roles);
+        if (match is not { Allow: true })
+          return Task.FromResult(
+            (Result<PriorityEligibility>)new PriorityEligibility
             {
               Eligible = false,
               Fee = null,
               Free = false,
               PolicyName = match?.Name,
-            };
-          var fee = PriorityRules.Fee(match, null);
-          return new PriorityEligibility
-          {
-            Eligible = true,
-            Fee = fee,
-            Free = fee == 0m,
-            SlotCap = match.SlotCap,
-            PolicyName = match.Name,
-          };
-        },
-        Errors.MapNone
-      );
+            }
+          );
+        var fee = PriorityRules.Fee(match, null);
+        if (match.SlotCap == null || slot == null)
+          return Task.FromResult(
+            (Result<PriorityEligibility>)new PriorityEligibility
+            {
+              Eligible = true,
+              Fee = fee,
+              Free = fee == 0m,
+              SlotCap = match.SlotCap,
+              PolicyName = match.Name,
+            }
+          );
+        return repo.CountSlotPriority(slot.Value.Direction, slot.Value.Date, slot.Value.Time)
+          .Then(
+            c =>
+            {
+              var slotsLeft = Math.Max(0, match.SlotCap.Value - c);
+              return new PriorityEligibility
+              {
+                // a full priority queue blocks everyone, however eligible
+                Eligible = slotsLeft > 0,
+                Fee = fee,
+                Free = fee == 0m,
+                SlotCap = match.SlotCap,
+                SlotsLeft = slotsLeft,
+                PolicyName = match.Name,
+              };
+            },
+            Errors.MapNone
+          );
+      });
   }
 
   // booking-scoped eligibility: hour-bounded rules apply (hours until the
@@ -1160,11 +1185,13 @@ public class BookingService(
   }
 
   // hours until the timeslot departs, in SGT (negative once departed)
-  private decimal HoursToDeparture(BookingRecord r)
+  private decimal HoursToDeparture(BookingRecord r) => this.HoursToDeparture(r.Date, r.Time);
+
+  private decimal HoursToDeparture(DateOnly date, TimeOnly time)
   {
     var singapore = TimeZoneInfo.FindSystemTimeZoneById("Singapore");
     var nowSgt = TimeZoneInfo.ConvertTimeFromUtc(this.Clock.GetUtcNow().UtcDateTime, singapore);
-    return (decimal)(r.Date.ToDateTime(r.Time) - nowSgt).TotalHours;
+    return (decimal)(date.ToDateTime(time) - nowSgt).TotalHours;
   }
 
   // the single booking-scoped evaluation shared by the eligibility endpoint

--- a/UnitTest/Bookings/BookingServicePrioritizeTests.cs
+++ b/UnitTest/Bookings/BookingServicePrioritizeTests.cs
@@ -136,6 +136,8 @@ public class BookingServicePrioritizeTests
     int? slotCap = null,
     TimeOnly? winStart = null,
     TimeOnly? winEnd = null,
+    decimal? minHours = null,
+    decimal? maxHours = null,
     string name = "allow"
   ) =>
     new()
@@ -148,6 +150,8 @@ public class BookingServicePrioritizeTests
       SlotCap = slotCap,
       WindowStartSgt = winStart,
       WindowEndSgt = winEnd,
+      MinHoursToDeparture = minHours,
+      MaxHoursToDeparture = maxHours,
     };
 
   private static PrioritySettingsRecord Rules(params PriorityPolicyRecord[] policies) =>
@@ -555,6 +559,102 @@ public class BookingServicePrioritizeTests
 
     result.IsSuccess().Should().BeTrue();
     result.SuccessOrDefault().Free.Should().BeTrue();
+  }
+
+  // ---- slot-aware generic eligibility (the purchase page: a timeslot is
+  // in scope before any booking exists) ----
+
+  // the slot the purchase page is buying, departing `hours` from now (SGT
+  // wall clock, same math the service uses)
+  private static (TrainDirection Direction, DateOnly Date, TimeOnly Time) SlotIn(double hours)
+  {
+    var sgt = DateTime.UtcNow.AddHours(8).AddHours(hours);
+    return (TrainDirection.JToW, DateOnly.FromDateTime(sgt), TimeOnly.FromDateTime(sgt));
+  }
+
+  [Fact]
+  public async Task PriorityEligibility_with_slot_applies_hour_bounded_rules()
+  {
+    var settings = Rules(Allow(minHours: 48m));
+    var (service, _, _, _) = Make(null, settings);
+
+    var result = await service.PriorityEligibility("user-1", null, SlotIn(60));
+
+    result.IsSuccess().Should().BeTrue();
+    result.SuccessOrDefault().Eligible.Should().BeTrue("60h out satisfies MinHoursToDeparture=48");
+    result.SuccessOrDefault().Fee.Should().Be(Fee);
+  }
+
+  [Fact]
+  public async Task PriorityEligibility_with_slot_below_the_min_hours_floor_is_refused()
+  {
+    var settings = Rules(Allow(minHours: 48m));
+    var (service, _, _, _) = Make(null, settings);
+
+    var result = await service.PriorityEligibility("user-1", null, SlotIn(18));
+
+    result.IsSuccess().Should().BeTrue();
+    result.SuccessOrDefault().Eligible.Should().BeFalse("18h out is below the 48h floor");
+  }
+
+  [Fact]
+  public async Task PriorityEligibility_without_slot_still_skips_hour_bounded_rules()
+  {
+    var settings = Rules(Allow(minHours: 48m));
+    var (service, _, _, _) = Make(null, settings);
+
+    var result = await service.PriorityEligibility("user-1");
+
+    result.IsSuccess().Should().BeTrue();
+    result
+      .SuccessOrDefault()
+      .Eligible.Should()
+      .BeFalse("no slot in scope — hour-bounded rules are skipped, preserving the old semantics");
+  }
+
+  [Fact]
+  public async Task PriorityEligibility_with_slot_counts_the_slot_cap()
+  {
+    var settings = Rules(Allow(slotCap: 5));
+    var (service, repo, _, _) = Make(null, settings);
+    repo.SlotPriorityCount = 3;
+
+    var result = await service.PriorityEligibility("user-1", null, SlotIn(60));
+
+    result.IsSuccess().Should().BeTrue();
+    var e = result.SuccessOrDefault();
+    e.Eligible.Should().BeTrue();
+    e.SlotCap.Should().Be(5);
+    e.SlotsLeft.Should().Be(2);
+  }
+
+  [Fact]
+  public async Task PriorityEligibility_with_slot_full_cap_is_refused_with_zero_slots_left()
+  {
+    var settings = Rules(Allow(slotCap: 2));
+    var (service, repo, _, _) = Make(null, settings);
+    repo.SlotPriorityCount = 2;
+
+    var result = await service.PriorityEligibility("user-1", null, SlotIn(60));
+
+    result.IsSuccess().Should().BeTrue();
+    var e = result.SuccessOrDefault();
+    e.Eligible.Should().BeFalse("the timeslot's priority queue is full");
+    e.SlotsLeft.Should().Be(0);
+  }
+
+  [Fact]
+  public async Task PriorityEligibility_with_slot_percent_fee_stays_unpriced()
+  {
+    var settings = Rules(Allow(fee: 25m, kind: PriorityFeeKind.Percent));
+    var (service, _, _, _) = Make(null, settings);
+
+    var result = await service.PriorityEligibility("user-1", null, SlotIn(60));
+
+    result.IsSuccess().Should().BeTrue();
+    var e = result.SuccessOrDefault();
+    e.Eligible.Should().BeTrue();
+    e.Fee.Should().BeNull("no charged ticket amount exists before the purchase");
   }
 
   // ---- access target (service flow) ----


### PR DESCRIPTION
## Problem

The purchase page's boost opt-in is driven by the generic `GET /api/v1/Booking/priority/eligibility` endpoint, which has **no slot context**: `PriorityRules.Match` runs with `hoursToDeparture = null` and (by design for the no-context case) **skips every hour-bounded rule**.

With raichu's current policy chain — "Default Boost" (everyone, `MinHoursToDeparture=48`, SGD 10, SlotCap 5) above "Admins Boost Anytime" — non-admins match **no** rule, so the purchase page hides the boost opt-in for everyone, even when buying a slot 77h out. The booking-page (booking-scoped) endpoint is unaffected.

## Fix

The generic endpoint now accepts an **optional slot**: `Direction`, `Date`, `Time` query params in the Reserve-route formats (`WToJ|JToW`, `dd-MM-yyyy`, `HH:mm:ss`). All three together = slot context; none = the old any-timeslot behavior; a partial slot = 400 (validator).

With a slot in scope, `BookingService.PriorityEligibility`:
- computes hours-to-departure from the slot's SGT wall-clock departure (same math as the booking-scoped path) and passes it to `PriorityRules.Match`, so hour-bounded rules apply;
- counts the matched Allow rule's `SlotCap` via `CountSlotPriority` and returns `SlotCap`/`SlotsLeft`, with `SlotsLeft == 0 ⇒ Eligible = false` (mirrors `EvaluateForBooking`);
- still returns `Fee = null` for percent-fee rules — no charged ticket amount exists before the purchase (documented on the endpoint and `IService`).

## Tests

6 new unit tests in `BookingServicePrioritizeTests` (slot-aware section): MinHours=48 with a slot 60h out ⇒ eligible at the flat fee; 18h out ⇒ ineligible; no slot ⇒ ineligible (old semantics preserved); cap counting (5 cap, 3 used ⇒ 2 left); full cap ⇒ ineligible with `SlotsLeft = 0`; percent fee stays unpriced.

`dotnet build`: 0 errors · `dotnet test UnitTest`: **523/523 green** (517 baseline + 6 new) · `dotnet format style --severity info`: no new findings (the `CostController.cs` IMPORTS info is pre-existing on main).

Argon-side change ships separately and is safe in either order: this zinc ignores nothing, and old zinc ignores the extra query params.

https://claude.ai/code/session_018kJbfRkYZXikAELSDPj7pX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Priority eligibility checks can now use an optional journey direction, date, and departure time.
  - Eligibility results reflect time-based priority rules and availability limits for the selected journey.
  - Responses can show remaining priority slots when applicable.
- **Validation**
  - Journey details must use supported formats and be supplied together.
  - Eligibility checks without journey details remain supported.
- **Bug Fixes**
  - Improved handling of capped availability and time-based eligibility decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->