### PR TITLE
feat(booking): capture actual KTMB cost with FX conversion and backfill

### DIFF
--- a/App/Migrations/20260714074808_AddKtmbActualCostAndFxRates.Designer.cs
+++ b/App/Migrations/20260714074808_AddKtmbActualCostAndFxRates.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using App.StartUp.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace App.Migrations
 {
     [DbContext(typeof(MainDbContext))]
-    partial class MainDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260714074808_AddKtmbActualCostAndFxRates")]
+    partial class AddKtmbActualCostAndFxRates
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/App/Migrations/20260714074808_AddKtmbActualCostAndFxRates.cs
+++ b/App/Migrations/20260714074808_AddKtmbActualCostAndFxRates.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace App.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddKtmbActualCostAndFxRates : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "KtmbAmount",
+                table: "Bookings",
+                type: "numeric(16,8)",
+                precision: 16,
+                scale: 8,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "KtmbCurrency",
+                table: "Bookings",
+                type: "character varying(8)",
+                maxLength: 8,
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "KtmbFxRates",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    EffectiveAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Rate = table.Column<decimal>(type: "numeric(16,8)", precision: 16, scale: 8, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_KtmbFxRates", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_KtmbFxRates_EffectiveAt",
+                table: "KtmbFxRates",
+                column: "EffectiveAt");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "KtmbFxRates");
+
+            migrationBuilder.DropColumn(
+                name: "KtmbAmount",
+                table: "Bookings");
+
+            migrationBuilder.DropColumn(
+                name: "KtmbCurrency",
+                table: "Bookings");
+        }
+    }
+}

--- a/App/Modules/Bookings/API/V1/BookingController.cs
+++ b/App/Modules/Bookings/API/V1/BookingController.cs
@@ -35,6 +35,7 @@ public class BookingController(
   IPriorityAccessRepository priorityAccessRepo,
   IBookingAnalysisRepository analysisRepo,
   IKtmbCostRepository ktmbCostRepo,
+  IKtmbFxRateRepository ktmbFxRateRepo,
   IUserService userService,
   IOptions<TerminatorOption> terminatorOptions,
   IOptions<RecoveryOption> recoveryOptions,
@@ -177,6 +178,36 @@ public class BookingController(
     return this.ReturnResult(x);
   }
 
+  // the MYR -> SGD rate in effect right now (null = never configured) +
+  // queued future changes + the effective history — the actual-KTMB-cost
+  // conversion source for the analysis
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("ktmb-fx")]
+  public async Task<ActionResult<KtmbFxRateRes>> GetKtmbFxRate()
+  {
+    var x = await ktmbFxRateRepo
+      .List()
+      .Then(
+        changes => KtmbFxRateSchedule.View(changes, DateTime.UtcNow).ToRes(),
+        Errors.MapNone
+      );
+    return this.ReturnResult(x);
+  }
+
+  // queue an MYR -> SGD rate change (immediate when EffectiveAt is omitted)
+  // — insert-only, effective-dated like the KTMB cost queue
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpPost("ktmb-fx")]
+  public async Task<ActionResult<KtmbFxRateChangeRes>> SetKtmbFxRate(
+    [FromBody] SetKtmbFxRateReq req,
+    [FromServices] SetKtmbFxRateReqValidator ktmbFxRateValidator
+  )
+  {
+    var x = await ktmbFxRateValidator
+      .ValidateAsyncResult(req, "Invalid SetKtmbFxRateReq")
+      .ThenAwait(r => ktmbFxRateRepo.Add(r.Rate, r.EffectiveAt))
+      .Then(c => c.ToRes(), Errors.MapNone);
+    return this.ReturnResult(x);
+  }
+
   [Authorize(Policy = AuthPolicies.AdminOrTin)]
   [HttpGet("refund")]
   public async Task<ActionResult<IEnumerable<BookingPrincipalRes>>> ListRefunds()
@@ -275,6 +306,9 @@ public class BookingController(
     );
   }
 
+  // ktmbAmount/ktmbCurrency (optional, both or neither): what tin actually
+  // paid KTMB for the ticket — stored on the completion so the analysis can
+  // cost the booking at the real price instead of the admin estimate
   [Authorize(Policy = AuthPolicies.AdminOrTin)]
   [HttpPost("complete/{id:guid}")]
   [Consumes(MediaTypeNames.Multipart.FormData)]
@@ -282,16 +316,59 @@ public class BookingController(
     Guid id,
     string bookingNo,
     string ticketNo,
-    IFormFile file
+    IFormFile file,
+    [FromServices] CompleteKtmbCostReqValidator ktmbCostValidator,
+    decimal? ktmbAmount,
+    string? ktmbCurrency
   )
   {
     using var stream = new MemoryStream();
     await file.CopyToAsync(stream);
     logger.LogInformation("Stream Size: {StreamSize}", stream.Length);
-    var x = await service
-      .Complete(id, bookingNo, ticketNo, stream)
+    var x = await ktmbCostValidator
+      .ValidateAsyncResult(
+        new CompleteKtmbCostReq(ktmbAmount, ktmbCurrency),
+        "Invalid CompleteKtmbCostReq"
+      )
+      .ThenAwait(k => service.Complete(id, bookingNo, ticketNo, stream, k.ToDomain()))
       .Then(x => x?.ToRes(), Errors.MapAll)
       .ThenAwait(x => Utils.ToNullableTaskResultOr(x, r => enrich.Enrich(r)));
+    return this.ReturnNullableResult(
+      x,
+      new EntityNotFound("Booking not found", typeof(Booking), id.ToString())
+    );
+  }
+
+  // The tin backfill worklist: Completed bookings that captured a KTMB
+  // reservation (BookingNo + TicketNo present) but have no actual paid
+  // amount recorded yet, oldest CompletedAt first
+  [Authorize(Policy = AuthPolicies.AdminOrTin), HttpGet("ktmb-cost/missing")]
+  public async Task<ActionResult<IEnumerable<KtmbCostMissingRes>>> MissingKtmbCost(
+    [FromQuery] KtmbCostMissingQuery query,
+    [FromServices] KtmbCostMissingQueryValidator missingValidator
+  )
+  {
+    var x = await missingValidator
+      .ValidateAsyncResult(query, "Invalid KtmbCostMissingQuery")
+      .ThenAwait(q => service.ListMissingKtmbActualCost(q.Limit ?? 100, q.Skip ?? 0))
+      .Then(rows => rows.Select(m => m.ToRes()), Errors.MapAll);
+    return this.ReturnResult(x);
+  }
+
+  // Record the actual KTMB-paid cost of an already-Completed booking after
+  // the fact (the tin backfill). Idempotent: once recorded, the stored
+  // values are returned as-is and never overwritten.
+  [Authorize(Policy = AuthPolicies.AdminOrTin), HttpPost("{id:guid}/ktmb-cost")]
+  public async Task<ActionResult<BookingKtmbCostRes>> RecordKtmbCost(
+    Guid id,
+    [FromBody] SetBookingKtmbCostReq req,
+    [FromServices] SetBookingKtmbCostReqValidator ktmbActualValidator
+  )
+  {
+    var x = await ktmbActualValidator
+      .ValidateAsyncResult(req, "Invalid SetBookingKtmbCostReq")
+      .ThenAwait(r => service.RecordKtmbActualCost(id, r.ToDomain()))
+      .Then(c => c?.ToRes(id), Errors.MapAll);
     return this.ReturnNullableResult(
       x,
       new EntityNotFound("Booking not found", typeof(Booking), id.ToString())

--- a/App/Modules/Bookings/API/V1/BookingController.cs
+++ b/App/Modules/Bookings/API/V1/BookingController.cs
@@ -178,9 +178,9 @@ public class BookingController(
     return this.ReturnResult(x);
   }
 
-  // the MYR -> SGD rate in effect right now (null = never configured) +
-  // queued future changes + the effective history — the actual-KTMB-cost
-  // conversion source for the analysis
+  // the MYR -> SGD rate row in effect right now (null before any row) + the
+  // entered rows most recent first — the actual-KTMB-cost conversion source
+  // for the analysis
   [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("ktmb-fx")]
   public async Task<ActionResult<KtmbFxRateRes>> GetKtmbFxRate()
   {
@@ -196,7 +196,7 @@ public class BookingController(
   // queue an MYR -> SGD rate change (immediate when EffectiveAt is omitted)
   // — insert-only, effective-dated like the KTMB cost queue
   [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpPost("ktmb-fx")]
-  public async Task<ActionResult<KtmbFxRateChangeRes>> SetKtmbFxRate(
+  public async Task<ActionResult<KtmbFxRateRowRes>> SetKtmbFxRate(
     [FromBody] SetKtmbFxRateReq req,
     [FromServices] SetKtmbFxRateReqValidator ktmbFxRateValidator
   )

--- a/App/Modules/Bookings/API/V1/BookingMapper.cs
+++ b/App/Modules/Bookings/API/V1/BookingMapper.cs
@@ -140,6 +140,10 @@ public static class BookingMapper
             a.Summary.GatewayFees.Coverage.PaymentsTotal
           )
         ),
+        new KtmbActualCoverageRes(
+          a.Summary.KtmbCoverage.WithActual,
+          a.Summary.KtmbCoverage.Total
+        ),
         a.Summary.ByDirection.Select(d => d.ToRes())
       ),
       a.Monthly.Select(m => m.ToRes()),
@@ -188,6 +192,28 @@ public static class BookingMapper
       v.Current.ToDictionary(kv => kv.Key.ToRes(), kv => kv.Value),
       v.Upcoming.Select(c => c.ToRes())
     );
+
+  // actual KTMB-paid cost (completion capture + backfill)
+  public static BookingKtmbCost? ToDomain(this CompleteKtmbCostReq req) =>
+    req.KtmbAmount == null || req.KtmbCurrency == null
+      ? null
+      : new BookingKtmbCost { Amount = req.KtmbAmount.Value, Currency = req.KtmbCurrency };
+
+  public static BookingKtmbCost ToDomain(this SetBookingKtmbCostReq req) =>
+    new() { Amount = req.Amount, Currency = req.Currency };
+
+  public static BookingKtmbCostRes ToRes(this BookingKtmbCost c, Guid id) =>
+    new(id, c.Amount, c.Currency);
+
+  public static KtmbCostMissingRes ToRes(this BookingKtmbCostMissing m) =>
+    new(m.Id, m.BookingNo, m.TicketNo, m.CompletedAt);
+
+  // KTMB MYR -> SGD FX rate
+  public static KtmbFxRateChangeRes ToRes(this KtmbFxRateChange c) =>
+    new(c.Id, c.Rate, c.EffectiveAt, c.CreatedAt);
+
+  public static KtmbFxRateRes ToRes(this KtmbFxRateView v) =>
+    new(v.Current, v.Upcoming.Select(c => c.ToRes()), v.History.Select(c => c.ToRes()));
 
   // REQ -> DOMAIN
   public static BookingCountSearch ToDomain(this BookingCountQuery q) =>

--- a/App/Modules/Bookings/API/V1/BookingMapper.cs
+++ b/App/Modules/Bookings/API/V1/BookingMapper.cs
@@ -141,8 +141,8 @@ public static class BookingMapper
           )
         ),
         new KtmbActualCoverageRes(
-          a.Summary.KtmbCoverage.WithActual,
-          a.Summary.KtmbCoverage.Total
+          a.Summary.KtmbActualCoverage.WithActual,
+          a.Summary.KtmbActualCoverage.Total
         ),
         a.Summary.ByDirection.Select(d => d.ToRes())
       ),
@@ -209,11 +209,11 @@ public static class BookingMapper
     new(m.Id, m.BookingNo, m.TicketNo, m.CompletedAt);
 
   // KTMB MYR -> SGD FX rate
-  public static KtmbFxRateChangeRes ToRes(this KtmbFxRateChange c) =>
-    new(c.Id, c.Rate, c.EffectiveAt, c.CreatedAt);
+  public static KtmbFxRateRowRes ToRes(this KtmbFxRateChange c) =>
+    new(c.Rate, c.EffectiveAt, c.CreatedAt);
 
   public static KtmbFxRateRes ToRes(this KtmbFxRateView v) =>
-    new(v.Current, v.Upcoming.Select(c => c.ToRes()), v.History.Select(c => c.ToRes()));
+    new(v.Current?.ToRes(), v.Recent.Select(c => c.ToRes()));
 
   // REQ -> DOMAIN
   public static BookingCountSearch ToDomain(this BookingCountQuery q) =>

--- a/App/Modules/Bookings/API/V1/BookingModel.cs
+++ b/App/Modules/Bookings/API/V1/BookingModel.cs
@@ -34,6 +34,38 @@ public record BookingBoostQueryReq(string? After, string? Before, int? Limit, in
 // immediate
 public record SetKtmbCostReq(string Direction, decimal Cost, DateTime? EffectiveAt);
 
+// the optional actual-cost capture on POST complete/{id}: what tin actually
+// paid KTMB for the ticket — both form fields together or neither (old tin
+// clients send neither; the backfill records it after the fact)
+public record CompleteKtmbCostReq(decimal? KtmbAmount, string? KtmbCurrency);
+
+// record the actual KTMB-paid cost of a Completed booking after the fact
+// (the tin backfill); idempotent — already-recorded values win
+public record SetBookingKtmbCostReq(decimal Amount, string Currency);
+
+public record BookingKtmbCostRes(Guid Id, decimal Amount, string Currency);
+
+// the tin backfill worklist page: Limit/Skip paging, oldest CompletedAt first
+public record KtmbCostMissingQuery(int? Limit, int? Skip);
+
+// one worklist row: a Completed booking with KTMB identifiers but no actual
+// paid amount recorded yet
+public record KtmbCostMissingRes(Guid Id, string BookingNo, string TicketNo, DateTime CompletedAt);
+
+// KTMB FX: queue an MYR -> SGD rate change (SGD per 1 MYR); EffectiveAt
+// omitted = immediate
+public record SetKtmbFxRateReq(decimal Rate, DateTime? EffectiveAt);
+
+public record KtmbFxRateChangeRes(Guid Id, decimal Rate, DateTime EffectiveAt, DateTime CreatedAt);
+
+// the rate in effect right now (null = never configured), queued future
+// changes and the already-effective history (newest first)
+public record KtmbFxRateRes(
+  decimal? Current,
+  IEnumerable<KtmbFxRateChangeRes> Upcoming,
+  IEnumerable<KtmbFxRateChangeRes> History
+);
+
 public record ReserveBookingQuery(string Date, string Direction, string Time);
 
 public record BookingCountQuery(string Date, string Direction);
@@ -152,6 +184,11 @@ public record InternalFeesRes(
 // with delay, so PaymentsWithFee < PaymentsTotal means "sync again later"
 public record GatewayFeeCoverageRes(int PaymentsWithFee, int PaymentsTotal);
 
+// actual-KTMB-cost capture coverage over the range's completed bookings —
+// tin records/backfills with delay, so WithActual < Total means estimates
+// still cost part of the range
+public record KtmbActualCoverageRes(int WithActual, int Total);
+
 // Airwallex's own fees: Payments = fees on captured intents (money in),
 // Payouts = fees on transfers + card refunds (money out)
 public record GatewayFeesRes(decimal Payments, decimal Payouts, GatewayFeeCoverageRes Coverage);
@@ -195,6 +232,7 @@ public record BookingAnalysisSummaryRes(
   DepositSummaryRes Deposits,
   InternalFeesRes InternalFees,
   GatewayFeesRes GatewayFees,
+  KtmbActualCoverageRes KtmbCoverage,
   IEnumerable<DirectionBreakdownRes> ByDirection
 );
 

--- a/App/Modules/Bookings/API/V1/BookingModel.cs
+++ b/App/Modules/Bookings/API/V1/BookingModel.cs
@@ -56,15 +56,13 @@ public record KtmbCostMissingRes(Guid Id, string BookingNo, string TicketNo, Dat
 // omitted = immediate
 public record SetKtmbFxRateReq(decimal Rate, DateTime? EffectiveAt);
 
-public record KtmbFxRateChangeRes(Guid Id, decimal Rate, DateTime EffectiveAt, DateTime CreatedAt);
+// one rate row on the wire — argon's hand-added contract shape, exactly
+// { rate, effectiveAt, createdAt }
+public record KtmbFxRateRowRes(decimal Rate, DateTime EffectiveAt, DateTime CreatedAt);
 
-// the rate in effect right now (null = never configured), queued future
-// changes and the already-effective history (newest first)
-public record KtmbFxRateRes(
-  decimal? Current,
-  IEnumerable<KtmbFxRateChangeRes> Upcoming,
-  IEnumerable<KtmbFxRateChangeRes> History
-);
+// the row in effect right now (null before any row) + every entered row,
+// most recent first — argon's { current, recent } contract shape
+public record KtmbFxRateRes(KtmbFxRateRowRes? Current, IEnumerable<KtmbFxRateRowRes> Recent);
 
 public record ReserveBookingQuery(string Date, string Direction, string Time);
 
@@ -232,7 +230,8 @@ public record BookingAnalysisSummaryRes(
   DepositSummaryRes Deposits,
   InternalFeesRes InternalFees,
   GatewayFeesRes GatewayFees,
-  KtmbActualCoverageRes KtmbCoverage,
+  // serializes as "ktmbActualCoverage" — argon's hand-added contract name
+  KtmbActualCoverageRes KtmbActualCoverage,
   IEnumerable<DirectionBreakdownRes> ByDirection
 );
 

--- a/App/Modules/Bookings/API/V1/BookingValidator.cs
+++ b/App/Modules/Bookings/API/V1/BookingValidator.cs
@@ -193,11 +193,12 @@ public class SetKtmbFxRateReqValidator : AbstractValidator<SetKtmbFxRateReq>
   public SetKtmbFxRateReqValidator()
   {
     // SGD per 1 MYR: strictly positive (a zero rate would silently erase
-    // every MYR cost), 100 as an obvious-typo ceiling
+    // every MYR cost), 1000 as an obvious-typo ceiling — argon validates
+    // the same bound client-side, the two must agree
     this.RuleFor(x => x.Rate)
       .GreaterThan(0)
-      .LessThanOrEqualTo(100)
-      .WithMessage("Rate must be greater than 0 and at most 100");
+      .LessThanOrEqualTo(1000)
+      .WithMessage("Rate must be greater than 0 and at most 1000");
     // a past effective date would insert a row that can never win the
     // newest-effective ordering — a silently dead change (small tolerance
     // for clock skew; omit the field for an immediate change)

--- a/App/Modules/Bookings/API/V1/BookingValidator.cs
+++ b/App/Modules/Bookings/API/V1/BookingValidator.cs
@@ -133,6 +133,80 @@ public class SetKtmbCostReqValidator : AbstractValidator<SetKtmbCostReq>
   }
 }
 
+// the actual amount tin paid KTMB: strictly positive (a free ticket is not
+// a purchase), in one of the two currencies the analysis knows how to cost
+// (MYR converts via the FX queue, SGD passes through) — anything else would
+// silently fall back to the estimate forever
+public class CompleteKtmbCostReqValidator : AbstractValidator<CompleteKtmbCostReq>
+{
+  public CompleteKtmbCostReqValidator()
+  {
+    // an amount without a currency (or vice versa) is uncostable — both or
+    // neither, like the other paired optional inputs
+    this.RuleFor(x => x.KtmbCurrency)
+      .Must((req, c) => (c == null) == (req.KtmbAmount == null))
+      .WithMessage("ktmbAmount and ktmbCurrency must be provided together (or both omitted)");
+    this.RuleFor(x => x.KtmbAmount)
+      .GreaterThan(0)
+      .When(x => x.KtmbAmount != null)
+      .WithMessage("ktmbAmount must be greater than 0");
+    // stay within the stored precision (numeric(16,8))
+    this.RuleFor(x => x.KtmbAmount)
+      .LessThanOrEqualTo(10_000_000)
+      .When(x => x.KtmbAmount != null)
+      .WithMessage("ktmbAmount must be at most 10000000");
+    this.RuleFor(x => x.KtmbCurrency)
+      .Must(c => c is null or "MYR" or "SGD")
+      .WithMessage("ktmbCurrency must be 'MYR' or 'SGD'");
+  }
+}
+
+public class SetBookingKtmbCostReqValidator : AbstractValidator<SetBookingKtmbCostReq>
+{
+  public SetBookingKtmbCostReqValidator()
+  {
+    this.RuleFor(x => x.Amount)
+      .GreaterThan(0)
+      .WithMessage("Amount must be greater than 0");
+    // stay within the stored precision (numeric(16,8))
+    this.RuleFor(x => x.Amount)
+      .LessThanOrEqualTo(10_000_000)
+      .WithMessage("Amount must be at most 10000000");
+    this.RuleFor(x => x.Currency)
+      .NotNull()
+      .Must(c => c is "MYR" or "SGD")
+      .WithMessage("Currency must be 'MYR' or 'SGD'");
+  }
+}
+
+public class KtmbCostMissingQueryValidator : AbstractValidator<KtmbCostMissingQuery>
+{
+  public KtmbCostMissingQueryValidator()
+  {
+    this.RuleFor(x => x.Limit).Limit();
+    this.RuleFor(x => x.Skip).Skip();
+  }
+}
+
+public class SetKtmbFxRateReqValidator : AbstractValidator<SetKtmbFxRateReq>
+{
+  public SetKtmbFxRateReqValidator()
+  {
+    // SGD per 1 MYR: strictly positive (a zero rate would silently erase
+    // every MYR cost), 100 as an obvious-typo ceiling
+    this.RuleFor(x => x.Rate)
+      .GreaterThan(0)
+      .LessThanOrEqualTo(100)
+      .WithMessage("Rate must be greater than 0 and at most 100");
+    // a past effective date would insert a row that can never win the
+    // newest-effective ordering — a silently dead change (small tolerance
+    // for clock skew; omit the field for an immediate change)
+    this.RuleFor(x => x.EffectiveAt)
+      .Must(x => x == null || x > DateTime.UtcNow.AddMinutes(-5))
+      .WithMessage("EffectiveAt must be in the future (omit it for an immediate change)");
+  }
+}
+
 public class BookingCountQueryValidator : AbstractValidator<BookingCountQuery>
 {
   public BookingCountQueryValidator()

--- a/App/Modules/Bookings/Data/BookingAnalysisRepository.cs
+++ b/App/Modules/Bookings/Data/BookingAnalysisRepository.cs
@@ -21,9 +21,13 @@ namespace App.Modules.Bookings.Data;
 // by construction — and only the request row is FK-linked per booking, which
 // makes it the joinable source of truth.
 //
-// KTMB COST: each completed booking is costed at the newest KtmbCosts row
-// with EffectiveAt <= its CompletedAt and a matching Direction (the SQL
-// LATERAL mirrors KtmbCostSchedule.EffectiveCost); no configured row = 0.
+// KTMB COST: the ACTUAL amount tin paid KTMB when recorded — SGD as-is, MYR
+// × the newest KtmbFxRates row effective at the booking's CompletedAt (the
+// CASE mirrors KtmbActualCost.Effective); a recorded MYR amount with no
+// effective rate falls back to the estimate. Bookings without an actual
+// amount are costed at the newest KtmbCosts row with EffectiveAt <= their
+// CompletedAt and a matching Direction (the LATERAL mirrors
+// KtmbCostSchedule.EffectiveCost); no configured row = 0.
 //
 // GATEWAY FEES: from the synced GatewayFees rows (Airwallex financial
 // transactions), bucketed on the SGT month of TransactedAt. Payment-type
@@ -110,9 +114,12 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
       // AT TIME ZONE 'UTC' renders the instant as UTC wall-clock regardless
       // of the session TimeZone; +8h then CAST AS date = the SGT calendar
       // date (same arithmetic booking_stats bakes into its view).
-      // The LATERAL resolves each booking's effective KTMB cost: the newest
-      // row effective at CompletedAt for the booking's direction — the exact
-      // DB-side mirror of KtmbCostSchedule.EffectiveCost (0 when none).
+      // The LATERALs resolve, per booking at its CompletedAt, the effective
+      // KTMB cost estimate (mirror of KtmbCostSchedule.EffectiveCost, 0 when
+      // none) and the effective MYR -> SGD rate (mirror of
+      // KtmbFxRateSchedule.EffectiveRate, NULL when none); the CASE mirrors
+      // KtmbActualCost.Effective — actual amount first (SGD as-is, MYR ×
+      // rate), estimate as the fallback.
       var rows = await db
         .Database.SqlQuery<RowDto>(
           $"""
@@ -122,7 +129,16 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
             b."Time" AS "Time",
             CAST(COUNT(*) AS int) AS "TicketsCompleted",
             SUM(t."Amount") AS "GrossRevenue",
-            SUM(COALESCE(kc."Cost", 0)) AS "KtmbCost"
+            SUM(
+              CASE
+                WHEN b."KtmbAmount" IS NOT NULL AND b."KtmbCurrency" = 'SGD'
+                  THEN b."KtmbAmount"
+                WHEN b."KtmbAmount" IS NOT NULL AND b."KtmbCurrency" = 'MYR'
+                  AND fx."Rate" IS NOT NULL
+                  THEN b."KtmbAmount" * fx."Rate"
+                ELSE COALESCE(kc."Cost", 0)
+              END
+            ) AS "KtmbCost"
           FROM "Bookings" b
           JOIN "Transactions" t ON t."Id" = b."TransactionId"
           LEFT JOIN LATERAL (
@@ -132,6 +148,13 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
             ORDER BY k."EffectiveAt" DESC, k."CreatedAt" DESC, k."Id" DESC
             LIMIT 1
           ) kc ON TRUE
+          LEFT JOIN LATERAL (
+            SELECT f."Rate"
+            FROM "KtmbFxRates" f
+            WHERE f."EffectiveAt" <= b."CompletedAt"
+            ORDER BY f."EffectiveAt" DESC, f."CreatedAt" DESC, f."Id" DESC
+            LIMIT 1
+          ) fx ON TRUE
           WHERE b."Status" = {completed}
             AND b."CompletedAt" IS NOT NULL
             AND b."CompletedAt" >= {afterUtc}
@@ -170,6 +193,18 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
       var paymentsWithFee = await capturedInRange
         .Where(p => db.GatewayFees.Any(f => f.SourceId == p.ExternalReference))
         .CountAsync();
+
+      // actual-KTMB-cost capture coverage: tin records/backfills the paid
+      // amount with delay, so the UI shows how many completed bookings in
+      // range already carry one (mirrors the gateway-fee coverage)
+      var completedInRange = db.Bookings.Where(b =>
+        b.Status == completed
+        && b.CompletedAt != null
+        && b.CompletedAt >= afterUtc
+        && b.CompletedAt < beforeUtc
+      );
+      var ktmbTotal = await completedInRange.CountAsync();
+      var ktmbWithActual = await completedInRange.Where(b => b.KtmbAmount != null).CountAsync();
 
       // the gateway's own fees, bucketed per SGT month of TransactedAt —
       // one grouped scan feeds both the range summary and the monthly rollup
@@ -309,7 +344,8 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
             Captured = depositCaptured ?? 0m,
           },
           sums,
-          gatewayFees
+          gatewayFees,
+          new KtmbActualCoverage { WithActual = ktmbWithActual, Total = ktmbTotal }
         ),
         Monthly = BookingAnalysisCalculator.MonthlyRollup(analysisRows, external),
         Components = components,

--- a/App/Modules/Bookings/Data/BookingData.cs
+++ b/App/Modules/Bookings/Data/BookingData.cs
@@ -100,6 +100,16 @@ public class BookingData
   [MaxLength(128)]
   public string? TicketNo { get; set; } = null;
 
+  // what BunnyBooker ACTUALLY paid KTMB for this ticket, captured by tin at
+  // completion or backfilled after the fact; both set together or both NULL
+  // (NULL = not recorded — the analysis falls back to the KtmbCosts estimate)
+  [Precision(16, 8)]
+  public decimal? KtmbAmount { get; set; }
+
+  // ISO currency of KtmbAmount ("MYR" or "SGD")
+  [MaxLength(8)]
+  public string? KtmbCurrency { get; set; }
+
   public BookingPassengerData Passenger { get; set; } = null!;
 
   // FK

--- a/App/Modules/Bookings/Data/BookingMapper.cs
+++ b/App/Modules/Bookings/Data/BookingMapper.cs
@@ -42,6 +42,8 @@ public static class BookingMapper
       Ticket = data.Ticket,
       BookingNumber = data.BookingNo,
       TicketNumber = data.TicketNo,
+      KtmbAmount = data.KtmbAmount,
+      KtmbCurrency = data.KtmbCurrency,
     };
 
   public static BookingPrincipal ToPrincipal(this BookingData data) =>
@@ -122,6 +124,8 @@ public static class BookingMapper
     data.Ticket = complete.Ticket;
     data.BookingNo = complete.BookingNumber;
     data.TicketNo = complete.TicketNumber;
+    data.KtmbAmount = complete.KtmbAmount;
+    data.KtmbCurrency = complete.KtmbCurrency;
     return data;
   }
 

--- a/App/Modules/Bookings/Data/BookingRepository.cs
+++ b/App/Modules/Bookings/Data/BookingRepository.cs
@@ -616,6 +616,52 @@ public class BookingRepository(
     }
   }
 
+  public async Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(
+    int limit,
+    int skip
+  )
+  {
+    try
+    {
+      logger.LogInformation(
+        "Listing bookings missing actual KTMB cost with limit {Limit} skip {Skip}",
+        limit,
+        skip
+      );
+      // oldest fulfilment first so the backfill drains the historical tail;
+      // Id keeps Skip/Take pagination stable across equal CompletedAt values
+      var rows = await db
+        .Bookings.Where(KtmbBackfill.Missing)
+        .OrderBy(x => x.CompletedAt)
+        .ThenBy(x => x.Id)
+        .Skip(skip)
+        .Take(limit)
+        .Select(x => new
+        {
+          x.Id,
+          x.BookingNo,
+          x.TicketNo,
+          x.CompletedAt,
+        })
+        .ToArrayAsync();
+
+      return rows
+        .Select(x => new BookingKtmbCostMissing
+        {
+          Id = x.Id,
+          BookingNo = x.BookingNo!,
+          TicketNo = x.TicketNo!,
+          CompletedAt = x.CompletedAt!.Value,
+        })
+        .ToResult();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to list bookings missing actual KTMB cost");
+      return e;
+    }
+  }
+
   public async Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id)
   {
     try

--- a/App/Modules/Bookings/Data/KtmbBackfill.cs
+++ b/App/Modules/Bookings/Data/KtmbBackfill.cs
@@ -1,0 +1,19 @@
+using System.Linq.Expressions;
+using Domain.Booking;
+
+namespace App.Modules.Bookings.Data;
+
+// The tin backfill worklist predicate in one place (the BookingQueue
+// convention): Completed bookings that captured a KTMB reservation (both
+// identifiers present) but have no actual paid amount recorded yet.
+// ListMissingKtmbCost pages with it DB-side and the unit tests pin it
+// in-memory — they must always agree.
+public static class KtmbBackfill
+{
+  public static readonly Expression<Func<BookingData, bool>> Missing = x =>
+    x.Status == (byte)BookStatus.Completed
+    && x.CompletedAt != null
+    && x.BookingNo != null
+    && x.TicketNo != null
+    && x.KtmbAmount == null;
+}

--- a/App/Modules/Bookings/Data/KtmbFxRateData.cs
+++ b/App/Modules/Bookings/Data/KtmbFxRateData.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace App.Modules.Bookings.Data;
+
+// Insert-only, effective-dated queue of the admin-entered MYR -> SGD rate
+// (SGD per 1 MYR) used to convert actual KTMB-paid amounts in the sales
+// analysis (same convention as the KtmbCosts estimate queue): the newest row
+// with EffectiveAt <= the booking's CompletedAt is the rate for that
+// booking; no effective row = no conversion (the analysis falls back to the
+// per-direction estimate).
+public class KtmbFxRateData
+{
+  public Guid Id { get; set; }
+
+  public DateTime CreatedAt { get; set; }
+
+  // the instant this rate starts applying; a future date queues it,
+  // CreatedAt (the default) makes it immediate
+  public DateTime EffectiveAt { get; set; }
+
+  [Precision(16, 8)]
+  public decimal Rate { get; set; }
+}

--- a/App/Modules/Bookings/Data/KtmbFxRateRepository.cs
+++ b/App/Modules/Bookings/Data/KtmbFxRateRepository.cs
@@ -1,0 +1,73 @@
+using App.StartUp.Database;
+using CSharp_Result;
+using Domain.Booking;
+using Microsoft.EntityFrameworkCore;
+
+namespace App.Modules.Bookings.Data;
+
+public static class KtmbFxRateMapper
+{
+  public static KtmbFxRateChange ToChange(this KtmbFxRateData data) =>
+    new()
+    {
+      Id = data.Id,
+      Rate = data.Rate,
+      EffectiveAt = data.EffectiveAt,
+      CreatedAt = data.CreatedAt,
+    };
+}
+
+public class KtmbFxRateRepository(MainDbContext db, ILogger<KtmbFxRateRepository> logger)
+  : IKtmbFxRateRepository
+{
+  public async Task<Result<IEnumerable<KtmbFxRateChange>>> List()
+  {
+    try
+    {
+      var rows = await db.KtmbFxRates.OrderBy(x => x.EffectiveAt).ToArrayAsync();
+      return rows.Select(x => x.ToChange()).ToResult();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to list KTMB FX rate changes");
+      return e;
+    }
+  }
+
+  public async Task<Result<KtmbFxRateChange>> Add(decimal rate, DateTime? effectiveAt)
+  {
+    try
+    {
+      var now = DateTime.UtcNow;
+      logger.LogInformation(
+        "Queueing KTMB FX rate change: {Rate}, effective {EffectiveAt}",
+        rate,
+        effectiveAt ?? now
+      );
+      // normalize to UTC exactly like KtmbCostRepository.Add: JSON without a
+      // Z binds as Unspecified and an offset binds as Local — Npgsql rejects
+      // both for timestamptz
+      var effective = effectiveAt?.Kind switch
+      {
+        null => now,
+        DateTimeKind.Utc => effectiveAt.Value,
+        DateTimeKind.Local => effectiveAt.Value.ToUniversalTime(),
+        _ => DateTime.SpecifyKind(effectiveAt.Value, DateTimeKind.Utc),
+      };
+      var data = new KtmbFxRateData
+      {
+        CreatedAt = now,
+        EffectiveAt = effective,
+        Rate = rate,
+      };
+      db.KtmbFxRates.Add(data);
+      await db.SaveChangesAsync();
+      return data.ToChange();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to queue KTMB FX rate change");
+      return e;
+    }
+  }
+}

--- a/App/Modules/DomainServices.cs
+++ b/App/Modules/DomainServices.cs
@@ -79,6 +79,10 @@ public static class DomainServices
     // KTMB ticket cost queue (effective-dated per direction, analysis costing)
     s.AddScoped<IKtmbCostRepository, KtmbCostRepository>().AutoTrace<IKtmbCostRepository>();
 
+    // KTMB MYR -> SGD FX rate queue (actual-cost conversion in the analysis)
+    s.AddScoped<IKtmbFxRateRepository, KtmbFxRateRepository>()
+      .AutoTrace<IKtmbFxRateRepository>();
+
     // Priority queue
     s.AddScoped<IPrioritySettingsRepository, PrioritySettingsRepository>()
       .AutoTrace<IPrioritySettingsRepository>();

--- a/App/StartUp/Database/MainDbContext.cs
+++ b/App/StartUp/Database/MainDbContext.cs
@@ -59,6 +59,9 @@ public class MainDbContext(
   // effective-dated per-direction KTMB ticket cost queue (analysis costing)
   public DbSet<KtmbCostData> KtmbCosts { get; set; }
 
+  // effective-dated MYR -> SGD rate queue for actual-KTMB-cost conversion
+  public DbSet<KtmbFxRateData> KtmbFxRates { get; set; }
+
   // keyless read-only projection of the booking_stats materialized view
   public DbSet<BookingStatData> BookingStats { get; set; }
 
@@ -258,6 +261,11 @@ public class MainDbContext(
     // effective row per direction, exactly like the withdrawal fee queue
     var ktmbCost = modelBuilder.Entity<KtmbCostData>();
     ktmbCost.HasIndex(x => new { x.Direction, x.EffectiveAt });
+
+    // effective-dated MYR -> SGD rate queue: reads scan the newest effective
+    // row (per booking CompletedAt in the analysis LATERAL)
+    var ktmbFxRate = modelBuilder.Entity<KtmbFxRateData>();
+    ktmbFxRate.HasIndex(x => x.EffectiveAt);
 
     var payments = modelBuilder.Entity<PaymentData>();
     payments.HasIndex(x => x.ExternalReference);

--- a/Domain/Booking/Analysis.cs
+++ b/Domain/Booking/Analysis.cs
@@ -21,8 +21,10 @@ public record BookingAnalysisQuery
 
 // One completed-revenue row: bookings completed on this SGT date, for this
 // departure slot. GrossRevenue = the booking cost collected at completion
-// (BookingReserve -> BunnyBooker); KtmbCost = the sum of each booking's
-// effective KTMB ticket cost at its CompletedAt (0 when none configured).
+// (BookingReserve -> BunnyBooker); KtmbCost = the sum of each booking's KTMB
+// cost — the ACTUAL amount paid when recorded (SGD as-is, MYR × the FX rate
+// effective at its CompletedAt; see KtmbActualCost), else the effective
+// per-direction estimate at its CompletedAt (0 when none configured).
 public record BookingAnalysisRow
 {
   // SGT date of CompletedAt (matches booking_stats' SGT date convention)
@@ -84,6 +86,16 @@ public record GatewayFeeSummary
   public required decimal Payouts { get; init; }
 
   public required GatewayFeeCoverage Coverage { get; init; }
+}
+
+// how many completed bookings in range carry an ACTUAL KTMB-paid amount —
+// tin captures/backfills with delay, so the UI can show capture coverage
+// (mirrors GatewayFeeCoverage)
+public record KtmbActualCoverage
+{
+  public required int WithActual { get; init; }
+
+  public required int Total { get; init; }
 }
 
 // per-direction slice of the completed rows (summary- and month-level)
@@ -172,6 +184,9 @@ public record BookingAnalysisSummary
 
   public required GatewayFeeSummary GatewayFees { get; init; }
 
+  // actual-KTMB-cost capture coverage over the range's completed bookings
+  public required KtmbActualCoverage KtmbCoverage { get; init; }
+
   public required DirectionBreakdown[] ByDirection { get; init; }
 }
 
@@ -214,7 +229,8 @@ public static class BookingAnalysisCalculator
     IReadOnlyCollection<BookingAnalysisRow> rows,
     DepositSummary deposits,
     BookingAnalysisLedgerSums sums,
-    GatewayFeeSummary gatewayFees
+    GatewayFeeSummary gatewayFees,
+    KtmbActualCoverage ktmbCoverage
   ) =>
     new()
     {
@@ -230,6 +246,7 @@ public static class BookingAnalysisCalculator
         Termination = sums.TerminatedGross - sums.TerminationRefunds,
       },
       GatewayFees = gatewayFees,
+      KtmbCoverage = ktmbCoverage,
       ByDirection = ByDirection(rows),
     };
 

--- a/Domain/Booking/Analysis.cs
+++ b/Domain/Booking/Analysis.cs
@@ -185,7 +185,7 @@ public record BookingAnalysisSummary
   public required GatewayFeeSummary GatewayFees { get; init; }
 
   // actual-KTMB-cost capture coverage over the range's completed bookings
-  public required KtmbActualCoverage KtmbCoverage { get; init; }
+  public required KtmbActualCoverage KtmbActualCoverage { get; init; }
 
   public required DirectionBreakdown[] ByDirection { get; init; }
 }
@@ -246,7 +246,7 @@ public static class BookingAnalysisCalculator
         Termination = sums.TerminatedGross - sums.TerminationRefunds,
       },
       GatewayFees = gatewayFees,
-      KtmbCoverage = ktmbCoverage,
+      KtmbActualCoverage = ktmbCoverage,
       ByDirection = ByDirection(rows),
     };
 

--- a/Domain/Booking/BookingOperations.cs
+++ b/Domain/Booking/BookingOperations.cs
@@ -29,4 +29,6 @@ public static class BookingOperations
   public const string CompleteNoCollect = "CompleteNoCollect";
 
   public const string Prioritize = "Prioritize";
+
+  public const string RecordKtmbCost = "RecordKtmbCost";
 }

--- a/Domain/Booking/IService.cs
+++ b/Domain/Booking/IService.cs
@@ -59,10 +59,25 @@ public interface IBookingService
   // and does that reference resolve to a real stored object
   Task<Result<BookingTicketHealth?>> TicketHealth(Guid id);
 
+  // ktmbCost = what tin actually paid KTMB for the ticket (optional — old
+  // tin clients don't send it; the backfill records it after the fact)
   Task<Result<BookingPrincipal?>> Complete(Guid id,
     string bookingNo,
     string ticketNo,
-    Stream ticketFile);
+    Stream ticketFile,
+    BookingKtmbCost? ktmbCost = null);
+
+  // record the actual KTMB-paid cost of an already-Completed booking (the
+  // tin backfill). Idempotent: once recorded the existing values are
+  // returned as-is, never overwritten; null when the booking does not exist
+  Task<Result<BookingKtmbCost?>> RecordKtmbActualCost(Guid id, BookingKtmbCost cost);
+
+  // the tin backfill worklist: Completed bookings with KTMB identifiers but
+  // no actual cost yet, oldest CompletedAt first
+  Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbActualCost(
+    int limit,
+    int skip
+  );
 
   Task<Result<BookingPrincipal?>> CompleteNoCollect(Guid id,
     string bookingNo,

--- a/Domain/Booking/KtmbFxRate.cs
+++ b/Domain/Booking/KtmbFxRate.cs
@@ -20,17 +20,16 @@ public record KtmbFxRateChange
   public required DateTime CreatedAt { get; init; }
 }
 
-// the rate in effect right now + queued future changes + the recent history,
-// for the admin UI (Current null = never configured)
+// the rate row in effect right now + the recent rows, for the admin UI
+// (argon's wire contract: { current, recent })
 public record KtmbFxRateView
 {
-  public required decimal? Current { get; init; }
+  // null before any row has taken effect
+  public required KtmbFxRateChange? Current { get; init; }
 
-  public required KtmbFxRateChange[] Upcoming { get; init; }
-
-  // already-effective rows, newest first (the table is tiny — a handful of
-  // admin-entered rows)
-  public required KtmbFxRateChange[] History { get; init; }
+  // every entered row, most recent EffectiveAt first (queued future rows
+  // included — the table is tiny, a handful of admin-entered rows)
+  public required KtmbFxRateChange[] Recent { get; init; }
 }
 
 public interface IKtmbFxRateRepository
@@ -46,27 +45,31 @@ public interface IKtmbFxRateRepository
 // (per booking CompletedAt); this is the single in-memory source of truth.
 public static class KtmbFxRateSchedule
 {
-  // the rate effective at a given instant; null when none has taken effect
-  public static decimal? EffectiveRate(IEnumerable<KtmbFxRateChange> changes, DateTime at) =>
+  // the row effective at a given instant; null when none has taken effect
+  public static KtmbFxRateChange? EffectiveChange(
+    IEnumerable<KtmbFxRateChange> changes,
+    DateTime at
+  ) =>
     changes
       .Where(x => x.EffectiveAt <= at)
       .OrderByDescending(x => x.EffectiveAt)
       .ThenByDescending(x => x.CreatedAt)
       .ThenByDescending(x => x.Id)
-      .Select(x => (decimal?)x.Rate)
       .FirstOrDefault();
+
+  // the rate effective at a given instant; null when none has taken effect
+  public static decimal? EffectiveRate(IEnumerable<KtmbFxRateChange> changes, DateTime at) =>
+    EffectiveChange(changes, at)?.Rate;
 
   public static KtmbFxRateView View(IEnumerable<KtmbFxRateChange> changes, DateTime now)
   {
     var all = changes.ToArray();
     return new KtmbFxRateView
     {
-      Current = EffectiveRate(all, now),
-      Upcoming = [.. all.Where(x => x.EffectiveAt > now).OrderBy(x => x.EffectiveAt)],
-      History =
+      Current = EffectiveChange(all, now),
+      Recent =
       [
         .. all
-          .Where(x => x.EffectiveAt <= now)
           .OrderByDescending(x => x.EffectiveAt)
           .ThenByDescending(x => x.CreatedAt)
           .ThenByDescending(x => x.Id),

--- a/Domain/Booking/KtmbFxRate.cs
+++ b/Domain/Booking/KtmbFxRate.cs
@@ -1,0 +1,103 @@
+using CSharp_Result;
+
+namespace Domain.Booking;
+
+// The admin-entered MYR -> SGD conversion rate (SGD per 1 MYR) used to cost
+// actual KTMB-paid amounts in the sales analysis — an insert-only,
+// effective-dated queue exactly like the KtmbCosts estimate queue: the
+// newest row whose EffectiveAt has passed is the live rate, future rows are
+// the queue, and with no effective row there is NO rate (analysis then falls
+// back to the per-direction estimate rather than guessing a conversion).
+public record KtmbFxRateChange
+{
+  public required Guid Id { get; init; }
+
+  // SGD per 1 MYR
+  public required decimal Rate { get; init; }
+
+  public required DateTime EffectiveAt { get; init; }
+
+  public required DateTime CreatedAt { get; init; }
+}
+
+// the rate in effect right now + queued future changes + the recent history,
+// for the admin UI (Current null = never configured)
+public record KtmbFxRateView
+{
+  public required decimal? Current { get; init; }
+
+  public required KtmbFxRateChange[] Upcoming { get; init; }
+
+  // already-effective rows, newest first (the table is tiny — a handful of
+  // admin-entered rows)
+  public required KtmbFxRateChange[] History { get; init; }
+}
+
+public interface IKtmbFxRateRepository
+{
+  // the full queue (tiny, admin-entered)
+  Task<Result<IEnumerable<KtmbFxRateChange>>> List();
+
+  Task<Result<KtmbFxRateChange>> Add(decimal rate, DateTime? effectiveAt);
+}
+
+// Pure effective-dating math, shared by the endpoint and the unit tests.
+// The analysis SQL implements the same newest-effective-first rule DB-side
+// (per booking CompletedAt); this is the single in-memory source of truth.
+public static class KtmbFxRateSchedule
+{
+  // the rate effective at a given instant; null when none has taken effect
+  public static decimal? EffectiveRate(IEnumerable<KtmbFxRateChange> changes, DateTime at) =>
+    changes
+      .Where(x => x.EffectiveAt <= at)
+      .OrderByDescending(x => x.EffectiveAt)
+      .ThenByDescending(x => x.CreatedAt)
+      .ThenByDescending(x => x.Id)
+      .Select(x => (decimal?)x.Rate)
+      .FirstOrDefault();
+
+  public static KtmbFxRateView View(IEnumerable<KtmbFxRateChange> changes, DateTime now)
+  {
+    var all = changes.ToArray();
+    return new KtmbFxRateView
+    {
+      Current = EffectiveRate(all, now),
+      Upcoming = [.. all.Where(x => x.EffectiveAt > now).OrderBy(x => x.EffectiveAt)],
+      History =
+      [
+        .. all
+          .Where(x => x.EffectiveAt <= now)
+          .OrderByDescending(x => x.EffectiveAt)
+          .ThenByDescending(x => x.CreatedAt)
+          .ThenByDescending(x => x.Id),
+      ],
+    };
+  }
+}
+
+// Pure per-booking costing rule, shared by the analysis SQL (its CASE
+// expression mirrors this) and the unit tests: the actual KTMB-paid amount
+// when recorded — SGD as-is, MYR × the rate effective at the booking's
+// CompletedAt — else the per-direction estimate. A recorded MYR amount with
+// no effective rate falls back to the estimate for that booking rather than
+// guessing a conversion.
+public static class KtmbActualCost
+{
+  public const string Myr = "MYR";
+
+  public const string Sgd = "SGD";
+
+  public static decimal Effective(
+    decimal? amount,
+    string? currency,
+    decimal? fxRate,
+    decimal estimate
+  ) =>
+    amount switch
+    {
+      null => estimate,
+      _ when currency == Sgd => amount.Value,
+      _ when currency == Myr && fxRate != null => amount.Value * fxRate.Value,
+      _ => estimate,
+    };
+}

--- a/Domain/Booking/Model.cs
+++ b/Domain/Booking/Model.cs
@@ -130,6 +130,38 @@ public record BookingComplete
   public required string? BookingNumber { get; init; } = null;
 
   public required string? TicketNumber { get; init; } = null;
+
+  // what BunnyBooker ACTUALLY paid KTMB for this ticket, captured by tin at
+  // completion (or backfilled after the fact). Both set together or both
+  // null; null = not recorded (the analysis then costs the booking at the
+  // admin-entered per-direction estimate). Never overwritten once recorded —
+  // the amount is a fact about the KTMB purchase.
+  public decimal? KtmbAmount { get; init; }
+
+  // ISO currency of KtmbAmount ("MYR" or "SGD")
+  public string? KtmbCurrency { get; init; }
+}
+
+// the actual KTMB-paid cost of one booking (see BookingComplete.KtmbAmount)
+public record BookingKtmbCost
+{
+  public required decimal Amount { get; init; }
+
+  public required string Currency { get; init; }
+}
+
+// one row of the tin backfill worklist: a Completed booking that captured a
+// KTMB reservation (both identifiers present) but has no actual paid amount
+// recorded yet
+public record BookingKtmbCostMissing
+{
+  public required Guid Id { get; init; }
+
+  public required string BookingNo { get; init; }
+
+  public required string TicketNo { get; init; }
+
+  public required DateTime CompletedAt { get; init; }
 }
 
 public record BookingStatus

--- a/Domain/Booking/Repository.cs
+++ b/Domain/Booking/Repository.cs
@@ -56,6 +56,11 @@ public interface IBookingRepository
     string? grantedBy
   );
 
+  // the tin backfill worklist: Completed bookings that captured a KTMB
+  // reservation (BookingNo + TicketNo present) but have no actual paid
+  // amount recorded yet, oldest CompletedAt first (Id as the stable tiebreak)
+  Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(int limit, int skip);
+
   // bumps the recovery retry counter by one; null when the booking does not
   // exist. Runs inside the caller's RecoverRevert transaction so the counter
   // and the status transition always move together.

--- a/Domain/Booking/Service.cs
+++ b/Domain/Booking/Service.cs
@@ -469,7 +469,8 @@ public class BookingService(
   public Task<Result<BookingPrincipal?>> Complete(Guid id,
     string bookingNo,
     string ticketNo,
-    Stream file)
+    Stream file,
+    BookingKtmbCost? ktmbCost = null)
   {
     return fileRepo
       .Save(file)
@@ -534,6 +535,10 @@ public class BookingService(
                     Ticket = fileId,
                     BookingNumber = bookingNo,
                     TicketNumber = ticketNo,
+                    // what tin actually paid KTMB, when the caller knows it
+                    // (old clients omit it — the backfill records it later)
+                    KtmbAmount = ktmbCost?.Amount,
+                    KtmbCurrency = ktmbCost?.Currency,
                   }
                 )
               )
@@ -554,6 +559,69 @@ public class BookingService(
             }), Errors.MapNone)
       .Then(BookingPrincipal? (x) => x.Principal, Errors.MapNone);
 
+  }
+
+  // The tin backfill: record what was ACTUALLY paid to KTMB for an already-
+  // Completed booking. Idempotent by design — the amount is a fact about the
+  // KTMB purchase, so once recorded the existing values are returned as-is
+  // and a retried backfill can never rewrite history. The guard read and the
+  // write run in ONE transaction so a concurrent recording cannot interleave
+  // between check and write.
+  public Task<Result<BookingKtmbCost?>> RecordKtmbActualCost(Guid id, BookingKtmbCost cost)
+  {
+    return transaction.Start(
+      () =>
+        repo.Get(null, id)
+          .ThenAwait(b =>
+          {
+            if (b == null)
+              return Task.FromResult((Result<BookingKtmbCost?>)(BookingKtmbCost?)null);
+
+            var existing = b.Principal.Complete;
+            // already recorded: report the stored values as success without
+            // overwriting (KtmbCurrency is always set alongside KtmbAmount)
+            if (existing.KtmbAmount != null)
+              return Task.FromResult(
+                (Result<BookingKtmbCost?>)
+                  new BookingKtmbCost
+                  {
+                    Amount = existing.KtmbAmount.Value,
+                    Currency = existing.KtmbCurrency!,
+                  }
+              );
+
+            // an actual paid amount only exists once the ticket was bought —
+            // the worklist pages Completed bookings, so anything else is a
+            // caller error, not a backfill
+            if (b.Principal.Status.Status != BookStatus.Completed)
+            {
+              var r = new InvalidBookingOperationException(
+                "Recording the actual KTMB cost requires a booking in 'Completed' Status",
+                b.Principal.Status.Status,
+                BookingOperations.RecordKtmbCost
+              );
+              return Task.FromResult((Result<BookingKtmbCost?>)r);
+            }
+
+            return repo.Update(
+                null,
+                id,
+                null,
+                null,
+                existing with { KtmbAmount = cost.Amount, KtmbCurrency = cost.Currency }
+              )
+              .NullToError(id.ToString())
+              .Then(BookingKtmbCost? (_) => cost, Errors.MapNone);
+          })
+    );
+  }
+
+  public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbActualCost(
+    int limit,
+    int skip
+  )
+  {
+    return repo.ListMissingKtmbCost(limit, skip);
   }
 
   // AttachTicket repairs the ticket artefacts of an already-Completed booking
@@ -620,14 +688,15 @@ public class BookingService(
                 }
               )
               // no money movement and no status write: repair the ticket
-              // reference and backfill any missing identifiers only
+              // reference and backfill any missing identifiers only (a
+              // recorded actual KTMB cost is preserved untouched)
               .ThenAwait(b =>
                 repo.Update(
                   null,
                   id,
                   null,
                   null,
-                  new BookingComplete
+                  b.Principal.Complete with
                   {
                     Ticket = fileId,
                     BookingNumber = b.Principal.Complete.BookingNumber ?? bookingNo,

--- a/UnitTest/Bookings/BookingAnalysisCalculatorTests.cs
+++ b/UnitTest/Bookings/BookingAnalysisCalculatorTests.cs
@@ -48,6 +48,8 @@ public class BookingAnalysisCalculatorTests
     Coverage = new GatewayFeeCoverage { PaymentsWithFee = 0, PaymentsTotal = 0 },
   };
 
+  private static readonly KtmbActualCoverage NoKtmbCoverage = new() { WithActual = 0, Total = 0 };
+
   private static readonly Dictionary<string, MonthlyExternalSums> NoExternal = new();
 
   [Fact]
@@ -60,7 +62,7 @@ public class BookingAnalysisCalculatorTests
       Row(5, 80m, ktmb: 50m),
     };
 
-    var s = BookingAnalysisCalculator.Summarize(rows, NoDeposits, ZeroSums, NoGatewayFees);
+    var s = BookingAnalysisCalculator.Summarize(rows, NoDeposits, ZeroSums, NoGatewayFees, NoKtmbCoverage);
 
     s.TotalTickets.Should().Be(10);
     s.TotalGross.Should().Be(150m);
@@ -70,7 +72,7 @@ public class BookingAnalysisCalculatorTests
   [Fact]
   public void Empty_rows_produce_zero_totals()
   {
-    var s = BookingAnalysisCalculator.Summarize([], NoDeposits, ZeroSums, NoGatewayFees);
+    var s = BookingAnalysisCalculator.Summarize([], NoDeposits, ZeroSums, NoGatewayFees, NoKtmbCoverage);
 
     s.TotalTickets.Should().Be(0);
     s.TotalGross.Should().Be(0m);
@@ -83,7 +85,7 @@ public class BookingAnalysisCalculatorTests
   {
     var deposits = new DepositSummary { Count = 7, Captured = 350.5m };
 
-    var s = BookingAnalysisCalculator.Summarize([], deposits, ZeroSums, NoGatewayFees);
+    var s = BookingAnalysisCalculator.Summarize([], deposits, ZeroSums, NoGatewayFees, NoKtmbCoverage);
 
     s.Deposits.Count.Should().Be(7);
     s.Deposits.Captured.Should().Be(350.5m);
@@ -94,7 +96,7 @@ public class BookingAnalysisCalculatorTests
   {
     var sums = ZeroSums with { DepositFees = 12.5m, WithdrawalFees = 4m };
 
-    var s = BookingAnalysisCalculator.Summarize([], NoDeposits, sums, NoGatewayFees);
+    var s = BookingAnalysisCalculator.Summarize([], NoDeposits, sums, NoGatewayFees, NoKtmbCoverage);
 
     s.InternalFees.Deposit.Should().Be(12.5m);
     s.InternalFees.Withdrawal.Should().Be(4m);
@@ -107,7 +109,7 @@ public class BookingAnalysisCalculatorTests
     // net is what BunnyBooker actually kept
     var sums = ZeroSums with { PriorityFeesCharged = 50m, PriorityFeesRefunded = 20m };
 
-    var s = BookingAnalysisCalculator.Summarize([], NoDeposits, sums, NoGatewayFees);
+    var s = BookingAnalysisCalculator.Summarize([], NoDeposits, sums, NoGatewayFees, NoKtmbCoverage);
 
     s.InternalFees.Priority.Should().Be(30m);
   }
@@ -119,7 +121,7 @@ public class BookingAnalysisCalculatorTests
     // is the terminated bookings' collected cost minus that refund
     var sums = ZeroSums with { TerminatedGross = 100m, TerminationRefunds = 60m };
 
-    var s = BookingAnalysisCalculator.Summarize([], NoDeposits, sums, NoGatewayFees);
+    var s = BookingAnalysisCalculator.Summarize([], NoDeposits, sums, NoGatewayFees, NoKtmbCoverage);
 
     s.InternalFees.Termination.Should().Be(40m);
   }
@@ -134,12 +136,25 @@ public class BookingAnalysisCalculatorTests
       Coverage = new GatewayFeeCoverage { PaymentsWithFee = 8, PaymentsTotal = 10 },
     };
 
-    var s = BookingAnalysisCalculator.Summarize([], NoDeposits, ZeroSums, gateway);
+    var s = BookingAnalysisCalculator.Summarize([], NoDeposits, ZeroSums, gateway, NoKtmbCoverage);
 
     s.GatewayFees.Payments.Should().Be(12.34m);
     s.GatewayFees.Payouts.Should().Be(5.67m);
     s.GatewayFees.Coverage.PaymentsWithFee.Should().Be(8);
     s.GatewayFees.Coverage.PaymentsTotal.Should().Be(10);
+  }
+
+  [Fact]
+  public void Ktmb_actual_coverage_passes_through_unchanged()
+  {
+    // tin records/backfills the actual paid amount with delay — the summary
+    // reports capture coverage exactly like the gateway-fee coverage
+    var coverage = new KtmbActualCoverage { WithActual = 3, Total = 9 };
+
+    var s = BookingAnalysisCalculator.Summarize([], NoDeposits, ZeroSums, NoGatewayFees, coverage);
+
+    s.KtmbCoverage.WithActual.Should().Be(3);
+    s.KtmbCoverage.Total.Should().Be(9);
   }
 
   [Fact]
@@ -152,7 +167,7 @@ public class BookingAnalysisCalculatorTests
       Row(5, 80m, ktmb: 50m),
     };
 
-    var s = BookingAnalysisCalculator.Summarize(rows, NoDeposits, ZeroSums, NoGatewayFees);
+    var s = BookingAnalysisCalculator.Summarize(rows, NoDeposits, ZeroSums, NoGatewayFees, NoKtmbCoverage);
 
     s.ByDirection.Should().HaveCount(2);
     var jtow = s.ByDirection.Single(d => d.Direction == TrainDirection.JToW);
@@ -180,7 +195,7 @@ public class BookingAnalysisCalculatorTests
       TerminationRefunds = 8m,
     };
 
-    var s = BookingAnalysisCalculator.Summarize(rows, deposits, sums, NoGatewayFees);
+    var s = BookingAnalysisCalculator.Summarize(rows, deposits, sums, NoGatewayFees, NoKtmbCoverage);
 
     s.TotalTickets.Should().Be(4);
     s.TotalGross.Should().Be(64m);

--- a/UnitTest/Bookings/BookingAnalysisCalculatorTests.cs
+++ b/UnitTest/Bookings/BookingAnalysisCalculatorTests.cs
@@ -153,8 +153,8 @@ public class BookingAnalysisCalculatorTests
 
     var s = BookingAnalysisCalculator.Summarize([], NoDeposits, ZeroSums, NoGatewayFees, coverage);
 
-    s.KtmbCoverage.WithActual.Should().Be(3);
-    s.KtmbCoverage.Total.Should().Be(9);
+    s.KtmbActualCoverage.WithActual.Should().Be(3);
+    s.KtmbActualCoverage.Total.Should().Be(9);
   }
 
   [Fact]

--- a/UnitTest/Bookings/BookingServiceAttachTicketTests.cs
+++ b/UnitTest/Bookings/BookingServiceAttachTicketTests.cs
@@ -249,6 +249,9 @@ public class BookingServiceAttachTicketTests
       return Task.FromResult((Result<BookingPrincipal?>)principal);
     }
 
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(int limit, int skip) =>
+      throw new NotImplementedException();
+
     public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>
       throw new NotImplementedException();
 

--- a/UnitTest/Bookings/BookingServiceBuyingGuardTests.cs
+++ b/UnitTest/Bookings/BookingServiceBuyingGuardTests.cs
@@ -220,6 +220,9 @@ public class BookingServiceBuyingGuardTests
     public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee, string? grantedBy = null) =>
       throw new NotImplementedException();
 
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(int limit, int skip) =>
+      throw new NotImplementedException();
+
     public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>
       throw new NotImplementedException();
 

--- a/UnitTest/Bookings/BookingServiceCompleteNoCollectTests.cs
+++ b/UnitTest/Bookings/BookingServiceCompleteNoCollectTests.cs
@@ -215,6 +215,9 @@ public class BookingServiceCompleteNoCollectTests
     public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee, string? grantedBy = null) =>
       throw new NotImplementedException();
 
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(int limit, int skip) =>
+      throw new NotImplementedException();
+
     public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>
       throw new NotImplementedException();
 

--- a/UnitTest/Bookings/BookingServiceKtmbActualCostTests.cs
+++ b/UnitTest/Bookings/BookingServiceKtmbActualCostTests.cs
@@ -1,0 +1,482 @@
+using CSharp_Result;
+using Domain;
+using Domain.Booking;
+using Domain.Exceptions;
+using Domain.Passenger;
+using Domain.Timings;
+using Domain.Transaction;
+using Domain.User;
+using Domain.Wallet;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace UnitTest.Bookings;
+
+// The actual-KTMB-cost capture paths: Complete() persists the optional
+// amount/currency tin sends alongside the ticket; RecordKtmbActualCost() is
+// the after-the-fact backfill — Completed-only, and IDEMPOTENT: once a cost
+// is recorded the stored values are returned as-is and never overwritten (a
+// retried backfill must not rewrite history). AttachTicket() repairs ticket
+// artefacts without disturbing a recorded cost.
+public class BookingServiceKtmbActualCostTests
+{
+  private const decimal Cost = 26m;
+
+  private static (BookingService Service, FakeBookingRepository Repo) Make(Booking booking)
+  {
+    var repo = new FakeBookingRepository(booking);
+    var service = new BookingService(
+      repo,
+      new FakeStorage(),
+      new FakeWalletRepository(),
+      new FakeTransactionRepository(),
+      new PassThroughTransactionManager(),
+      new TransactionGenerator(),
+      null!,
+      null!,
+      new FakeCdc(),
+      new FakeNotifier(),
+      null!,
+      null!,
+      null!,
+      NullLogger<BookingService>.Instance
+    );
+    return (service, repo);
+  }
+
+  private static Booking BookingWith(BookStatus status, BookingComplete complete)
+  {
+    var id = Guid.NewGuid();
+    return new Booking
+    {
+      Principal = new BookingPrincipal
+      {
+        Id = id,
+        UserId = "user-1",
+        CreatedAt = DateTime.UtcNow,
+        Record = new BookingRecord
+        {
+          Date = new DateOnly(2026, 7, 15),
+          Time = new TimeOnly(8, 30),
+          Direction = TrainDirection.JToW,
+          Passenger = new PassengerRecord
+          {
+            FullName = "Test Passenger",
+            Gender = PassengerGender.M,
+            PassportExpiry = new DateOnly(2030, 1, 1),
+            PassportNumber = "P1234567",
+          },
+        },
+        Status = new BookingStatus
+        {
+          Status = status,
+          CompletedAt = status == BookStatus.Completed ? DateTime.UtcNow : null,
+        },
+        Complete = complete,
+      },
+      User = new UserPrincipal
+      {
+        Id = "user-1",
+        Record = new UserRecord { Username = "tester" },
+      },
+      Transaction = new TransactionPrincipal
+      {
+        Id = Guid.NewGuid(),
+        CreatedAt = DateTime.UtcNow,
+        Record = new TransactionRecord
+        {
+          Name = "Purchased Booking Service",
+          Description = "test",
+          Type = TransactionType.BookingRequest,
+          Amount = Cost,
+          From = Accounts.Usable.DisplayName,
+          To = Accounts.BookingReserve.DisplayName,
+        },
+      },
+      Wallet = new WalletPrincipal
+      {
+        Id = Guid.NewGuid(),
+        UserId = "user-1",
+        Record = new WalletRecord
+        {
+          Usable = 100m,
+          WithdrawReserve = 0m,
+          BookingReserve = Cost,
+        },
+      },
+    };
+  }
+
+  private static readonly BookingComplete Uncaptured = new()
+  {
+    Ticket = null,
+    BookingNumber = null,
+    TicketNumber = null,
+  };
+
+  private static readonly BookingComplete CompletedWithoutCost = new()
+  {
+    Ticket = "ticket-file",
+    BookingNumber = "BN-1",
+    TicketNumber = "TN-1",
+  };
+
+  private static readonly BookingComplete CompletedWithCost = new()
+  {
+    Ticket = "ticket-file",
+    BookingNumber = "BN-1",
+    TicketNumber = "TN-1",
+    KtmbAmount = 35.5m,
+    KtmbCurrency = "MYR",
+  };
+
+  private static readonly BookingKtmbCost NewCost = new() { Amount = 40m, Currency = "SGD" };
+
+  // ---- Complete() capture ----
+
+  [Fact]
+  public async Task Complete_with_ktmb_cost_stores_amount_and_currency_on_the_completion()
+  {
+    var booking = BookingWith(BookStatus.Buying, Uncaptured);
+    var (service, repo) = Make(booking);
+
+    var result = await service.Complete(
+      booking.Principal.Id,
+      "BN-1",
+      "TN-1",
+      new MemoryStream([1, 2, 3]),
+      new BookingKtmbCost { Amount = 35.5m, Currency = "MYR" }
+    );
+
+    result.IsSuccess().Should().BeTrue();
+    repo.LastCompleteWritten!.KtmbAmount.Should().Be(35.5m);
+    repo.LastCompleteWritten!.KtmbCurrency.Should().Be("MYR");
+    repo.LastCompleteWritten!.BookingNumber.Should().Be("BN-1");
+    repo.LastCompleteWritten!.TicketNumber.Should().Be("TN-1");
+  }
+
+  [Fact]
+  public async Task Complete_without_ktmb_cost_stores_null_for_the_old_client_path()
+  {
+    var booking = BookingWith(BookStatus.Buying, Uncaptured);
+    var (service, repo) = Make(booking);
+
+    var result = await service.Complete(
+      booking.Principal.Id,
+      "BN-1",
+      "TN-1",
+      new MemoryStream([1, 2, 3])
+    );
+
+    result.IsSuccess().Should().BeTrue();
+    repo.LastCompleteWritten!.KtmbAmount.Should().BeNull();
+    repo.LastCompleteWritten!.KtmbCurrency.Should().BeNull();
+  }
+
+  // ---- RecordKtmbActualCost() backfill ----
+
+  [Fact]
+  public async Task Backfill_on_a_completed_booking_without_cost_records_it()
+  {
+    var booking = BookingWith(BookStatus.Completed, CompletedWithoutCost);
+    var (service, repo) = Make(booking);
+
+    var result = await service.RecordKtmbActualCost(booking.Principal.Id, NewCost);
+
+    result.IsSuccess().Should().BeTrue();
+    result.SuccessOrDefault()!.Amount.Should().Be(40m);
+    result.SuccessOrDefault()!.Currency.Should().Be("SGD");
+    repo.UpdateCalls.Should().Be(1);
+    repo.LastCompleteWritten!.KtmbAmount.Should().Be(40m);
+    repo.LastCompleteWritten!.KtmbCurrency.Should().Be("SGD");
+    // the ticket artefacts must survive the backfill untouched
+    repo.LastCompleteWritten!.Ticket.Should().Be("ticket-file");
+    repo.LastCompleteWritten!.BookingNumber.Should().Be("BN-1");
+    repo.LastCompleteWritten!.TicketNumber.Should().Be("TN-1");
+  }
+
+  [Fact]
+  public async Task Backfill_is_idempotent_and_never_overwrites_a_recorded_cost()
+  {
+    var booking = BookingWith(BookStatus.Completed, CompletedWithCost);
+    var (service, repo) = Make(booking);
+
+    var result = await service.RecordKtmbActualCost(booking.Principal.Id, NewCost);
+
+    // success reporting the STORED values, not the caller's
+    result.IsSuccess().Should().BeTrue("a retried backfill must succeed without rewriting history");
+    result.SuccessOrDefault()!.Amount.Should().Be(35.5m);
+    result.SuccessOrDefault()!.Currency.Should().Be("MYR");
+    repo.UpdateCalls.Should().Be(0, "an already-recorded cost must never be overwritten");
+  }
+
+  [Theory]
+  [InlineData(BookStatus.Pending)]
+  [InlineData(BookStatus.Buying)]
+  [InlineData(BookStatus.Recovering)]
+  [InlineData(BookStatus.Cancelled)]
+  [InlineData(BookStatus.Refunded)]
+  [InlineData(BookStatus.Terminated)]
+  [InlineData(BookStatus.Duplicate)]
+  [InlineData(BookStatus.RequireManualIntervention)]
+  public async Task Backfill_on_a_non_completed_booking_is_rejected(BookStatus status)
+  {
+    var booking = BookingWith(status, Uncaptured);
+    var (service, repo) = Make(booking);
+
+    var result = await service.RecordKtmbActualCost(booking.Principal.Id, NewCost);
+
+    result.IsSuccess().Should().BeFalse($"a '{status}' booking has no actual KTMB purchase to cost");
+    result.FailureOrDefault().Should().BeOfType<InvalidBookingOperationException>();
+    repo.UpdateCalls.Should().Be(0);
+  }
+
+  [Fact]
+  public async Task Backfill_on_a_missing_booking_returns_null()
+  {
+    var (service, _) = Make(null!);
+
+    var result = await service.RecordKtmbActualCost(Guid.NewGuid(), NewCost);
+
+    result.IsSuccess().Should().BeTrue();
+    result.SuccessOrDefault().Should().BeNull();
+  }
+
+  // ---- AttachTicket() preservation ----
+
+  [Fact]
+  public async Task AttachTicket_preserves_a_recorded_ktmb_cost()
+  {
+    var booking = BookingWith(BookStatus.Completed, CompletedWithCost);
+    var (service, repo) = Make(booking);
+
+    var result = await service.AttachTicket(
+      booking.Principal.Id,
+      null,
+      null,
+      new MemoryStream([1, 2, 3])
+    );
+
+    result.IsSuccess().Should().BeTrue();
+    repo.LastCompleteWritten!.KtmbAmount.Should().Be(35.5m);
+    repo.LastCompleteWritten!.KtmbCurrency.Should().Be("MYR");
+  }
+
+  // ---- fakes ----
+
+  private sealed class PassThroughTransactionManager : ITransactionManager
+  {
+    public Task<Result<T>> Start<T>(Func<Task<Result<T>>> func) => func();
+  }
+
+  private sealed class FakeStorage : IBookingStorage
+  {
+    public Task<Result<string>> Save(Stream stream) => Task.FromResult((Result<string>)"file-id");
+
+    public Task<Result<string>> Get(string key) => Task.FromResult((Result<string>)"file-url");
+
+    public Task<Result<bool>> Exists(string key) => Task.FromResult((Result<bool>)true);
+  }
+
+  private sealed class FakeCdc : IBookingCdcRepository
+  {
+    public Task<Result<Unit>> Add(string action) => Task.FromResult((Result<Unit>)new Unit());
+  }
+
+  private sealed class FakeNotifier : IBookingNotificationService
+  {
+    public Task<Result<Unit>> NotifyBookingCompleted(Booking booking) =>
+      Task.FromResult((Result<Unit>)new Unit());
+
+    public Task<Result<Unit>> NotifyBookingCancelled(Booking booking) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Unit>> NotifyBookingTerminated(Booking booking) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Unit>> NotifyBookingRefunded(Booking booking) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Unit>> NotifyBookingDuplicate(Booking booking) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Unit>> NotifyBookingManualIntervention(Booking booking) =>
+      throw new NotImplementedException();
+  }
+
+  private sealed class FakeBookingRepository(Booking? booking) : IBookingRepository
+  {
+    private BookingComplete? completeOverride;
+
+    private BookingStatus? statusOverride;
+
+    public int UpdateCalls { get; private set; }
+
+    public BookingComplete? LastCompleteWritten { get; private set; }
+
+    private Booking? Current()
+    {
+      if (booking == null)
+        return null;
+      var p = booking.Principal with
+      {
+        Complete = completeOverride ?? booking.Principal.Complete,
+        Status = statusOverride ?? booking.Principal.Status,
+      };
+      return booking with { Principal = p };
+    }
+
+    public Task<Result<Booking?>> Get(string? userId, Guid id) =>
+      Task.FromResult((Result<Booking?>)Current());
+
+    public Task<Result<BookingPrincipal?>> Update(
+      string? userId,
+      Guid id,
+      BookingStatus? status,
+      BookingRecord? record,
+      BookingComplete? complete
+    )
+    {
+      UpdateCalls++;
+      if (complete != null)
+      {
+        LastCompleteWritten = complete;
+        completeOverride = complete;
+      }
+      if (status != null)
+        statusOverride = status;
+      return Task.FromResult((Result<BookingPrincipal?>)Current()!.Principal);
+    }
+
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(
+      int limit,
+      int skip
+    ) => throw new NotImplementedException();
+
+    public Task<Result<BookingPrincipal?>> Prioritize(
+      string? userId,
+      Guid id,
+      decimal? fee,
+      string? grantedBy
+    ) => throw new NotImplementedException();
+
+    public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>
+      throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingPrincipal>>> Search(BookingSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<int>> SearchCount(BookingSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<BookingQueuePosition?>> QueuePosition(string? userId, Guid id) =>
+      throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingStatRow>>> Stats(BookingStatsQuery query) =>
+      throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingPrincipal>>> RefundList(DateOnly date, TimeOnly time) =>
+      throw new NotImplementedException();
+
+    public Task<Result<BookingPrincipal>> Create(
+      string userId,
+      Guid transactionId,
+      BookingRecord record,
+      BookingPriceBreakdown? breakdown
+    ) => throw new NotImplementedException();
+
+    public Task<Result<BookingPrincipal?>> Reserve(
+      TrainDirection direction,
+      DateOnly date,
+      TimeOnly time
+    ) => throw new NotImplementedException();
+
+    public Task<Result<int>> CountSlotPriority(
+      TrainDirection direction,
+      DateOnly date,
+      TimeOnly time
+    ) => Task.FromResult((Result<int>)0);
+
+    public Task<Result<Unit?>> Delete(string? userId, Guid id) =>
+      throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingCount>>> Count(
+      DateOnly date,
+      TimeOnly time,
+      DateOnly? filterDate,
+      TrainDirection? filterDirection
+    ) => throw new NotImplementedException();
+  }
+
+  private sealed class FakeWalletRepository : IWalletRepository
+  {
+    private static WalletPrincipal Wallet(Guid id) =>
+      new()
+      {
+        Id = id,
+        UserId = "user-1",
+        Record = new WalletRecord
+        {
+          Usable = 100m,
+          WithdrawReserve = 0m,
+          BookingReserve = 0m,
+        },
+      };
+
+    public Task<Result<WalletPrincipal?>> BookEnd(Guid id, decimal revert, decimal collect) =>
+      Task.FromResult((Result<WalletPrincipal?>)Wallet(id));
+
+    public Task<Result<WalletPrincipal?>> Deposit(Guid id, decimal amount) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WalletPrincipal?>> Collect(Guid id, decimal amount) =>
+      throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<WalletPrincipal>>> Search(WalletSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Wallet?>> Get(Guid id, string? userId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Wallet?>> GetByUserId(string userId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WalletPrincipal?>> PrepareWithdraw(Guid id, decimal amount) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WalletPrincipal?>> Withdraw(Guid id, decimal amount) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WalletPrincipal?>> CancelWithdraw(Guid id, decimal amount) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WalletPrincipal?>> BookStart(Guid id, decimal amount) =>
+      throw new NotImplementedException();
+  }
+
+  private sealed class FakeTransactionRepository : ITransactionRepository
+  {
+    public Task<Result<TransactionPrincipal>> Create(
+      Guid walletId,
+      TransactionRecord record,
+      Guid? paymentId = null
+    ) =>
+      Task.FromResult(
+        (Result<TransactionPrincipal>)
+          new TransactionPrincipal
+          {
+            Id = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+            Record = record,
+          }
+      );
+
+    public Task<Result<IEnumerable<TransactionPrincipal>>> Search(TransactionSearch search) =>
+      throw new NotSupportedException();
+
+    public Task<Result<Domain.Transaction.Transaction?>> Get(Guid id, string? userId) =>
+      throw new NotSupportedException();
+
+    public Task<Result<Unit?>> Delete(Guid id) => throw new NotSupportedException();
+  }
+}

--- a/UnitTest/Bookings/BookingServicePrioritizeTests.cs
+++ b/UnitTest/Bookings/BookingServicePrioritizeTests.cs
@@ -955,6 +955,9 @@ public class BookingServicePrioritizeTests
       return Task.FromResult((Result<BookingPrincipal?>)Current()!.Principal);
     }
 
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(int limit, int skip) =>
+      throw new NotImplementedException();
+
     public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>
       throw new NotImplementedException();
 

--- a/UnitTest/Bookings/BookingServiceRecoverRevertTests.cs
+++ b/UnitTest/Bookings/BookingServiceRecoverRevertTests.cs
@@ -244,6 +244,9 @@ public class BookingServiceRecoverRevertTests
     public Task<Result<Booking?>> Get(string? userId, Guid id) =>
       Task.FromResult((Result<Booking?>)Current());
 
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(int limit, int skip) =>
+      throw new NotImplementedException();
+
     public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id)
     {
       IncrementCalls++;

--- a/UnitTest/Bookings/BookingServiceRevertGuardTests.cs
+++ b/UnitTest/Bookings/BookingServiceRevertGuardTests.cs
@@ -353,6 +353,9 @@ public class BookingServiceRevertGuardTests
     public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee, string? grantedBy = null) =>
       throw new NotImplementedException();
 
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(int limit, int skip) =>
+      throw new NotImplementedException();
+
     public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>
       throw new NotImplementedException();
 

--- a/UnitTest/Bookings/BookingServiceTerminateTests.cs
+++ b/UnitTest/Bookings/BookingServiceTerminateTests.cs
@@ -308,6 +308,9 @@ public class BookingServiceTerminateTests
     public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee, string? grantedBy = null) =>
       throw new NotImplementedException();
 
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(int limit, int skip) =>
+      throw new NotImplementedException();
+
     public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>
       throw new NotImplementedException();
 

--- a/UnitTest/Bookings/BookingServiceTicketHealthTests.cs
+++ b/UnitTest/Bookings/BookingServiceTicketHealthTests.cs
@@ -177,6 +177,9 @@ public class BookingServiceTicketHealthTests
       BookingComplete? complete
     ) => throw new NotImplementedException();
 
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(int limit, int skip) =>
+      throw new NotImplementedException();
+
     public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>
       throw new NotImplementedException();
 

--- a/UnitTest/Bookings/KtmbActualCostTests.cs
+++ b/UnitTest/Bookings/KtmbActualCostTests.cs
@@ -1,0 +1,61 @@
+using Domain.Booking;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// The per-booking analysis costing rule (the SQL CASE mirrors this): the
+// ACTUAL KTMB-paid amount when recorded — SGD as-is, MYR × the FX rate
+// effective at the booking's CompletedAt — else the per-direction estimate.
+// A recorded MYR amount with no effective rate falls back to the estimate
+// rather than guessing a conversion.
+public class KtmbActualCostTests
+{
+  private const decimal Estimate = 12m;
+
+  [Fact]
+  public void No_actual_amount_falls_back_to_the_estimate()
+  {
+    KtmbActualCost.Effective(null, null, 0.32m, Estimate).Should().Be(Estimate);
+  }
+
+  [Fact]
+  public void Sgd_actual_amount_is_used_as_is()
+  {
+    KtmbActualCost.Effective(10.5m, KtmbActualCost.Sgd, null, Estimate).Should().Be(10.5m);
+  }
+
+  [Fact]
+  public void Sgd_ignores_the_fx_rate()
+  {
+    KtmbActualCost.Effective(10.5m, KtmbActualCost.Sgd, 0.32m, Estimate).Should().Be(10.5m);
+  }
+
+  [Fact]
+  public void Myr_actual_amount_converts_at_the_effective_rate()
+  {
+    KtmbActualCost.Effective(35m, KtmbActualCost.Myr, 0.30m, Estimate).Should().Be(10.5m);
+  }
+
+  [Fact]
+  public void Myr_without_an_effective_rate_falls_back_to_the_estimate()
+  {
+    // no rate row effective at the booking's CompletedAt: never guess a
+    // conversion — cost this booking at the per-direction estimate
+    KtmbActualCost.Effective(35m, KtmbActualCost.Myr, null, Estimate).Should().Be(Estimate);
+  }
+
+  [Fact]
+  public void Fallback_estimate_may_be_zero_when_never_configured()
+  {
+    KtmbActualCost.Effective(null, null, null, 0m).Should().Be(0m);
+    KtmbActualCost.Effective(35m, KtmbActualCost.Myr, null, 0m).Should().Be(0m);
+  }
+
+  [Fact]
+  public void An_unknown_currency_falls_back_to_the_estimate()
+  {
+    // the validators only admit MYR/SGD; anything else that slips through
+    // must degrade to the estimate, not silently miscost
+    KtmbActualCost.Effective(35m, "USD", 0.30m, Estimate).Should().Be(Estimate);
+  }
+}

--- a/UnitTest/Bookings/KtmbActualCostValidatorTests.cs
+++ b/UnitTest/Bookings/KtmbActualCostValidatorTests.cs
@@ -1,0 +1,152 @@
+using App.Modules.Bookings.API.V1;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// The request validation around actual-KTMB-cost capture: the paired
+// optional form fields on complete/{id}, the required backfill body, and the
+// MYR -> SGD FX rate queue (rate bounds + no-past effective dating, the
+// SetKtmbCostReq convention).
+public class KtmbActualCostValidatorTests
+{
+  // ---- complete/{id} optional form fields ----
+
+  private readonly CompleteKtmbCostReqValidator completeValidator = new();
+
+  [Fact]
+  public void Complete_without_ktmb_fields_is_valid()
+  {
+    completeValidator.Validate(new CompleteKtmbCostReq(null, null)).IsValid.Should().BeTrue();
+  }
+
+  [Theory]
+  [InlineData("MYR")]
+  [InlineData("SGD")]
+  public void Complete_with_both_fields_is_valid(string currency)
+  {
+    completeValidator
+      .Validate(new CompleteKtmbCostReq(35.5m, currency))
+      .IsValid.Should()
+      .BeTrue();
+  }
+
+  [Fact]
+  public void Complete_with_amount_but_no_currency_is_rejected()
+  {
+    completeValidator.Validate(new CompleteKtmbCostReq(35.5m, null)).IsValid.Should().BeFalse();
+  }
+
+  [Fact]
+  public void Complete_with_currency_but_no_amount_is_rejected()
+  {
+    completeValidator.Validate(new CompleteKtmbCostReq(null, "MYR")).IsValid.Should().BeFalse();
+  }
+
+  [Theory]
+  [InlineData(0)]
+  [InlineData(-1)]
+  public void Complete_with_non_positive_amount_is_rejected(decimal amount)
+  {
+    completeValidator
+      .Validate(new CompleteKtmbCostReq(amount, "MYR"))
+      .IsValid.Should()
+      .BeFalse();
+  }
+
+  [Theory]
+  [InlineData("USD")]
+  [InlineData("myr")]
+  [InlineData("")]
+  public void Complete_with_unknown_currency_is_rejected(string currency)
+  {
+    completeValidator
+      .Validate(new CompleteKtmbCostReq(35.5m, currency))
+      .IsValid.Should()
+      .BeFalse();
+  }
+
+  // ---- the backfill body ----
+
+  private readonly SetBookingKtmbCostReqValidator backfillValidator = new();
+
+  [Theory]
+  [InlineData("MYR")]
+  [InlineData("SGD")]
+  public void Backfill_with_positive_amount_and_known_currency_is_valid(string currency)
+  {
+    backfillValidator
+      .Validate(new SetBookingKtmbCostReq(35.5m, currency))
+      .IsValid.Should()
+      .BeTrue();
+  }
+
+  [Theory]
+  [InlineData(0)]
+  [InlineData(-1)]
+  public void Backfill_with_non_positive_amount_is_rejected(decimal amount)
+  {
+    backfillValidator
+      .Validate(new SetBookingKtmbCostReq(amount, "MYR"))
+      .IsValid.Should()
+      .BeFalse();
+  }
+
+  [Theory]
+  [InlineData("USD")]
+  [InlineData("sgd")]
+  public void Backfill_with_unknown_currency_is_rejected(string currency)
+  {
+    backfillValidator
+      .Validate(new SetBookingKtmbCostReq(35.5m, currency))
+      .IsValid.Should()
+      .BeFalse();
+  }
+
+  // ---- the FX rate queue ----
+
+  private readonly SetKtmbFxRateReqValidator fxValidator = new();
+
+  [Theory]
+  [InlineData(0.01)]
+  [InlineData(0.32)]
+  [InlineData(100)]
+  public void Fx_rate_within_bounds_is_valid(decimal rate)
+  {
+    fxValidator.Validate(new SetKtmbFxRateReq(rate, null)).IsValid.Should().BeTrue();
+  }
+
+  [Theory]
+  [InlineData(0)]
+  [InlineData(-0.3)]
+  [InlineData(100.01)]
+  public void Fx_rate_out_of_bounds_is_rejected(decimal rate)
+  {
+    fxValidator.Validate(new SetKtmbFxRateReq(rate, null)).IsValid.Should().BeFalse();
+  }
+
+  [Fact]
+  public void Fx_future_effective_date_is_valid()
+  {
+    fxValidator
+      .Validate(new SetKtmbFxRateReq(0.32m, DateTime.UtcNow.AddDays(1)))
+      .IsValid.Should()
+      .BeTrue();
+  }
+
+  [Fact]
+  public void Fx_past_effective_date_is_rejected()
+  {
+    // a past effective date inserts a row that can never win the
+    // newest-effective ordering — a silently dead change
+    fxValidator
+      .Validate(new SetKtmbFxRateReq(0.32m, DateTime.UtcNow.AddDays(-1)))
+      .IsValid.Should()
+      .BeFalse();
+  }
+
+  [Fact]
+  public void Fx_omitted_effective_date_means_immediate_and_is_valid()
+  {
+    fxValidator.Validate(new SetKtmbFxRateReq(0.32m, null)).IsValid.Should().BeTrue();
+  }
+}

--- a/UnitTest/Bookings/KtmbActualCostValidatorTests.cs
+++ b/UnitTest/Bookings/KtmbActualCostValidatorTests.cs
@@ -109,7 +109,7 @@ public class KtmbActualCostValidatorTests
   [Theory]
   [InlineData(0.01)]
   [InlineData(0.32)]
-  [InlineData(100)]
+  [InlineData(1000)]
   public void Fx_rate_within_bounds_is_valid(decimal rate)
   {
     fxValidator.Validate(new SetKtmbFxRateReq(rate, null)).IsValid.Should().BeTrue();
@@ -118,9 +118,10 @@ public class KtmbActualCostValidatorTests
   [Theory]
   [InlineData(0)]
   [InlineData(-0.3)]
-  [InlineData(100.01)]
+  [InlineData(1000.01)]
   public void Fx_rate_out_of_bounds_is_rejected(decimal rate)
   {
+    // argon validates the same 0 < rate <= 1000 bound client-side
     fxValidator.Validate(new SetKtmbFxRateReq(rate, null)).IsValid.Should().BeFalse();
   }
 

--- a/UnitTest/Bookings/KtmbBackfillWorklistTests.cs
+++ b/UnitTest/Bookings/KtmbBackfillWorklistTests.cs
@@ -1,0 +1,79 @@
+using App.Modules.Bookings.Data;
+using Domain.Booking;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// The tin backfill worklist predicate (KtmbBackfill.Missing): Completed
+// bookings that captured a KTMB reservation (BookingNo + TicketNo present)
+// but have no actual paid amount recorded yet. ListMissingKtmbCost pages
+// with it DB-side — these tests pin the filter in-memory.
+public class KtmbBackfillWorklistTests
+{
+  private static readonly Func<BookingData, bool> Missing = KtmbBackfill.Missing.Compile();
+
+  private static BookingData Booking(
+    BookStatus status = BookStatus.Completed,
+    string? bookingNo = "BN-1",
+    string? ticketNo = "TN-1",
+    decimal? ktmbAmount = null,
+    DateTime? completedAt = null
+  ) =>
+    new()
+    {
+      Id = Guid.NewGuid(),
+      Status = (byte)status,
+      CompletedAt = completedAt ?? new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc),
+      BookingNo = bookingNo,
+      TicketNo = ticketNo,
+      KtmbAmount = ktmbAmount,
+      KtmbCurrency = ktmbAmount == null ? null : "MYR",
+    };
+
+  [Fact]
+  public void A_completed_booking_with_identifiers_and_no_actual_cost_is_on_the_worklist()
+  {
+    Missing(Booking()).Should().BeTrue();
+  }
+
+  [Fact]
+  public void A_booking_with_a_recorded_actual_cost_is_off_the_worklist()
+  {
+    Missing(Booking(ktmbAmount: 35.5m)).Should().BeFalse();
+  }
+
+  [Theory]
+  [InlineData(BookStatus.Pending)]
+  [InlineData(BookStatus.Buying)]
+  [InlineData(BookStatus.Recovering)]
+  [InlineData(BookStatus.Cancelled)]
+  [InlineData(BookStatus.Refunded)]
+  [InlineData(BookStatus.Terminated)]
+  [InlineData(BookStatus.Duplicate)]
+  [InlineData(BookStatus.RequireManualIntervention)]
+  public void A_non_completed_booking_is_off_the_worklist(BookStatus status)
+  {
+    Missing(Booking(status)).Should().BeFalse();
+  }
+
+  [Fact]
+  public void A_booking_without_a_booking_number_is_off_the_worklist()
+  {
+    // no KTMB identifiers = nothing tin can look up on KTMB's side
+    Missing(Booking(bookingNo: null)).Should().BeFalse();
+  }
+
+  [Fact]
+  public void A_booking_without_a_ticket_number_is_off_the_worklist()
+  {
+    Missing(Booking(ticketNo: null)).Should().BeFalse();
+  }
+
+  [Fact]
+  public void A_booking_without_a_completion_instant_is_off_the_worklist()
+  {
+    var b = Booking();
+    b.CompletedAt = null;
+    Missing(b).Should().BeFalse();
+  }
+}

--- a/UnitTest/Bookings/KtmbFxRateScheduleTests.cs
+++ b/UnitTest/Bookings/KtmbFxRateScheduleTests.cs
@@ -32,8 +32,7 @@ public class KtmbFxRateScheduleTests
 
     var view = KtmbFxRateSchedule.View([], Now);
     view.Current.Should().BeNull();
-    view.Upcoming.Should().BeEmpty();
-    view.History.Should().BeEmpty();
+    view.Recent.Should().BeEmpty();
   }
 
   [Fact]
@@ -49,15 +48,15 @@ public class KtmbFxRateScheduleTests
   }
 
   [Fact]
-  public void Future_rows_queue_and_do_not_apply_yet()
+  public void Future_rows_do_not_apply_yet_but_still_list_in_recent()
   {
     var future = Change(0.35m, Now.AddDays(2));
     var changes = new[] { Change(0.30m, Now.AddDays(-1)), future };
 
     var view = KtmbFxRateSchedule.View(changes, Now);
 
-    view.Current.Should().Be(0.30m);
-    view.Upcoming.Should().ContainSingle(x => x.Id == future.Id);
+    view.Current!.Rate.Should().Be(0.30m);
+    view.Recent.Should().Contain(x => x.Id == future.Id);
   }
 
   [Fact]
@@ -113,7 +112,7 @@ public class KtmbFxRateScheduleTests
   }
 
   [Fact]
-  public void History_lists_effective_rows_newest_first()
+  public void Recent_lists_every_row_most_recent_first()
   {
     var changes = new[]
     {
@@ -124,7 +123,7 @@ public class KtmbFxRateScheduleTests
 
     var view = KtmbFxRateSchedule.View(changes, Now);
 
-    view.History.Select(x => x.Rate).Should().Equal(0.32m, 0.30m);
-    view.Upcoming.Select(x => x.Rate).Should().Equal(0.35m);
+    view.Recent.Select(x => x.Rate).Should().Equal(0.35m, 0.32m, 0.30m);
+    view.Current!.Rate.Should().Be(0.32m);
   }
 }

--- a/UnitTest/Bookings/KtmbFxRateScheduleTests.cs
+++ b/UnitTest/Bookings/KtmbFxRateScheduleTests.cs
@@ -1,0 +1,130 @@
+using Domain.Booking;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// The effective-dating rule behind the MYR -> SGD rate queue: the newest row
+// whose EffectiveAt has passed wins; future rows queue; no configured row =
+// NO rate (null — the analysis falls back to the estimate rather than
+// guessing a conversion). The analysis SQL implements the same rule DB-side
+// — this pure schedule is the in-memory source of truth.
+public class KtmbFxRateScheduleTests
+{
+  private static readonly DateTime Now = new(2026, 7, 10, 12, 0, 0, DateTimeKind.Utc);
+
+  private static KtmbFxRateChange Change(
+    decimal rate,
+    DateTime effectiveAt,
+    DateTime? createdAt = null
+  ) =>
+    new()
+    {
+      Id = Guid.NewGuid(),
+      Rate = rate,
+      EffectiveAt = effectiveAt,
+      CreatedAt = createdAt ?? effectiveAt,
+    };
+
+  [Fact]
+  public void No_configured_rows_means_no_rate()
+  {
+    KtmbFxRateSchedule.EffectiveRate([], Now).Should().BeNull();
+
+    var view = KtmbFxRateSchedule.View([], Now);
+    view.Current.Should().BeNull();
+    view.Upcoming.Should().BeEmpty();
+    view.History.Should().BeEmpty();
+  }
+
+  [Fact]
+  public void Newest_effective_row_wins()
+  {
+    var changes = new[]
+    {
+      Change(0.30m, Now.AddDays(-10)),
+      Change(0.32m, Now.AddDays(-1)),
+    };
+
+    KtmbFxRateSchedule.EffectiveRate(changes, Now).Should().Be(0.32m);
+  }
+
+  [Fact]
+  public void Future_rows_queue_and_do_not_apply_yet()
+  {
+    var future = Change(0.35m, Now.AddDays(2));
+    var changes = new[] { Change(0.30m, Now.AddDays(-1)), future };
+
+    var view = KtmbFxRateSchedule.View(changes, Now);
+
+    view.Current.Should().Be(0.30m);
+    view.Upcoming.Should().ContainSingle(x => x.Id == future.Id);
+  }
+
+  [Fact]
+  public void A_queued_row_takes_over_once_its_instant_passes()
+  {
+    var changes = new[]
+    {
+      Change(0.30m, Now.AddDays(-10)),
+      Change(0.35m, Now.AddDays(2)),
+    };
+
+    // the exact effective instant is inclusive (EffectiveAt <= at)
+    KtmbFxRateSchedule.EffectiveRate(changes, Now.AddDays(2)).Should().Be(0.35m);
+  }
+
+  [Fact]
+  public void Bookings_are_rated_at_their_own_completion_instant()
+  {
+    // the analysis converts each booking at ITS CompletedAt, not at "now":
+    // a booking completed before a rate change keeps the old rate
+    var changes = new[]
+    {
+      Change(0.30m, new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc)),
+      Change(0.32m, new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc)),
+    };
+
+    var june = new DateTime(2026, 6, 15, 0, 0, 0, DateTimeKind.Utc);
+    var july = new DateTime(2026, 7, 15, 0, 0, 0, DateTimeKind.Utc);
+    KtmbFxRateSchedule.EffectiveRate(changes, june).Should().Be(0.30m);
+    KtmbFxRateSchedule.EffectiveRate(changes, july).Should().Be(0.32m);
+  }
+
+  [Fact]
+  public void A_booking_completed_before_the_first_effective_row_has_no_rate()
+  {
+    var changes = new[] { Change(0.30m, new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc)) };
+
+    var june = new DateTime(2026, 6, 15, 0, 0, 0, DateTimeKind.Utc);
+    KtmbFxRateSchedule.EffectiveRate(changes, june).Should().BeNull();
+  }
+
+  [Fact]
+  public void Same_effective_instant_ties_break_on_newest_created()
+  {
+    var effective = Now.AddDays(-1);
+    var changes = new[]
+    {
+      Change(0.30m, effective, Now.AddDays(-3)),
+      Change(0.31m, effective, Now.AddDays(-2)),
+    };
+
+    KtmbFxRateSchedule.EffectiveRate(changes, Now).Should().Be(0.31m);
+  }
+
+  [Fact]
+  public void History_lists_effective_rows_newest_first()
+  {
+    var changes = new[]
+    {
+      Change(0.30m, Now.AddDays(-10)),
+      Change(0.32m, Now.AddDays(-1)),
+      Change(0.35m, Now.AddDays(2)),
+    };
+
+    var view = KtmbFxRateSchedule.View(changes, Now);
+
+    view.History.Select(x => x.Rate).Should().Equal(0.32m, 0.30m);
+    view.Upcoming.Select(x => x.Rate).Should().Equal(0.35m);
+  }
+}

--- a/UnitTest/Bookings/KtmbWireContractTests.cs
+++ b/UnitTest/Bookings/KtmbWireContractTests.cs
@@ -1,0 +1,79 @@
+using System.Text.Json;
+using App.Modules.Bookings.API.V1;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// argon (PR #281) and tin (PR #44) hand-added these EXACT wire shapes — pin
+// the serialized JSON so a rename on our side can never silently break them.
+// ASP.NET Core serializes with JsonSerializerDefaults.Web (camelCase).
+public class KtmbWireContractTests
+{
+  private static readonly JsonSerializerOptions Web = new(JsonSerializerDefaults.Web);
+
+  [Fact]
+  public void Fx_rate_view_serializes_as_current_and_recent_rows()
+  {
+    var at = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+    var row = new KtmbFxRateRowRes(0.32m, at, at);
+    var res = new KtmbFxRateRes(row, [row]);
+
+    var json = JsonSerializer.Serialize(res, Web);
+
+    json.Should().Be(
+      "{\"current\":{\"rate\":0.32,\"effectiveAt\":\"2026-07-01T00:00:00Z\",\"createdAt\":\"2026-07-01T00:00:00Z\"},"
+        + "\"recent\":[{\"rate\":0.32,\"effectiveAt\":\"2026-07-01T00:00:00Z\",\"createdAt\":\"2026-07-01T00:00:00Z\"}]}"
+    );
+  }
+
+  [Fact]
+  public void Fx_rate_view_serializes_null_current_before_any_row()
+  {
+    var json = JsonSerializer.Serialize(new KtmbFxRateRes(null, []), Web);
+
+    json.Should().Be("{\"current\":null,\"recent\":[]}");
+  }
+
+  [Fact]
+  public void Actual_coverage_serializes_as_withActual_and_total()
+  {
+    var json = JsonSerializer.Serialize(new KtmbActualCoverageRes(3, 9), Web);
+
+    json.Should().Be("{\"withActual\":3,\"total\":9}");
+  }
+
+  [Fact]
+  public void Missing_worklist_row_serializes_as_id_bookingNo_ticketNo_completedAt()
+  {
+    var id = Guid.Parse("11111111-2222-3333-4444-555555555555");
+    var at = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    var json = JsonSerializer.Serialize(new KtmbCostMissingRes(id, "BN-1", "TN-1", at), Web);
+
+    json.Should().Be(
+      "{\"id\":\"11111111-2222-3333-4444-555555555555\",\"bookingNo\":\"BN-1\","
+        + "\"ticketNo\":\"TN-1\",\"completedAt\":\"2026-07-01T00:00:00Z\"}"
+    );
+  }
+
+  [Fact]
+  public void Backfill_body_binds_amount_and_currency()
+  {
+    var req = JsonSerializer.Deserialize<SetBookingKtmbCostReq>(
+      "{\"amount\": 35.5, \"currency\": \"MYR\"}",
+      Web
+    );
+
+    req!.Amount.Should().Be(35.5m);
+    req.Currency.Should().Be("MYR");
+  }
+
+  [Fact]
+  public void Fx_post_body_binds_rate_and_optional_effectiveAt()
+  {
+    var req = JsonSerializer.Deserialize<SetKtmbFxRateReq>("{\"rate\": 0.32}", Web);
+
+    req!.Rate.Should().Be(0.32m);
+    req.EffectiveAt.Should().BeNull();
+  }
+}


### PR DESCRIPTION
## Summary

tin knows the exact amount paid to KTMB (in MYR) when it buys a ticket, but zinc never stored it — the admin Sales Analysis costed every booking at an admin-entered per-direction estimate (`KtmbCosts`). This adds actual per-booking cost capture, a backfill path for historical bookings, and an admin-entered effective-dated MYR→SGD FX rate, then makes the analysis prefer actuals.

## API (per the agreed tin/argon contract)

1. **`POST /api/v1/Booking/complete/{id}`** (existing multipart) gains optional form fields `ktmbAmount` (decimal, > 0) and `ktmbCurrency` (`MYR`|`SGD`; both present or both absent). Stored on the booking completion.
2. **`GET /api/v1/Booking/ktmb-cost/missing?Limit=&Skip=`** (AdminOrTin): pages Completed bookings that have `BookingNo`+`TicketNo` but no actual cost yet → `[{id, bookingNo, ticketNo, completedAt}]`, ordered `CompletedAt` asc — the tin backfill worklist.
3. **`POST /api/v1/Booking/{id}/ktmb-cost`** (AdminOrTin), body `{amount, currency}`: records the actual cost after the fact. **Idempotent** — if already set, returns the stored values as success without overwriting. Guarded to Completed bookings.
4. **`POST /api/v1/Booking/ktmb-fx`** `{rate, effectiveAt?}` (OnlyAdmin) and **`GET /api/v1/Booking/ktmb-fx`** (OnlyAdmin) → `{ current: <row|null>, recent: [<row>...] }` where a row is `{rate, effectiveAt, createdAt}` (most recent first): insert-only, effective-dated MYR→SGD rate rows (SGD per 1 MYR), exactly the `KtmbCosts` pattern. Validates `0 < rate <= 1000` (matching argon's client-side bound); `effectiveAt` must not be in the past (mirrors `SetKtmbCostReqValidator`).
5. **Analysis**: per completed booking, KTMB cost = actual amount when recorded (SGD as-is; MYR × the rate effective at its `CompletedAt`; no effective rate ⇒ that booking falls back to the estimate) else the per-direction `KtmbCosts` estimate. The summary gains actual-cost coverage `ktmbActualCoverage {withActual, total}` (mirrors `GatewayFeeCoverage`).

## Implementation

- **Migration `20260714074808_AddKtmbActualCostAndFxRates`**: nullable `Bookings.KtmbAmount` (numeric(16,8)) + `Bookings.KtmbCurrency` (varchar(8)), new `KtmbFxRates` table with an `EffectiveAt` index.
- Domain/Data/API layering, Result monad, mapper + validator conventions follow the repo patterns; the pure `KtmbFxRateSchedule` / `KtmbActualCost` helpers are the in-memory source of truth the analysis SQL mirrors (same convention as `KtmbCostSchedule`).
- `AttachTicket` preserves a recorded actual cost; `Complete` remains guarded to uncaptured bookings so a recorded cost can never be clobbered.
- The worklist predicate lives in `KtmbBackfill.Missing` (the `BookingQueue` convention) so the DB filter and the unit tests share one definition.
- Wire-contract tests pin the exact serialized JSON shapes argon (PR #281) and tin (PR #44) hand-coded against.

## Tests

597 unit tests green (523 baseline + 74 new), covering: complete-with-amount stored (and the legacy no-amount path), backfill idempotency + Completed-only guard + 404 path, missing-worklist filtering, fx-rate + actual-cost request validation, FX effective-dating math, analysis conversion incl. MYR-without-rate fallback and coverage counts, AttachTicket preservation, and the exact wire shapes.

## Assumptions documented

- `ktmbCurrency` is restricted to `MYR`|`SGD` — the only currencies the analysis can cost; anything else would silently fall back to the estimate forever.
- The backfill endpoint requires the booking to be Completed (the worklist only pages Completed bookings); missing booking → 404.
- `GET ktmb-fx`'s `recent` includes queued future rows (most recent `effectiveAt` first) so an admin can see a scheduled change; `current` is the row in effect now.
- Backfill worklist default page size is 100 (max 100 via the shared `Limit()` validator).