### PR TITLE
feat: per-travel-day 6h-block profit analysis

### DIFF
--- a/App/Modules/Bookings/API/V1/BookingController.cs
+++ b/App/Modules/Bookings/API/V1/BookingController.cs
@@ -151,6 +151,26 @@ public class BookingController(
     return this.ReturnResult(x);
   }
 
+  // The travel-day profit view for the admin Analysis page: revenue vs
+  // ACTUAL KTMB cost (SGD; no estimate fallback) per travel date (b.Date,
+  // not CompletedAt) and quarter-day (6-hour) departure bucket, BOTH
+  // directions combined — withActualCost reports cost coverage and the
+  // client computes profit = revenue − cost. Only blocks with completed
+  // tickets are returned, ordered by date then bucket. After/Before are
+  // inclusive travel dates; null = unbounded.
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("analysis/profit")]
+  public async Task<ActionResult<IEnumerable<BookingProfitAnalysisRowRes>>> ProfitAnalysis(
+    [FromQuery] BookingProfitAnalysisQueryReq query,
+    [FromServices] BookingProfitAnalysisQueryReqValidator profitValidator
+  )
+  {
+    var x = await profitValidator
+      .ValidateAsyncResult(query, "Invalid BookingProfitAnalysisQueryReq")
+      .ThenAwait(q => analysisRepo.ProfitAnalysis(q.ToDomain()))
+      .Then(rows => rows.Select(r => r.ToRes()), Errors.MapAll);
+    return this.ReturnResult(x);
+  }
+
   // The boost ledger: who prioritized which booking, when, for what fee (or
   // free). BoostedAt falls back to the booking's CreatedAt for boosts that
   // predate the PrioritizedAt stamp; GrantedBy identifies admin-granted

--- a/App/Modules/Bookings/API/V1/BookingMapper.cs
+++ b/App/Modules/Bookings/API/V1/BookingMapper.cs
@@ -91,7 +91,12 @@ public static class BookingMapper
 
   // Sales/revenue analysis
   public static BookingAnalysisQuery ToDomain(this BookingAnalysisQueryReq req) =>
-    new() { After = req.After?.ToDate(), Before = req.Before?.ToDate() };
+    new()
+    {
+      After = req.After?.ToDate(),
+      Before = req.Before?.ToDate(),
+      Estimate = req.Estimate ?? false,
+    };
 
   public static BookingAnalysisRowRes ToRes(this BookingAnalysisRow r) =>
     new(
@@ -162,6 +167,20 @@ public static class BookingMapper
 
   public static BookingTravelAnalysisRowRes ToRes(this TravelAnalysisRow r) =>
     new(r.Date.ToStandardDateFormat(), r.Direction.ToRes(), r.QuarterStartHour, r.Tickets);
+
+  // travel-day profit view
+  public static ProfitAnalysisQuery ToDomain(this BookingProfitAnalysisQueryReq req) =>
+    new() { After = req.After?.ToDate(), Before = req.Before?.ToDate() };
+
+  public static BookingProfitAnalysisRowRes ToRes(this ProfitAnalysisRow r) =>
+    new(
+      r.Date.ToStandardDateFormat(),
+      r.QuarterStartHour,
+      r.Tickets,
+      r.Revenue,
+      r.Cost,
+      r.WithActualCost
+    );
 
   // boost ledger
   public static BookingBoostQuery ToDomain(this BookingBoostQueryReq req) =>

--- a/App/Modules/Bookings/API/V1/BookingModel.cs
+++ b/App/Modules/Bookings/API/V1/BookingModel.cs
@@ -23,12 +23,20 @@ public record SearchBookingQuery(
 public record BookingStatsQueryReq(string? After, string? Before);
 
 // sales/revenue analysis range (dd-MM-yyyy, inclusive SGT dates; null =
-// unbounded) — the admin Analysis page source
-public record BookingAnalysisQueryReq(string? After, string? Before);
+// unbounded) — the admin Analysis page source. Estimate=true opts back into
+// the legacy KtmbCosts-estimate fallback for bookings without an actual KTMB
+// cost; absent/false (the default — the admin UI dropped its estimate input
+// now that actuals are backfilled) costs those bookings at 0 (coverage stays
+// visible via ktmbActualCoverage)
+public record BookingAnalysisQueryReq(string? After, string? Before, bool? Estimate);
 
 // travel-date demand range (dd-MM-yyyy, inclusive TRAVEL dates — not
 // completion dates; null = unbounded) — the admin demand view source
 public record BookingTravelAnalysisQueryReq(string? After, string? Before);
+
+// travel-day profit range (dd-MM-yyyy, inclusive TRAVEL dates — not
+// completion dates; null = unbounded) — the admin profit view source
+public record BookingProfitAnalysisQueryReq(string? After, string? Before);
 
 // the boost ledger page (dd-MM-yyyy inclusive SGT dates; Limit default 50
 // max 200, Skip offset)
@@ -181,6 +189,24 @@ public record BookingTravelAnalysisRowRes(
   string Direction,
   int QuarterStartHour,
   int Tickets
+);
+
+// one travel-day profit row — argon's contract shape, exactly { date,
+// quarterStartHour, tickets, revenue, cost, withActualCost }: completed
+// bookings travelling on this dd-MM-yyyy date departing within the 6-hour
+// bucket starting at QuarterStartHour (0, 6, 12 or 18), BOTH directions
+// combined. Revenue = what customers paid (SGD); Cost = the ACTUAL KTMB
+// amounts in SGD (no estimate fallback — bookings without one contribute 0);
+// WithActualCost = how many of the block's bookings carry an actual, so the
+// client can show coverage and compute profit = revenue − cost itself. Only
+// blocks with tickets > 0 are returned.
+public record BookingProfitAnalysisRowRes(
+  string Date,
+  int QuarterStartHour,
+  int Tickets,
+  decimal Revenue,
+  decimal Cost,
+  int WithActualCost
 );
 
 public record DepositSummaryRes(int Count, decimal Captured);

--- a/App/Modules/Bookings/API/V1/BookingValidator.cs
+++ b/App/Modules/Bookings/API/V1/BookingValidator.cs
@@ -111,6 +111,16 @@ public class BookingTravelAnalysisQueryReqValidator
   }
 }
 
+public class BookingProfitAnalysisQueryReqValidator
+  : AbstractValidator<BookingProfitAnalysisQueryReq>
+{
+  public BookingProfitAnalysisQueryReqValidator()
+  {
+    this.RuleFor(x => x.After).NullableDateValid();
+    this.RuleFor(x => x.Before).NullableDateValid();
+  }
+}
+
 public class BookingBoostQueryReqValidator : AbstractValidator<BookingBoostQueryReq>
 {
   public BookingBoostQueryReqValidator()

--- a/App/Modules/Bookings/Data/BookingAnalysisRepository.cs
+++ b/App/Modules/Bookings/Data/BookingAnalysisRepository.cs
@@ -23,11 +23,12 @@ namespace App.Modules.Bookings.Data;
 //
 // KTMB COST: the ACTUAL amount tin paid KTMB when recorded — SGD as-is, MYR
 // × the newest KtmbFxRates row effective at the booking's CompletedAt (the
-// CASE mirrors KtmbActualCost.Effective); a recorded MYR amount with no
-// effective rate falls back to the estimate. Bookings without an actual
-// amount are costed at the newest KtmbCosts row with EffectiveAt <= their
-// CompletedAt and a matching Direction (the LATERAL mirrors
-// KtmbCostSchedule.EffectiveCost); no configured row = 0.
+// CASE mirrors KtmbActualCost.Effective). Bookings without a usable actual
+// (none recorded, or MYR with no effective rate) contribute 0 by default —
+// actuals are backfilled and KtmbActualCoverage reports the gap; only when
+// the query opts into Estimate are they costed at the newest KtmbCosts row
+// with EffectiveAt <= their CompletedAt and a matching Direction (the
+// LATERAL mirrors KtmbCostSchedule.EffectiveCost); no configured row = 0.
 //
 // GATEWAY FEES: from the synced GatewayFees rows (Airwallex financial
 // transactions), bucketed on the SGT month of TransactedAt. Payment-type
@@ -60,6 +61,26 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
     public decimal GrossRevenue { get; set; }
 
     public decimal KtmbCost { get; set; }
+  }
+
+  // raw-SQL row shape for the profit view: one row per (travel date,
+  // direction, departure time) timeslot with its revenue, actual-cost and
+  // coverage sums; column names must match the SELECT aliases
+  private sealed class ProfitRowDto
+  {
+    public DateOnly Date { get; set; }
+
+    public int Direction { get; set; }
+
+    public TimeOnly Time { get; set; }
+
+    public int Tickets { get; set; }
+
+    public decimal Revenue { get; set; }
+
+    public decimal Cost { get; set; }
+
+    public int WithActualCost { get; set; }
   }
 
   // month-bucketed gateway fee sums (payments vs payouts)
@@ -111,6 +132,7 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
         ?? DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc);
 
       var completed = (byte)BookStatus.Completed;
+      var estimate = query.Estimate;
       // AT TIME ZONE 'UTC' renders the instant as UTC wall-clock regardless
       // of the session TimeZone; +8h then CAST AS date = the SGT calendar
       // date (same arithmetic booking_stats bakes into its view).
@@ -119,7 +141,8 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
       // none) and the effective MYR -> SGD rate (mirror of
       // KtmbFxRateSchedule.EffectiveRate, NULL when none); the CASE mirrors
       // KtmbActualCost.Effective — actual amount first (SGD as-is, MYR ×
-      // rate), estimate as the fallback.
+      // rate); bookings without a usable actual fall back to the estimate
+      // only when the query opted in, else they contribute 0.
       var rows = await db
         .Database.SqlQuery<RowDto>(
           $"""
@@ -136,7 +159,8 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
                 WHEN b."KtmbAmount" IS NOT NULL AND b."KtmbCurrency" = 'MYR'
                   AND fx."Rate" IS NOT NULL
                   THEN b."KtmbAmount" * fx."Rate"
-                ELSE COALESCE(kc."Cost", 0)
+                WHEN {estimate} THEN COALESCE(kc."Cost", 0)
+                ELSE 0
               END
             ) AS "KtmbCost"
           FROM "Bookings" b
@@ -409,6 +433,91 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
     catch (Exception e)
     {
       logger.LogError(e, "Failed to compute travel analysis with {@Query}", query.ToJson());
+      return e;
+    }
+  }
+
+  // The travel-day profit view: completed bookings' revenue and ACTUAL KTMB
+  // cost per TRAVEL date and quarter-day (6-hour) departure bucket, both
+  // directions combined. Travel Date/Time are SGT wall-clock columns, so the
+  // inclusive range filter and grouping need no timezone conversion — one
+  // grouped scan per timeslot DB-side (raw SQL only because the FX LATERAL
+  // is not LINQ-translatable), collapsed into blocks by the pure calculator
+  // (which owns the spec's filters and ordering).
+  //
+  // REVENUE reuses the analysis' per-booking attribution: the booking's
+  // REQUEST transaction amount (Bookings.TransactionId ->
+  // Transactions.Amount — see the AMOUNT SOURCE note above). COST sums only
+  // ACTUAL KTMB amounts in SGD — SGD as-is, MYR × the newest KtmbFxRates row
+  // effective at the booking's CompletedAt (the same LATERAL Analyze uses);
+  // bookings without an actual (or MYR with no effective rate) contribute 0,
+  // and WithActualCost counts the bookings that do carry an actual so the UI
+  // can show coverage. No estimate fallback here, ever.
+  public async Task<Result<ProfitAnalysisRow[]>> ProfitAnalysis(ProfitAnalysisQuery query)
+  {
+    try
+    {
+      logger.LogInformation("Computing profit analysis with {@Query}", query.ToJson());
+      var completed = (byte)BookStatus.Completed;
+      var after = query.After ?? DateOnly.MinValue;
+      var before = query.Before ?? DateOnly.MaxValue;
+
+      var slots = await db
+        .Database.SqlQuery<ProfitRowDto>(
+          $"""
+          SELECT
+            b."Date" AS "Date",
+            b."Direction" AS "Direction",
+            b."Time" AS "Time",
+            CAST(COUNT(*) AS int) AS "Tickets",
+            SUM(t."Amount") AS "Revenue",
+            SUM(
+              CASE
+                WHEN b."KtmbAmount" IS NOT NULL AND b."KtmbCurrency" = 'SGD'
+                  THEN b."KtmbAmount"
+                WHEN b."KtmbAmount" IS NOT NULL AND b."KtmbCurrency" = 'MYR'
+                  AND fx."Rate" IS NOT NULL
+                  THEN b."KtmbAmount" * fx."Rate"
+                ELSE 0
+              END
+            ) AS "Cost",
+            CAST(COUNT(*) FILTER (WHERE b."KtmbAmount" IS NOT NULL) AS int) AS "WithActualCost"
+          FROM "Bookings" b
+          JOIN "Transactions" t ON t."Id" = b."TransactionId"
+          LEFT JOIN LATERAL (
+            SELECT f."Rate"
+            FROM "KtmbFxRates" f
+            WHERE f."EffectiveAt" <= b."CompletedAt"
+            ORDER BY f."EffectiveAt" DESC, f."CreatedAt" DESC, f."Id" DESC
+            LIMIT 1
+          ) fx ON TRUE
+          WHERE b."Status" = {completed}
+            AND b."Date" >= {after}
+            AND b."Date" <= {before}
+          GROUP BY b."Date", b."Direction", b."Time"
+          """
+        )
+        .ToArrayAsync();
+
+      return ProfitAnalysisCalculator.Analyze(
+        slots.Select(s => new ProfitSlotSum
+        {
+          Date = s.Date,
+          Direction = s.Direction.ToTrainDirection(),
+          Time = s.Time,
+          Status = BookStatus.Completed,
+          Tickets = s.Tickets,
+          Revenue = s.Revenue,
+          Cost = s.Cost,
+          WithActualCost = s.WithActualCost,
+        }),
+        query.After,
+        query.Before
+      );
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to compute profit analysis with {@Query}", query.ToJson());
       return e;
     }
   }

--- a/Domain/Booking/Analysis.cs
+++ b/Domain/Booking/Analysis.cs
@@ -17,6 +17,14 @@ public record BookingAnalysisQuery
   public DateOnly? After { get; init; }
 
   public DateOnly? Before { get; init; }
+
+  // opt-in to the legacy estimate fallback: when true, bookings without an
+  // ACTUAL KTMB amount (and MYR actuals with no effective FX rate) are
+  // costed at the effective-dated KtmbCosts estimate, exactly as before the
+  // admin UI dropped its estimate input; when false (the default now that
+  // actual costs are backfilled) they contribute 0 and
+  // KtmbActualCoverage reports how much of the range that leaves uncosted
+  public bool Estimate { get; init; }
 }
 
 // One completed-revenue row: bookings completed on this SGT date, for this
@@ -445,11 +453,108 @@ public static class TravelAnalysisCalculator
     ];
 }
 
+// ---- travel-day profit view (GET Booking/analysis/profit) ----
+
+// Profit view for the admin Analysis page: what each travel day earns and
+// costs, collapsed into quarter-day (6-hour) departure buckets with BOTH
+// directions combined — the client computes profit as revenue − cost.
+// Like TravelAnalysisQuery this ranges over the booking's TRAVEL date
+// (b.Date), not CompletedAt.
+public record ProfitAnalysisQuery
+{
+  // inclusive TRAVEL-date range; null = unbounded. Travel Date/Time are SGT
+  // wall-clock columns already, so no instant conversion is involved.
+  public DateOnly? After { get; init; }
+
+  public DateOnly? Before { get; init; }
+}
+
+// one scanned timeslot: the completed bookings sharing this travel
+// date/direction/departure time, with their revenue (the request-transaction
+// amounts collected at completion), their ACTUAL KTMB cost in SGD (SGD
+// as-is, MYR × the FX rate effective at CompletedAt; bookings without an
+// actual — or a convertible one — contribute 0) and how many of them carry
+// an actual at all — the raw input the calculator collapses into blocks
+public record ProfitSlotSum
+{
+  public required DateOnly Date { get; init; }
+
+  public required TrainDirection Direction { get; init; }
+
+  public required TimeOnly Time { get; init; }
+
+  public required BookStatus Status { get; init; }
+
+  public required int Tickets { get; init; }
+
+  public required decimal Revenue { get; init; }
+
+  public required decimal Cost { get; init; }
+
+  public required int WithActualCost { get; init; }
+}
+
+// one quarter-day profit row: completed tickets travelling on this date,
+// departing within [QuarterStartHour, QuarterStartHour + 6), both directions
+// combined. Cost sums only ACTUAL KTMB amounts (in SGD); WithActualCost says
+// how many of the block's bookings that covers, so the UI can show coverage.
+public record ProfitAnalysisRow
+{
+  // the booking's TRAVEL date (SGT wall-clock), NOT its CompletedAt date
+  public required DateOnly Date { get; init; }
+
+  // floor of the departure hour to 6h buckets: 0, 6, 12 or 18
+  public required int QuarterStartHour { get; init; }
+
+  public required int Tickets { get; init; }
+
+  public required decimal Revenue { get; init; }
+
+  public required decimal Cost { get; init; }
+
+  public required int WithActualCost { get; init; }
+}
+
+// Pure profit math, shared by the repository and the unit tests. Analyze is
+// the full specification — only Completed bookings count, the travel-date
+// range is inclusive on both ends, directions are combined per block, and
+// only blocks with tickets remain — while the repository pushes the same
+// filters into SQL so the scan stays cheap and reuses this for the
+// bucket/order stage.
+public static class ProfitAnalysisCalculator
+{
+  public static ProfitAnalysisRow[] Analyze(
+    IEnumerable<ProfitSlotSum> slots,
+    DateOnly? after,
+    DateOnly? before
+  ) =>
+    [
+      .. slots
+        .Where(s => s.Status == BookStatus.Completed)
+        .Where(s => (after is null || s.Date >= after) && (before is null || s.Date <= before))
+        .GroupBy(s => (s.Date, Quarter: TravelAnalysisCalculator.QuarterStartHour(s.Time)))
+        .Select(g => new ProfitAnalysisRow
+        {
+          Date = g.Key.Date,
+          QuarterStartHour = g.Key.Quarter,
+          Tickets = g.Sum(s => s.Tickets),
+          Revenue = g.Sum(s => s.Revenue),
+          Cost = g.Sum(s => s.Cost),
+          WithActualCost = g.Sum(s => s.WithActualCost),
+        })
+        .Where(r => r.Tickets > 0)
+        .OrderBy(r => r.Date)
+        .ThenBy(r => r.QuarterStartHour),
+    ];
+}
+
 public interface IBookingAnalysisRepository
 {
   Task<Result<BookingAnalysis>> Analyze(BookingAnalysisQuery query);
 
   Task<Result<TravelAnalysisRow[]>> TravelAnalysis(TravelAnalysisQuery query);
+
+  Task<Result<ProfitAnalysisRow[]>> ProfitAnalysis(ProfitAnalysisQuery query);
 
   Task<Result<BookingBoostPage>> Boosts(BookingBoostQuery query);
 }

--- a/UnitTest/Bookings/BookingAnalysisEstimateQueryTests.cs
+++ b/UnitTest/Bookings/BookingAnalysisEstimateQueryTests.cs
@@ -1,0 +1,44 @@
+using App.Modules.Bookings.API.V1;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// The ticket-cost estimate on GET Booking/analysis is opt-in now that actual
+// KTMB costs are backfilled: an absent (or false) Estimate binds to a query
+// that costs bookings without an actual at 0, while Estimate=true keeps the
+// legacy KtmbCosts-fallback behavior byte-for-byte — existing callers that
+// never sent the parameter keep a valid request (After/Before still bind).
+public class BookingAnalysisEstimateQueryTests
+{
+  [Fact]
+  public void Absent_estimate_defaults_to_no_estimate_fallback()
+  {
+    var req = new BookingAnalysisQueryReq("01-08-2026", "31-08-2026", null);
+
+    var domain = req.ToDomain();
+
+    domain.Estimate.Should().BeFalse();
+    domain.After.Should().Be(new DateOnly(2026, 8, 1));
+    domain.Before.Should().Be(new DateOnly(2026, 8, 31));
+  }
+
+  [Fact]
+  public void Estimate_true_opts_back_into_the_legacy_fallback()
+  {
+    var req = new BookingAnalysisQueryReq(null, null, true);
+
+    var domain = req.ToDomain();
+
+    domain.Estimate.Should().BeTrue();
+    domain.After.Should().BeNull();
+    domain.Before.Should().BeNull();
+  }
+
+  [Fact]
+  public void Estimate_false_behaves_like_absent()
+  {
+    var req = new BookingAnalysisQueryReq(null, null, false);
+
+    req.ToDomain().Estimate.Should().BeFalse();
+  }
+}

--- a/UnitTest/Bookings/ProfitAnalysisCalculatorTests.cs
+++ b/UnitTest/Bookings/ProfitAnalysisCalculatorTests.cs
@@ -1,0 +1,212 @@
+using Domain.Booking;
+using Domain.Timings;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// The pure profit math behind GET Booking/analysis/profit: departure hours
+// floor to quarter-day (6-hour) buckets, BOTH directions combine into one
+// block, only Completed bookings count, the travel-date range is inclusive
+// on both ends (null = unbounded), blocks without tickets never appear, and
+// rows order by date then bucket. Revenue/Cost/WithActualCost sum over the
+// block's slots — cost conversion itself happens upstream (SQL), the
+// calculator only aggregates.
+public class ProfitAnalysisCalculatorTests
+{
+  private static ProfitSlotSum Slot(
+    TimeOnly time,
+    DateOnly? date = null,
+    TrainDirection direction = TrainDirection.JToW,
+    BookStatus status = BookStatus.Completed,
+    int tickets = 1,
+    decimal revenue = 0m,
+    decimal cost = 0m,
+    int withActualCost = 0
+  ) =>
+    new()
+    {
+      Date = date ?? new DateOnly(2026, 8, 1),
+      Direction = direction,
+      Time = time,
+      Status = status,
+      Tickets = tickets,
+      Revenue = revenue,
+      Cost = cost,
+      WithActualCost = withActualCost,
+    };
+
+  [Fact]
+  public void Timeslots_in_the_same_bucket_collapse_and_sum_all_measures()
+  {
+    var rows = ProfitAnalysisCalculator.Analyze(
+      [
+        Slot(new TimeOnly(8, 30), tickets: 2, revenue: 90m, cost: 40m, withActualCost: 1),
+        Slot(new TimeOnly(11, 0), tickets: 3, revenue: 135m, cost: 60.5m, withActualCost: 3),
+      ],
+      null,
+      null
+    );
+
+    rows.Should().HaveCount(1);
+    rows[0].QuarterStartHour.Should().Be(6);
+    rows[0].Tickets.Should().Be(5);
+    rows[0].Revenue.Should().Be(225m);
+    rows[0].Cost.Should().Be(100.5m);
+    rows[0].WithActualCost.Should().Be(4);
+  }
+
+  [Fact]
+  public void Both_directions_combine_into_one_block()
+  {
+    var rows = ProfitAnalysisCalculator.Analyze(
+      [
+        Slot(
+          new TimeOnly(8, 30),
+          direction: TrainDirection.JToW,
+          tickets: 2,
+          revenue: 90m,
+          cost: 40m,
+          withActualCost: 2
+        ),
+        Slot(
+          new TimeOnly(9, 45),
+          direction: TrainDirection.WToJ,
+          tickets: 1,
+          revenue: 45m,
+          cost: 20m,
+          withActualCost: 1
+        ),
+      ],
+      null,
+      null
+    );
+
+    rows.Should().HaveCount(1);
+    rows[0].Tickets.Should().Be(3);
+    rows[0].Revenue.Should().Be(135m);
+    rows[0].Cost.Should().Be(60m);
+    rows[0].WithActualCost.Should().Be(3);
+  }
+
+  [Fact]
+  public void Only_completed_bookings_count()
+  {
+    var rows = ProfitAnalysisCalculator.Analyze(
+      [
+        Slot(new TimeOnly(8, 30), status: BookStatus.Pending, revenue: 45m),
+        Slot(new TimeOnly(8, 30), status: BookStatus.Buying, revenue: 45m),
+        Slot(new TimeOnly(8, 30), status: BookStatus.Cancelled, revenue: 45m),
+        Slot(new TimeOnly(8, 30), status: BookStatus.Refunded, revenue: 45m),
+        Slot(new TimeOnly(8, 30), status: BookStatus.Terminated, revenue: 45m),
+        Slot(new TimeOnly(8, 30), tickets: 4, revenue: 180m),
+      ],
+      null,
+      null
+    );
+
+    rows.Should().HaveCount(1);
+    rows[0].Tickets.Should().Be(4);
+    rows[0].Revenue.Should().Be(180m);
+  }
+
+  [Fact]
+  public void Travel_date_range_is_inclusive_on_both_ends()
+  {
+    var rows = ProfitAnalysisCalculator.Analyze(
+      [
+        Slot(new TimeOnly(8, 30), new DateOnly(2026, 8, 1)),
+        Slot(new TimeOnly(8, 30), new DateOnly(2026, 8, 2)),
+        Slot(new TimeOnly(8, 30), new DateOnly(2026, 8, 3)),
+        Slot(new TimeOnly(8, 30), new DateOnly(2026, 8, 4)),
+      ],
+      new DateOnly(2026, 8, 2),
+      new DateOnly(2026, 8, 3)
+    );
+
+    rows.Select(r => r.Date)
+      .Should()
+      .Equal(new DateOnly(2026, 8, 2), new DateOnly(2026, 8, 3));
+  }
+
+  [Fact]
+  public void Null_bounds_are_unbounded()
+  {
+    var slots = new[]
+    {
+      Slot(new TimeOnly(8, 30), new DateOnly(2026, 8, 1)),
+      Slot(new TimeOnly(8, 30), new DateOnly(2026, 8, 9)),
+    };
+
+    ProfitAnalysisCalculator.Analyze(slots, null, new DateOnly(2026, 8, 1))
+      .Select(r => r.Date)
+      .Should()
+      .Equal(new DateOnly(2026, 8, 1));
+    ProfitAnalysisCalculator.Analyze(slots, new DateOnly(2026, 8, 9), null)
+      .Select(r => r.Date)
+      .Should()
+      .Equal(new DateOnly(2026, 8, 9));
+    ProfitAnalysisCalculator.Analyze(slots, null, null).Should().HaveCount(2);
+  }
+
+  [Fact]
+  public void Rows_order_by_date_then_bucket()
+  {
+    var rows = ProfitAnalysisCalculator.Analyze(
+      [
+        Slot(new TimeOnly(19, 0), new DateOnly(2026, 8, 2)),
+        Slot(new TimeOnly(7, 0), new DateOnly(2026, 8, 2), TrainDirection.WToJ),
+        Slot(new TimeOnly(13, 0), new DateOnly(2026, 8, 2)),
+        Slot(new TimeOnly(8, 30), new DateOnly(2026, 8, 1), TrainDirection.WToJ),
+      ],
+      null,
+      null
+    );
+
+    rows.Select(r => (r.Date.Day, r.QuarterStartHour))
+      .Should()
+      .Equal((1, 6), (2, 6), (2, 12), (2, 18));
+  }
+
+  [Fact]
+  public void Empty_blocks_never_appear()
+  {
+    var rows = ProfitAnalysisCalculator.Analyze(
+      [
+        Slot(new TimeOnly(8, 30), tickets: 0),
+        Slot(new TimeOnly(13, 0), tickets: 2, revenue: 90m),
+      ],
+      null,
+      null
+    );
+
+    rows.Should().HaveCount(1);
+    rows[0].QuarterStartHour.Should().Be(12);
+  }
+
+  [Fact]
+  public void Bookings_without_actual_cost_contribute_zero_cost_but_full_revenue()
+  {
+    // upstream (SQL) costs a booking without an actual KTMB amount at 0 and
+    // excludes it from WithActualCost — the block still carries its revenue
+    var rows = ProfitAnalysisCalculator.Analyze(
+      [
+        Slot(new TimeOnly(8, 30), tickets: 1, revenue: 45m, cost: 20m, withActualCost: 1),
+        Slot(new TimeOnly(9, 0), tickets: 1, revenue: 45m, cost: 0m, withActualCost: 0),
+      ],
+      null,
+      null
+    );
+
+    rows.Should().HaveCount(1);
+    rows[0].Revenue.Should().Be(90m);
+    rows[0].Cost.Should().Be(20m);
+    rows[0].WithActualCost.Should().Be(1);
+    rows[0].Tickets.Should().Be(2);
+  }
+
+  [Fact]
+  public void No_slots_produce_no_rows()
+  {
+    ProfitAnalysisCalculator.Analyze([], null, null).Should().BeEmpty();
+  }
+}

--- a/UnitTest/Bookings/ProfitAnalysisWireContractTests.cs
+++ b/UnitTest/Bookings/ProfitAnalysisWireContractTests.cs
@@ -1,0 +1,83 @@
+using System.Text.Json;
+using App.Modules.Bookings.API.V1;
+using Domain.Booking;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// argon builds its profit view against this EXACT wire shape — pin the
+// serialized JSON so a rename on our side can never silently break it.
+// ASP.NET Core serializes with JsonSerializerDefaults.Web (camelCase).
+public class ProfitAnalysisWireContractTests
+{
+  private static readonly JsonSerializerOptions Web = new(JsonSerializerDefaults.Web);
+
+  [Fact]
+  public void Profit_row_serializes_as_date_quarterStartHour_tickets_revenue_cost_withActualCost()
+  {
+    var row = new ProfitAnalysisRow
+    {
+      Date = new DateOnly(2026, 8, 1),
+      QuarterStartHour = 6,
+      Tickets = 3,
+      Revenue = 135.5m,
+      Cost = 60.25m,
+      WithActualCost = 2,
+    };
+
+    var json = JsonSerializer.Serialize(row.ToRes(), Web);
+
+    json.Should()
+      .Be(
+        "{\"date\":\"01-08-2026\",\"quarterStartHour\":6,\"tickets\":3,"
+          + "\"revenue\":135.5,\"cost\":60.25,\"withActualCost\":2}"
+      );
+  }
+
+  [Fact]
+  public void Profit_rows_serialize_as_a_flat_array()
+  {
+    var rows = new[]
+    {
+      new ProfitAnalysisRow
+      {
+        Date = new DateOnly(2026, 8, 1),
+        QuarterStartHour = 0,
+        Tickets = 1,
+        Revenue = 45m,
+        Cost = 0m,
+        WithActualCost = 0,
+      },
+      new ProfitAnalysisRow
+      {
+        Date = new DateOnly(2026, 8, 1),
+        QuarterStartHour = 18,
+        Tickets = 2,
+        Revenue = 90m,
+        Cost = 41.8m,
+        WithActualCost = 2,
+      },
+    };
+
+    var json = JsonSerializer.Serialize(rows.Select(r => r.ToRes()), Web);
+
+    json.Should()
+      .Be(
+        "[{\"date\":\"01-08-2026\",\"quarterStartHour\":0,\"tickets\":1,"
+          + "\"revenue\":45,\"cost\":0,\"withActualCost\":0},"
+          + "{\"date\":\"01-08-2026\",\"quarterStartHour\":18,\"tickets\":2,"
+          + "\"revenue\":90,\"cost\":41.8,\"withActualCost\":2}]"
+      );
+  }
+
+  [Fact]
+  public void Profit_query_binds_optional_after_and_before_as_dd_MM_yyyy()
+  {
+    var req = new BookingProfitAnalysisQueryReq("01-08-2026", null);
+
+    var domain = req.ToDomain();
+
+    domain.After.Should().Be(new DateOnly(2026, 8, 1));
+    domain.Before.Should().BeNull();
+  }
+}


### PR DESCRIPTION
## What

Two backend changes for the admin **Analysis** page:

### 1. NEW: `GET /api/v{version}/Booking/analysis/profit`

Per-travel-day, 6-hour-block profit rows (pinned wire contract — the argon frontend is built against this in parallel):

```
GET /api/v{version}/Booking/analysis/profit?After=dd-MM-yyyy&Before=dd-MM-yyyy
→ [ { "date": "dd-MM-yyyy", "quarterStartHour": 0|6|12|18,
      "tickets": int, "revenue": decimal, "cost": decimal,
      "withActualCost": int } ]
```

Semantics:
- **COMPLETED** bookings only, grouped by **travel date** (SGT, `b.Date`) and the 6h block of the **travel time** (0–5:59→0, 6–11:59→6, 12–17:59→12, 18–23:59→18); **both directions combined** per block.
- `After`/`Before` are inclusive SGT travel dates, optional (null = unbounded).
- `revenue` = sum of what customers paid (SGD) — the same per-booking revenue attribution `GET Booking/analysis` uses (the booking's request-transaction amount via `Bookings.TransactionId → Transactions.Amount`).
- `cost` = sum of **actual** KTMB cost converted to SGD: `KtmbCurrency` SGD → as-is; MYR → amount × the `KtmbFxRates` rate effective at completion time (same LATERAL effective-rate logic as the existing analysis SQL). Bookings with no actual cost recorded contribute **0** — no estimate fallback, ever.
- `withActualCost` = count of the block's bookings that HAVE an actual cost recorded, so the UI can show coverage.
- No `profit` field — the client computes `revenue − cost`. Empty blocks are omitted (no zero-filling).
- **OnlyAdmin** policy, dd-MM-yyyy validation, and structure all mirror the existing `GET Booking/analysis/travel` pattern: raw-SQL grouped scan per timeslot (raw only because the FX LATERAL is not LINQ-translatable) collapsed by a new pure `ProfitAnalysisCalculator` that owns the spec's filters and ordering.

### 2. `GET /Booking/analysis`: ticket-cost ESTIMATE is now opt-in

The admin UI is removing its estimate input because actual KTMB costs are backfilled. The estimate here is the effective-dated `KtmbCosts` schedule the analysis previously always fell back to for bookings without an actual cost — there was never a wire-level estimate parameter, so the toggle is exposed as a new **optional** `Estimate` query param:

- **Absent / `false` (new default):** bookings without a usable actual KTMB cost contribute **0** to cost; coverage stays visible via the existing `ktmbActualCoverage`.
- **`Estimate=true`:** byte-for-byte today's behavior (actual first, `KtmbCosts` estimate fallback, 0 when none configured) for backward compatibility.

No response shapes changed; `GET Booking/analysis/travel` untouched.

## Tests

- `ProfitAnalysisCalculatorTests` — bucket floors, direction combining, completed-only, inclusive/unbounded ranges, ordering, empty-block omission, zero-cost coverage semantics.
- `ProfitAnalysisWireContractTests` — pins the exact serialized JSON (camelCase field names, dd-MM-yyyy dates) argon builds against.
- `BookingAnalysisEstimateQueryTests` — absent/false/true `Estimate` binding.
- Full suite: **630/630 unit tests + integration tests pass** (run in the dotnet 8 SDK Docker image).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin-only profit analysis endpoint with date-range filtering.
  * Added travel-day profit reporting grouped into six-hour time blocks.
  * Profit results include tickets, revenue, cost, and actual-cost coverage.
  * Added an option to include estimated costs in booking analysis.
* **Bug Fixes**
  * Booking costs without actual amounts now default to zero unless estimates are explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->