### PR TITLE
feat(booking): travel-date quarter-day demand analysis

### DIFF
--- a/App/Modules/Bookings/API/V1/BookingController.cs
+++ b/App/Modules/Bookings/API/V1/BookingController.cs
@@ -133,6 +133,24 @@ public class BookingController(
     return this.ReturnResult(x);
   }
 
+  // The travel-date demand view for the admin Analysis page: how many
+  // tickets are secured FOR each travel date (b.Date, not CompletedAt), per
+  // direction, collapsed into quarter-day (6-hour) departure buckets — only
+  // buckets with completed tickets are returned, ordered by date, direction,
+  // bucket. After/Before are inclusive travel dates; null = unbounded.
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("analysis/travel")]
+  public async Task<ActionResult<IEnumerable<BookingTravelAnalysisRowRes>>> TravelAnalysis(
+    [FromQuery] BookingTravelAnalysisQueryReq query,
+    [FromServices] BookingTravelAnalysisQueryReqValidator travelValidator
+  )
+  {
+    var x = await travelValidator
+      .ValidateAsyncResult(query, "Invalid BookingTravelAnalysisQueryReq")
+      .ThenAwait(q => analysisRepo.TravelAnalysis(q.ToDomain()))
+      .Then(rows => rows.Select(r => r.ToRes()), Errors.MapAll);
+    return this.ReturnResult(x);
+  }
+
   // The boost ledger: who prioritized which booking, when, for what fee (or
   // free). BoostedAt falls back to the booking's CreatedAt for boosts that
   // predate the PrioritizedAt stamp; GrantedBy identifies admin-granted

--- a/App/Modules/Bookings/API/V1/BookingMapper.cs
+++ b/App/Modules/Bookings/API/V1/BookingMapper.cs
@@ -156,6 +156,13 @@ public static class BookingMapper
       new ComponentsCoverageRes(a.ComponentsCoverage.WithBreakdown, a.ComponentsCoverage.Total)
     );
 
+  // travel-date demand view
+  public static TravelAnalysisQuery ToDomain(this BookingTravelAnalysisQueryReq req) =>
+    new() { After = req.After?.ToDate(), Before = req.Before?.ToDate() };
+
+  public static BookingTravelAnalysisRowRes ToRes(this TravelAnalysisRow r) =>
+    new(r.Date.ToStandardDateFormat(), r.Direction.ToRes(), r.QuarterStartHour, r.Tickets);
+
   // boost ledger
   public static BookingBoostQuery ToDomain(this BookingBoostQueryReq req) =>
     new()

--- a/App/Modules/Bookings/API/V1/BookingModel.cs
+++ b/App/Modules/Bookings/API/V1/BookingModel.cs
@@ -26,6 +26,10 @@ public record BookingStatsQueryReq(string? After, string? Before);
 // unbounded) — the admin Analysis page source
 public record BookingAnalysisQueryReq(string? After, string? Before);
 
+// travel-date demand range (dd-MM-yyyy, inclusive TRAVEL dates — not
+// completion dates; null = unbounded) — the admin demand view source
+public record BookingTravelAnalysisQueryReq(string? After, string? Before);
+
 // the boost ledger page (dd-MM-yyyy inclusive SGT dates; Limit default 50
 // max 200, Skip offset)
 public record BookingBoostQueryReq(string? After, string? Before, int? Limit, int? Skip);
@@ -165,6 +169,18 @@ public record BookingAnalysisRowRes(
   int TicketsCompleted,
   decimal GrossRevenue,
   decimal KtmbCost
+);
+
+// one travel-demand row — argon's hand-added contract shape, exactly
+// { date, direction, quarterStartHour, tickets }: completed tickets
+// travelling on this dd-MM-yyyy date, in this direction, departing within
+// the 6-hour bucket starting at QuarterStartHour (0, 6, 12 or 18); only
+// buckets with tickets > 0 are returned
+public record BookingTravelAnalysisRowRes(
+  string Date,
+  string Direction,
+  int QuarterStartHour,
+  int Tickets
 );
 
 public record DepositSummaryRes(int Count, decimal Captured);

--- a/App/Modules/Bookings/API/V1/BookingValidator.cs
+++ b/App/Modules/Bookings/API/V1/BookingValidator.cs
@@ -101,6 +101,16 @@ public class BookingAnalysisQueryReqValidator : AbstractValidator<BookingAnalysi
   }
 }
 
+public class BookingTravelAnalysisQueryReqValidator
+  : AbstractValidator<BookingTravelAnalysisQueryReq>
+{
+  public BookingTravelAnalysisQueryReqValidator()
+  {
+    this.RuleFor(x => x.After).NullableDateValid();
+    this.RuleFor(x => x.Before).NullableDateValid();
+  }
+}
+
 public class BookingBoostQueryReqValidator : AbstractValidator<BookingBoostQueryReq>
 {
   public BookingBoostQueryReqValidator()

--- a/App/Modules/Bookings/Data/BookingAnalysisRepository.cs
+++ b/App/Modules/Bookings/Data/BookingAnalysisRepository.cs
@@ -359,6 +359,60 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
     }
   }
 
+  // The travel-date demand view: completed tickets per TRAVEL date,
+  // direction and quarter-day (6-hour) departure bucket. Travel Date/Time
+  // are SGT wall-clock columns, so the inclusive range filter and grouping
+  // need no timezone conversion — one grouped scan per timeslot DB-side,
+  // collapsed into buckets by the pure calculator (which owns the spec's
+  // filters and ordering).
+  public async Task<Result<TravelAnalysisRow[]>> TravelAnalysis(TravelAnalysisQuery query)
+  {
+    try
+    {
+      logger.LogInformation("Computing travel analysis with {@Query}", query.ToJson());
+      var completed = (byte)BookStatus.Completed;
+      var bookings = db.Bookings.Where(b => b.Status == completed);
+      if (query.After is { } after)
+        bookings = bookings.Where(b => b.Date >= after);
+      if (query.Before is { } before)
+        bookings = bookings.Where(b => b.Date <= before);
+
+      var slots = await bookings
+        .GroupBy(b => new
+        {
+          b.Date,
+          b.Direction,
+          b.Time,
+        })
+        .Select(g => new
+        {
+          g.Key.Date,
+          g.Key.Direction,
+          g.Key.Time,
+          Tickets = g.Count(),
+        })
+        .ToArrayAsync();
+
+      return TravelAnalysisCalculator.Analyze(
+        slots.Select(s => new TravelSlotCount
+        {
+          Date = s.Date,
+          Direction = s.Direction.ToTrainDirection(),
+          Time = s.Time,
+          Status = BookStatus.Completed,
+          Tickets = s.Tickets,
+        }),
+        query.After,
+        query.Before
+      );
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to compute travel analysis with {@Query}", query.ToJson());
+      return e;
+    }
+  }
+
   // Revenue by pricing component over completed bookings in range: explode
   // the persisted price-breakdown JSON DB-side and aggregate per (kind,
   // name); priority-boost revenue comes from the PriorityFee column. Only

--- a/Domain/Booking/Analysis.cs
+++ b/Domain/Booking/Analysis.cs
@@ -364,9 +364,92 @@ public record BookingBoostPage
   public required BookingBoost[] Items { get; init; }
 }
 
+// ---- travel-date demand view (GET Booking/analysis/travel) ----
+
+// Demand view for the admin Analysis page: how many tickets are secured FOR
+// each travel date, per direction, collapsed into quarter-day (6-hour)
+// departure buckets — a day is 4 scannable rows instead of every timeslot.
+// Unlike BookingAnalysisQuery this ranges over the booking's TRAVEL date
+// (b.Date), not CompletedAt.
+public record TravelAnalysisQuery
+{
+  // inclusive TRAVEL-date range; null = unbounded. Travel Date/Time are SGT
+  // wall-clock columns already, so no instant conversion is involved.
+  public DateOnly? After { get; init; }
+
+  public DateOnly? Before { get; init; }
+}
+
+// one scanned timeslot: how many bookings share this travel
+// date/direction/departure time at this status — the raw input the
+// calculator filters and collapses into quarter-day buckets
+public record TravelSlotCount
+{
+  public required DateOnly Date { get; init; }
+
+  public required TrainDirection Direction { get; init; }
+
+  public required TimeOnly Time { get; init; }
+
+  public required BookStatus Status { get; init; }
+
+  public required int Tickets { get; init; }
+}
+
+// one quarter-day demand row: completed tickets travelling on this date, in
+// this direction, departing within [QuarterStartHour, QuarterStartHour + 6)
+public record TravelAnalysisRow
+{
+  // the booking's TRAVEL date (SGT wall-clock), NOT its CompletedAt date
+  public required DateOnly Date { get; init; }
+
+  public required TrainDirection Direction { get; init; }
+
+  // floor of the departure hour to 6h buckets: 0, 6, 12 or 18
+  public required int QuarterStartHour { get; init; }
+
+  public required int Tickets { get; init; }
+}
+
+// Pure demand math, shared by the repository and the unit tests. Analyze is
+// the full specification — only Completed bookings count, the travel-date
+// range is inclusive on both ends, and only buckets with tickets remain —
+// while the repository pushes the same filters into SQL so the scan stays
+// cheap and reuses this for the bucket/order stage.
+public static class TravelAnalysisCalculator
+{
+  // [0,6) -> 0, [6,12) -> 6, [12,18) -> 12, [18,24) -> 18
+  public static int QuarterStartHour(TimeOnly time) => time.Hour / 6 * 6;
+
+  public static TravelAnalysisRow[] Analyze(
+    IEnumerable<TravelSlotCount> slots,
+    DateOnly? after,
+    DateOnly? before
+  ) =>
+    [
+      .. slots
+        .Where(s => s.Status == BookStatus.Completed)
+        .Where(s => (after is null || s.Date >= after) && (before is null || s.Date <= before))
+        .GroupBy(s => (s.Date, s.Direction, Quarter: QuarterStartHour(s.Time)))
+        .Select(g => new TravelAnalysisRow
+        {
+          Date = g.Key.Date,
+          Direction = g.Key.Direction,
+          QuarterStartHour = g.Key.Quarter,
+          Tickets = g.Sum(s => s.Tickets),
+        })
+        .Where(r => r.Tickets > 0)
+        .OrderBy(r => r.Date)
+        .ThenBy(r => r.Direction)
+        .ThenBy(r => r.QuarterStartHour),
+    ];
+}
+
 public interface IBookingAnalysisRepository
 {
   Task<Result<BookingAnalysis>> Analyze(BookingAnalysisQuery query);
+
+  Task<Result<TravelAnalysisRow[]>> TravelAnalysis(TravelAnalysisQuery query);
 
   Task<Result<BookingBoostPage>> Boosts(BookingBoostQuery query);
 }

--- a/UnitTest/Bookings/TravelAnalysisCalculatorTests.cs
+++ b/UnitTest/Bookings/TravelAnalysisCalculatorTests.cs
@@ -1,0 +1,158 @@
+using Domain.Booking;
+using Domain.Timings;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// The pure demand math behind GET Booking/analysis/travel: departure hours
+// floor to quarter-day (6-hour) buckets, only Completed bookings count, the
+// travel-date range is inclusive on both ends (null = unbounded), buckets
+// without tickets never appear, and rows order by date, direction, bucket.
+public class TravelAnalysisCalculatorTests
+{
+  private static TravelSlotCount Slot(
+    TimeOnly time,
+    DateOnly? date = null,
+    TrainDirection direction = TrainDirection.JToW,
+    BookStatus status = BookStatus.Completed,
+    int tickets = 1
+  ) =>
+    new()
+    {
+      Date = date ?? new DateOnly(2026, 8, 1),
+      Direction = direction,
+      Time = time,
+      Status = status,
+      Tickets = tickets,
+    };
+
+  [Theory]
+  [InlineData(0, 0, 0)]
+  [InlineData(5, 59, 0)]
+  [InlineData(6, 0, 6)]
+  [InlineData(11, 59, 6)]
+  [InlineData(12, 0, 12)]
+  [InlineData(17, 59, 12)]
+  [InlineData(18, 0, 18)]
+  [InlineData(23, 59, 18)]
+  public void Departure_hours_floor_to_quarter_day_buckets(int hour, int minute, int expected)
+  {
+    TravelAnalysisCalculator.QuarterStartHour(new TimeOnly(hour, minute)).Should().Be(expected);
+  }
+
+  [Fact]
+  public void Timeslots_in_the_same_bucket_collapse_and_sum_tickets()
+  {
+    var rows = TravelAnalysisCalculator.Analyze(
+      [Slot(new TimeOnly(8, 30), tickets: 2), Slot(new TimeOnly(11, 0), tickets: 3)],
+      null,
+      null
+    );
+
+    rows.Should().HaveCount(1);
+    rows[0].QuarterStartHour.Should().Be(6);
+    rows[0].Tickets.Should().Be(5);
+  }
+
+  [Fact]
+  public void Only_completed_bookings_count()
+  {
+    var rows = TravelAnalysisCalculator.Analyze(
+      [
+        Slot(new TimeOnly(8, 30), status: BookStatus.Pending),
+        Slot(new TimeOnly(8, 30), status: BookStatus.Buying),
+        Slot(new TimeOnly(8, 30), status: BookStatus.Cancelled),
+        Slot(new TimeOnly(8, 30), status: BookStatus.Refunded),
+        Slot(new TimeOnly(8, 30), status: BookStatus.Terminated),
+        Slot(new TimeOnly(8, 30), tickets: 4),
+      ],
+      null,
+      null
+    );
+
+    rows.Should().HaveCount(1);
+    rows[0].Tickets.Should().Be(4);
+  }
+
+  [Fact]
+  public void Travel_date_range_is_inclusive_on_both_ends()
+  {
+    var rows = TravelAnalysisCalculator.Analyze(
+      [
+        Slot(new TimeOnly(8, 30), new DateOnly(2026, 8, 1)),
+        Slot(new TimeOnly(8, 30), new DateOnly(2026, 8, 2)),
+        Slot(new TimeOnly(8, 30), new DateOnly(2026, 8, 3)),
+        Slot(new TimeOnly(8, 30), new DateOnly(2026, 8, 4)),
+      ],
+      new DateOnly(2026, 8, 2),
+      new DateOnly(2026, 8, 3)
+    );
+
+    rows.Select(r => r.Date)
+      .Should()
+      .Equal(new DateOnly(2026, 8, 2), new DateOnly(2026, 8, 3));
+  }
+
+  [Fact]
+  public void Null_bounds_are_unbounded()
+  {
+    var slots = new[]
+    {
+      Slot(new TimeOnly(8, 30), new DateOnly(2026, 8, 1)),
+      Slot(new TimeOnly(8, 30), new DateOnly(2026, 8, 9)),
+    };
+
+    TravelAnalysisCalculator.Analyze(slots, null, new DateOnly(2026, 8, 1))
+      .Select(r => r.Date)
+      .Should()
+      .Equal(new DateOnly(2026, 8, 1));
+    TravelAnalysisCalculator.Analyze(slots, new DateOnly(2026, 8, 9), null)
+      .Select(r => r.Date)
+      .Should()
+      .Equal(new DateOnly(2026, 8, 9));
+    TravelAnalysisCalculator.Analyze(slots, null, null).Should().HaveCount(2);
+  }
+
+  [Fact]
+  public void Rows_order_by_date_then_direction_then_bucket()
+  {
+    var rows = TravelAnalysisCalculator.Analyze(
+      [
+        Slot(new TimeOnly(19, 0), new DateOnly(2026, 8, 2), TrainDirection.WToJ),
+        Slot(new TimeOnly(7, 0), new DateOnly(2026, 8, 2), TrainDirection.WToJ),
+        Slot(new TimeOnly(13, 0), new DateOnly(2026, 8, 2), TrainDirection.JToW),
+        Slot(new TimeOnly(8, 30), new DateOnly(2026, 8, 1), TrainDirection.WToJ),
+      ],
+      null,
+      null
+    );
+
+    rows.Select(r => (r.Date.Day, r.Direction, r.QuarterStartHour))
+      .Should()
+      .Equal(
+        (1, TrainDirection.WToJ, 6),
+        (2, TrainDirection.JToW, 12),
+        (2, TrainDirection.WToJ, 6),
+        (2, TrainDirection.WToJ, 18)
+      );
+  }
+
+  [Fact]
+  public void Empty_buckets_never_appear()
+  {
+    var rows = TravelAnalysisCalculator.Analyze(
+      [Slot(new TimeOnly(8, 30), tickets: 0), Slot(new TimeOnly(13, 0), tickets: 2)],
+      null,
+      null
+    );
+
+    rows.Should().HaveCount(1);
+    rows[0].QuarterStartHour.Should().Be(12);
+  }
+
+  [Fact]
+  public void No_slots_produce_no_rows()
+  {
+    TravelAnalysisCalculator.Analyze([], null, null).Should().BeEmpty();
+  }
+}

--- a/UnitTest/Bookings/TravelAnalysisWireContractTests.cs
+++ b/UnitTest/Bookings/TravelAnalysisWireContractTests.cs
@@ -1,0 +1,71 @@
+using System.Text.Json;
+using App.Modules.Bookings.API.V1;
+using Domain.Booking;
+using Domain.Timings;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// argon builds its demand view against this EXACT wire shape — pin the
+// serialized JSON so a rename on our side can never silently break it.
+// ASP.NET Core serializes with JsonSerializerDefaults.Web (camelCase).
+public class TravelAnalysisWireContractTests
+{
+  private static readonly JsonSerializerOptions Web = new(JsonSerializerDefaults.Web);
+
+  [Fact]
+  public void Travel_row_serializes_as_date_direction_quarterStartHour_tickets()
+  {
+    var row = new TravelAnalysisRow
+    {
+      Date = new DateOnly(2026, 8, 1),
+      Direction = TrainDirection.WToJ,
+      QuarterStartHour = 6,
+      Tickets = 3,
+    };
+
+    var json = JsonSerializer.Serialize(row.ToRes(), Web);
+
+    json.Should().Be("{\"date\":\"01-08-2026\",\"direction\":\"WToJ\",\"quarterStartHour\":6,\"tickets\":3}");
+  }
+
+  [Fact]
+  public void Travel_rows_serialize_as_a_flat_array()
+  {
+    var rows = new[]
+    {
+      new TravelAnalysisRow
+      {
+        Date = new DateOnly(2026, 8, 1),
+        Direction = TrainDirection.JToW,
+        QuarterStartHour = 0,
+        Tickets = 1,
+      },
+      new TravelAnalysisRow
+      {
+        Date = new DateOnly(2026, 8, 1),
+        Direction = TrainDirection.WToJ,
+        QuarterStartHour = 18,
+        Tickets = 2,
+      },
+    };
+
+    var json = JsonSerializer.Serialize(rows.Select(r => r.ToRes()), Web);
+
+    json.Should().Be(
+      "[{\"date\":\"01-08-2026\",\"direction\":\"JToW\",\"quarterStartHour\":0,\"tickets\":1},"
+        + "{\"date\":\"01-08-2026\",\"direction\":\"WToJ\",\"quarterStartHour\":18,\"tickets\":2}]"
+    );
+  }
+
+  [Fact]
+  public void Travel_query_binds_optional_after_and_before_as_dd_MM_yyyy()
+  {
+    var req = new BookingTravelAnalysisQueryReq("01-08-2026", null);
+
+    var domain = req.ToDomain();
+
+    domain.After.Should().Be(new DateOnly(2026, 8, 1));
+    domain.Before.Should().BeNull();
+  }
+}


### PR DESCRIPTION
## Summary

Adds the admin **demand view**: `GET /api/v1/Booking/analysis/travel` — how many tickets have been secured **for** each travel date, per direction, collapsed into quarter-day (6-hour) departure buckets so a day is 4 scannable rows instead of every timeslot. Complements the existing sales analysis, which buckets on **completion** date.

## API contract (argon builds against this)

`GET /api/v1/Booking/analysis/travel?After=dd-MM-yyyy&Before=dd-MM-yyyy` (admin-only; `After`/`Before` are **inclusive travel dates**, both optional — null = unbounded). Flat array, only buckets with tickets > 0:

```json
[
  { "date": "01-08-2026", "direction": "JToW", "quarterStartHour": 6,  "tickets": 12 },
  { "date": "01-08-2026", "direction": "WToJ", "quarterStartHour": 18, "tickets": 3 }
]
```

- `date` = the booking's **travel** date (`b.Date`), not `CompletedAt`
- `quarterStartHour` = departure hour floored to 6h buckets ([0,6)→0, [6,12)→6, [12,18)→12, [18,24)→18)
- `tickets` = count of **Completed** bookings in that travel-date/direction/bucket
- ordered by date asc, direction, quarterStartHour

## Implementation

Follows the existing analysis endpoint end to end (controller route + `NullableDateValid` validator + mapper + `Domain/Booking/Analysis.cs` types + `BookingAnalysisRepository`). The pure `TravelAnalysisCalculator` owns the full spec (completed-only, inclusive bounds, bucketing, ordering) and is shared with the unit tests; the repository pushes the same filters into one grouped DB-side scan (LINQ-translatable — travel `Date`/`Time` are already SGT wall-clock columns, so no timezone conversion) and reuses the calculator to collapse timeslots into buckets. No migration.

## Tests

+18 unit tests (597 → 615, all green):
- bucket edges (05:59→0, 06:00→6, …, 23:59→18)
- only-Completed filtering (Pending/Buying/Cancelled/Refunded/Terminated excluded)
- inclusive range bounds + null-unbounded
- ordering (date, direction, bucket) and same-bucket timeslot collapse
- wire-contract tests pinning the exact serialized JSON field names above