### PR TITLE
feat: monthly P&L analysis endpoint

### DIFF
--- a/App/Modules/Bookings/API/V1/BookingController.cs
+++ b/App/Modules/Bookings/API/V1/BookingController.cs
@@ -171,6 +171,21 @@ public class BookingController(
     return this.ReturnResult(x);
   }
 
+  // Monthly P&L for the admin Analysis page. Every source is bucketed on its
+  // SGT calendar month; empty months are omitted and the client derives nets.
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("analysis/pnl")]
+  public async Task<ActionResult<IEnumerable<BookingPnlAnalysisRowRes>>> PnlAnalysis(
+    [FromQuery] BookingPnlAnalysisQueryReq query,
+    [FromServices] BookingPnlAnalysisQueryReqValidator pnlValidator
+  )
+  {
+    var x = await pnlValidator
+      .ValidateAsyncResult(query, "Invalid BookingPnlAnalysisQueryReq")
+      .ThenAwait(q => analysisRepo.PnlAnalysis(q.ToDomain()))
+      .Then(rows => rows.Select(r => r.ToRes()), Errors.MapAll);
+    return this.ReturnResult(x);
+  }
+
   // The boost ledger: who prioritized which booking, when, for what fee (or
   // free). BoostedAt falls back to the booking's CreatedAt for boosts that
   // predate the PrioritizedAt stamp; GrantedBy identifies admin-granted

--- a/App/Modules/Bookings/API/V1/BookingMapper.cs
+++ b/App/Modules/Bookings/API/V1/BookingMapper.cs
@@ -182,6 +182,22 @@ public static class BookingMapper
       r.WithActualCost
     );
 
+  // monthly P&L view
+  public static PnlAnalysisQuery ToDomain(this BookingPnlAnalysisQueryReq req) =>
+    new() { After = req.After?.ToDate(), Before = req.Before?.ToDate() };
+
+  public static BookingPnlAnalysisRowRes ToRes(this PnlAnalysisRow r) =>
+    new(
+      r.Month,
+      r.Deposits,
+      r.WithdrawalCount,
+      r.WithdrawalTotal,
+      r.WithdrawalFeeIncome,
+      r.GatewayFees,
+      r.TicketRevenue,
+      r.KtmbCost
+    );
+
   // boost ledger
   public static BookingBoostQuery ToDomain(this BookingBoostQueryReq req) =>
     new()

--- a/App/Modules/Bookings/API/V1/BookingModel.cs
+++ b/App/Modules/Bookings/API/V1/BookingModel.cs
@@ -38,6 +38,10 @@ public record BookingTravelAnalysisQueryReq(string? After, string? Before);
 // completion dates; null = unbounded) — the admin profit view source
 public record BookingProfitAnalysisQueryReq(string? After, string? Before);
 
+// monthly P&L range (dd-MM-yyyy, inclusive SGT source-event dates; null =
+// unbounded)
+public record BookingPnlAnalysisQueryReq(string? After, string? Before);
+
 // the boost ledger page (dd-MM-yyyy inclusive SGT dates; Limit default 50
 // max 200, Skip offset)
 public record BookingBoostQueryReq(string? After, string? Before, int? Limit, int? Skip);
@@ -207,6 +211,19 @@ public record BookingProfitAnalysisRowRes(
   decimal Revenue,
   decimal Cost,
   int WithActualCost
+);
+
+// Monthly P&L wire contract. WithdrawalTotal is the gross wallet debit (the
+// user's payout is Amount - Fee); the client derives cash and earned nets.
+public record BookingPnlAnalysisRowRes(
+  string Month,
+  decimal Deposits,
+  int WithdrawalCount,
+  decimal WithdrawalTotal,
+  decimal WithdrawalFeeIncome,
+  decimal GatewayFees,
+  decimal TicketRevenue,
+  decimal KtmbCost
 );
 
 public record DepositSummaryRes(int Count, decimal Captured);

--- a/App/Modules/Bookings/API/V1/BookingValidator.cs
+++ b/App/Modules/Bookings/API/V1/BookingValidator.cs
@@ -121,6 +121,15 @@ public class BookingProfitAnalysisQueryReqValidator
   }
 }
 
+public class BookingPnlAnalysisQueryReqValidator : AbstractValidator<BookingPnlAnalysisQueryReq>
+{
+  public BookingPnlAnalysisQueryReqValidator()
+  {
+    this.RuleFor(x => x.After).NullableDateValid();
+    this.RuleFor(x => x.Before).NullableDateValid();
+  }
+}
+
 public class BookingBoostQueryReqValidator : AbstractValidator<BookingBoostQueryReq>
 {
   public BookingBoostQueryReqValidator()

--- a/App/Modules/Bookings/Data/BookingAnalysisRepository.cs
+++ b/App/Modules/Bookings/Data/BookingAnalysisRepository.cs
@@ -83,6 +83,27 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
     public int WithActualCost { get; set; }
   }
 
+  // One daily subtotal from one P&L source. UNION ALL emits sparse rows and
+  // the pure calculator merges them into the pinned monthly response.
+  private sealed class PnlDayDto
+  {
+    public DateOnly Date { get; set; }
+
+    public decimal Deposits { get; set; }
+
+    public int WithdrawalCount { get; set; }
+
+    public decimal WithdrawalTotal { get; set; }
+
+    public decimal WithdrawalFeeIncome { get; set; }
+
+    public decimal GatewayFees { get; set; }
+
+    public decimal TicketRevenue { get; set; }
+
+    public decimal KtmbCost { get; set; }
+  }
+
   // month-bucketed gateway fee sums (payments vs payouts)
   private sealed class GatewayMonthDto
   {
@@ -518,6 +539,138 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
     catch (Exception e)
     {
       logger.LogError(e, "Failed to compute profit analysis with {@Query}", query.ToJson());
+      return e;
+    }
+  }
+
+  // Monthly P&L source scan. All timestamp sources use the same explicit SGT
+  // wall-clock arithmetic as Analyze's gateway-fee rollup. Each UNION arm is
+  // grouped by SGT date DB-side; the pure calculator applies the inclusive
+  // date contract again, merges sources into months and omits empty months.
+  public async Task<Result<PnlAnalysisRow[]>> PnlAnalysis(PnlAnalysisQuery query)
+  {
+    try
+    {
+      logger.LogInformation("Computing P&L analysis with {@Query}", query.ToJson());
+      var sgt = TimeZoneInfo.FindSystemTimeZoneById("Asia/Singapore");
+      var afterUtc =
+        query.After?.ToZonedDateTime(TimeOnly.MinValue, sgt)
+        ?? DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc);
+      var beforeUtc =
+        query.Before?.AddDays(1).ToZonedDateTime(TimeOnly.MinValue, sgt)
+        ?? DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc);
+      var completedBooking = (byte)BookStatus.Completed;
+      var completedWithdrawal = (byte)Domain.Withdrawal.WithdrawStatus.Completed;
+
+      var days = await db
+        .Database.SqlQuery<PnlDayDto>(
+          $"""
+          SELECT
+            CAST((p."CreatedAt" AT TIME ZONE 'UTC' + INTERVAL '8 hours') AS date) AS "Date",
+            SUM(p."CapturedAmount") AS "Deposits",
+            CAST(0 AS int) AS "WithdrawalCount",
+            CAST(0 AS numeric) AS "WithdrawalTotal",
+            CAST(0 AS numeric) AS "WithdrawalFeeIncome",
+            CAST(0 AS numeric) AS "GatewayFees",
+            CAST(0 AS numeric) AS "TicketRevenue",
+            CAST(0 AS numeric) AS "KtmbCost"
+          FROM "Payments" p
+          WHERE p."Status" = 'SUCCEEDED'
+            AND p."CreatedAt" >= {afterUtc}
+            AND p."CreatedAt" < {beforeUtc}
+          GROUP BY 1
+
+          UNION ALL
+
+          SELECT
+            CAST((w."CompletedAt" AT TIME ZONE 'UTC' + INTERVAL '8 hours') AS date) AS "Date",
+            CAST(0 AS numeric) AS "Deposits",
+            CAST(COUNT(*) AS int) AS "WithdrawalCount",
+            SUM(w."Amount") AS "WithdrawalTotal",
+            SUM(COALESCE(w."Fee", 0)) AS "WithdrawalFeeIncome",
+            CAST(0 AS numeric) AS "GatewayFees",
+            CAST(0 AS numeric) AS "TicketRevenue",
+            CAST(0 AS numeric) AS "KtmbCost"
+          FROM "Withdrawals" w
+          WHERE w."Status" = {completedWithdrawal}
+            AND w."CompletedAt" IS NOT NULL
+            AND w."CompletedAt" >= {afterUtc}
+            AND w."CompletedAt" < {beforeUtc}
+          GROUP BY 1
+
+          UNION ALL
+
+          SELECT
+            CAST((g."TransactedAt" AT TIME ZONE 'UTC' + INTERVAL '8 hours') AS date) AS "Date",
+            CAST(0 AS numeric) AS "Deposits",
+            CAST(0 AS int) AS "WithdrawalCount",
+            CAST(0 AS numeric) AS "WithdrawalTotal",
+            CAST(0 AS numeric) AS "WithdrawalFeeIncome",
+            SUM(g."Fee") AS "GatewayFees",
+            CAST(0 AS numeric) AS "TicketRevenue",
+            CAST(0 AS numeric) AS "KtmbCost"
+          FROM "GatewayFees" g
+          WHERE g."TransactedAt" >= {afterUtc}
+            AND g."TransactedAt" < {beforeUtc}
+          GROUP BY 1
+
+          UNION ALL
+
+          SELECT
+            CAST((b."CompletedAt" AT TIME ZONE 'UTC' + INTERVAL '8 hours') AS date) AS "Date",
+            CAST(0 AS numeric) AS "Deposits",
+            CAST(0 AS int) AS "WithdrawalCount",
+            CAST(0 AS numeric) AS "WithdrawalTotal",
+            CAST(0 AS numeric) AS "WithdrawalFeeIncome",
+            CAST(0 AS numeric) AS "GatewayFees",
+            SUM(t."Amount") AS "TicketRevenue",
+            SUM(
+              CASE
+                WHEN b."KtmbAmount" IS NOT NULL AND b."KtmbCurrency" = 'SGD'
+                  THEN b."KtmbAmount"
+                WHEN b."KtmbAmount" IS NOT NULL AND b."KtmbCurrency" = 'MYR'
+                  AND fx."Rate" IS NOT NULL
+                  THEN b."KtmbAmount" * fx."Rate"
+                ELSE 0
+              END
+            ) AS "KtmbCost"
+          FROM "Bookings" b
+          JOIN "Transactions" t ON t."Id" = b."TransactionId"
+          LEFT JOIN LATERAL (
+            SELECT f."Rate"
+            FROM "KtmbFxRates" f
+            WHERE f."EffectiveAt" <= b."CompletedAt"
+            ORDER BY f."EffectiveAt" DESC, f."CreatedAt" DESC, f."Id" DESC
+            LIMIT 1
+          ) fx ON TRUE
+          WHERE b."Status" = {completedBooking}
+            AND b."CompletedAt" IS NOT NULL
+            AND b."CompletedAt" >= {afterUtc}
+            AND b."CompletedAt" < {beforeUtc}
+          GROUP BY 1
+          """
+        )
+        .ToArrayAsync();
+
+      return PnlAnalysisCalculator.Analyze(
+        days.Select(d => new PnlAnalysisDailySum
+        {
+          Date = d.Date,
+          Deposits = d.Deposits,
+          WithdrawalCount = d.WithdrawalCount,
+          WithdrawalTotal = d.WithdrawalTotal,
+          WithdrawalFeeIncome = d.WithdrawalFeeIncome,
+          GatewayFees = d.GatewayFees,
+          TicketRevenue = d.TicketRevenue,
+          KtmbCost = d.KtmbCost,
+        }),
+        query.After,
+        query.Before
+      );
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to compute P&L analysis with {@Query}", query.ToJson());
       return e;
     }
   }

--- a/Domain/Booking/Analysis.cs
+++ b/Domain/Booking/Analysis.cs
@@ -548,6 +548,99 @@ public static class ProfitAnalysisCalculator
     ];
 }
 
+// ---- monthly P&L view (GET Booking/analysis/pnl) ----
+
+// Monthly cash/revenue inputs for the admin Analysis page. The range is over
+// each source event's SGT calendar date (payment CreatedAt, withdrawal or
+// booking CompletedAt, and gateway-fee TransactedAt), inclusive at both ends.
+public record PnlAnalysisQuery
+{
+  public DateOnly? After { get; init; }
+
+  public DateOnly? Before { get; init; }
+}
+
+// One DB-side daily subtotal. Keeping the SGT date until this pure boundary
+// lets the calculator own inclusive-range filtering, month bucketing and
+// ordering while the repository keeps all source scans aggregated.
+public record PnlAnalysisDailySum
+{
+  public required DateOnly Date { get; init; }
+
+  public required decimal Deposits { get; init; }
+
+  public required int WithdrawalCount { get; init; }
+
+  // Gross wallet debit (the user receives Amount - Fee).
+  public required decimal WithdrawalTotal { get; init; }
+
+  public required decimal WithdrawalFeeIncome { get; init; }
+
+  public required decimal GatewayFees { get; init; }
+
+  public required decimal TicketRevenue { get; init; }
+
+  public required decimal KtmbCost { get; init; }
+}
+
+// One non-empty SGT calendar month. No net is derived here: the client owns
+// both cash-net and earned-net presentation.
+public record PnlAnalysisRow
+{
+  // "MM-yyyy"
+  public required string Month { get; init; }
+
+  public required decimal Deposits { get; init; }
+
+  public required int WithdrawalCount { get; init; }
+
+  public required decimal WithdrawalTotal { get; init; }
+
+  public required decimal WithdrawalFeeIncome { get; init; }
+
+  public required decimal GatewayFees { get; init; }
+
+  public required decimal TicketRevenue { get; init; }
+
+  public required decimal KtmbCost { get; init; }
+}
+
+public static class PnlAnalysisCalculator
+{
+  public static PnlAnalysisRow[] Analyze(
+    IEnumerable<PnlAnalysisDailySum> days,
+    DateOnly? after,
+    DateOnly? before
+  ) =>
+    [
+      .. days
+        .Where(d => (after is null || d.Date >= after) && (before is null || d.Date <= before))
+        .GroupBy(d => new { d.Date.Year, d.Date.Month })
+        .Select(g => new PnlAnalysisRow
+        {
+          Month = new DateOnly(g.Key.Year, g.Key.Month, 1).ToString("MM-yyyy"),
+          Deposits = g.Sum(d => d.Deposits),
+          WithdrawalCount = g.Sum(d => d.WithdrawalCount),
+          WithdrawalTotal = g.Sum(d => d.WithdrawalTotal),
+          WithdrawalFeeIncome = g.Sum(d => d.WithdrawalFeeIncome),
+          GatewayFees = g.Sum(d => d.GatewayFees),
+          TicketRevenue = g.Sum(d => d.TicketRevenue),
+          KtmbCost = g.Sum(d => d.KtmbCost),
+        })
+        .Where(r =>
+          r.Deposits != 0m
+          || r.WithdrawalCount != 0
+          || r.WithdrawalTotal != 0m
+          || r.WithdrawalFeeIncome != 0m
+          || r.GatewayFees != 0m
+          || r.TicketRevenue != 0m
+          || r.KtmbCost != 0m
+        )
+        .OrderBy(r => r.Month[3..])
+        .ThenBy(r => r.Month[..2]),
+    ];
+}
+
 public interface IBookingAnalysisRepository
 {
   Task<Result<BookingAnalysis>> Analyze(BookingAnalysisQuery query);
@@ -555,6 +648,8 @@ public interface IBookingAnalysisRepository
   Task<Result<TravelAnalysisRow[]>> TravelAnalysis(TravelAnalysisQuery query);
 
   Task<Result<ProfitAnalysisRow[]>> ProfitAnalysis(ProfitAnalysisQuery query);
+
+  Task<Result<PnlAnalysisRow[]>> PnlAnalysis(PnlAnalysisQuery query);
 
   Task<Result<BookingBoostPage>> Boosts(BookingBoostQuery query);
 }

--- a/UnitTest/Bookings/PnlAnalysisCalculatorTests.cs
+++ b/UnitTest/Bookings/PnlAnalysisCalculatorTests.cs
@@ -1,0 +1,133 @@
+using Domain.Booking;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// Pure monthly P&L math: SGT daily subtotals merge across sources, bounds
+// are inclusive, months are chronological, and no zero-only month leaks to
+// the wire. Source-specific attribution and FX conversion happen in SQL.
+public class PnlAnalysisCalculatorTests
+{
+  private static PnlAnalysisDailySum Day(
+    DateOnly? date = null,
+    decimal deposits = 0m,
+    int withdrawalCount = 0,
+    decimal withdrawalTotal = 0m,
+    decimal withdrawalFeeIncome = 0m,
+    decimal gatewayFees = 0m,
+    decimal ticketRevenue = 0m,
+    decimal ktmbCost = 0m
+  ) =>
+    new()
+    {
+      Date = date ?? new DateOnly(2026, 8, 1),
+      Deposits = deposits,
+      WithdrawalCount = withdrawalCount,
+      WithdrawalTotal = withdrawalTotal,
+      WithdrawalFeeIncome = withdrawalFeeIncome,
+      GatewayFees = gatewayFees,
+      TicketRevenue = ticketRevenue,
+      KtmbCost = ktmbCost,
+    };
+
+  [Fact]
+  public void Days_and_sparse_sources_in_the_same_month_merge_all_measures()
+  {
+    var rows = PnlAnalysisCalculator.Analyze(
+      [
+        Day(new DateOnly(2026, 8, 1), deposits: 200m),
+        Day(
+          new DateOnly(2026, 8, 7),
+          withdrawalCount: 2,
+          withdrawalTotal: 90m,
+          withdrawalFeeIncome: 4m
+        ),
+        Day(new DateOnly(2026, 8, 7), gatewayFees: 3.25m),
+        Day(new DateOnly(2026, 8, 31), ticketRevenue: 135m, ktmbCost: 61.2m),
+      ],
+      null,
+      null
+    );
+
+    rows.Should().ContainSingle();
+    rows[0]
+      .Should()
+      .BeEquivalentTo(
+        new PnlAnalysisRow
+        {
+          Month = "08-2026",
+          Deposits = 200m,
+          WithdrawalCount = 2,
+          WithdrawalTotal = 90m,
+          WithdrawalFeeIncome = 4m,
+          GatewayFees = 3.25m,
+          TicketRevenue = 135m,
+          KtmbCost = 61.2m,
+        }
+      );
+  }
+
+  [Fact]
+  public void Withdrawal_total_stays_gross_and_fee_income_is_separate()
+  {
+    var rows = PnlAnalysisCalculator.Analyze(
+      [Day(withdrawalCount: 1, withdrawalTotal: 100m, withdrawalFeeIncome: 2m)],
+      null,
+      null
+    );
+
+    rows[0].WithdrawalTotal.Should().Be(100m);
+    rows[0].WithdrawalFeeIncome.Should().Be(2m);
+  }
+
+  [Fact]
+  public void Inclusive_date_bounds_filter_before_month_bucketing()
+  {
+    var rows = PnlAnalysisCalculator.Analyze(
+      [
+        Day(new DateOnly(2026, 7, 31), deposits: 1m),
+        Day(new DateOnly(2026, 8, 1), deposits: 2m),
+        Day(new DateOnly(2026, 8, 31), deposits: 3m),
+        Day(new DateOnly(2026, 9, 1), deposits: 4m),
+      ],
+      new DateOnly(2026, 8, 1),
+      new DateOnly(2026, 8, 31)
+    );
+
+    rows.Should().ContainSingle();
+    rows[0].Month.Should().Be("08-2026");
+    rows[0].Deposits.Should().Be(5m);
+  }
+
+  [Fact]
+  public void Null_bounds_are_unbounded_and_months_sort_chronologically()
+  {
+    var rows = PnlAnalysisCalculator.Analyze(
+      [
+        Day(new DateOnly(2027, 1, 1), deposits: 1m),
+        Day(new DateOnly(2026, 12, 1), deposits: 1m),
+        Day(new DateOnly(2026, 2, 1), deposits: 1m),
+      ],
+      null,
+      null
+    );
+
+    rows.Select(r => r.Month).Should().Equal("02-2026", "12-2026", "01-2027");
+  }
+
+  [Fact]
+  public void A_month_with_other_activity_keeps_zero_gateway_fees()
+  {
+    var rows = PnlAnalysisCalculator.Analyze([Day(ticketRevenue: 45m)], null, null);
+
+    rows.Should().ContainSingle();
+    rows[0].GatewayFees.Should().Be(0m);
+  }
+
+  [Fact]
+  public void Empty_or_zero_only_inputs_produce_no_months()
+  {
+    PnlAnalysisCalculator.Analyze([], null, null).Should().BeEmpty();
+    PnlAnalysisCalculator.Analyze([Day()], null, null).Should().BeEmpty();
+  }
+}

--- a/UnitTest/Bookings/PnlAnalysisWireContractTests.cs
+++ b/UnitTest/Bookings/PnlAnalysisWireContractTests.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+using App.Modules.Bookings.API.V1;
+using Domain.Booking;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// The admin frontend builds against this exact flat monthly shape. Pin the
+// web-default camelCase JSON so field renames or derived server-side nets
+// cannot silently change the contract.
+public class PnlAnalysisWireContractTests
+{
+  private static readonly JsonSerializerOptions Web = new(JsonSerializerDefaults.Web);
+
+  [Fact]
+  public void Pnl_row_serializes_with_the_pinned_fields_in_order()
+  {
+    var row = new PnlAnalysisRow
+    {
+      Month = "08-2026",
+      Deposits = 200m,
+      WithdrawalCount = 2,
+      WithdrawalTotal = 90m,
+      WithdrawalFeeIncome = 4m,
+      GatewayFees = 3.25m,
+      TicketRevenue = 135.5m,
+      KtmbCost = 61.2m,
+    };
+
+    var json = JsonSerializer.Serialize(row.ToRes(), Web);
+
+    json.Should()
+      .Be(
+        "{\"month\":\"08-2026\",\"deposits\":200,\"withdrawalCount\":2,"
+          + "\"withdrawalTotal\":90,\"withdrawalFeeIncome\":4,\"gatewayFees\":3.25,"
+          + "\"ticketRevenue\":135.5,\"ktmbCost\":61.2}"
+      );
+  }
+
+  [Fact]
+  public void Pnl_rows_serialize_as_a_flat_array_without_derived_nets()
+  {
+    var rows = new[]
+    {
+      new PnlAnalysisRow
+      {
+        Month = "08-2026",
+        Deposits = 0m,
+        WithdrawalCount = 0,
+        WithdrawalTotal = 0m,
+        WithdrawalFeeIncome = 0m,
+        GatewayFees = 0m,
+        TicketRevenue = 45m,
+        KtmbCost = 20m,
+      },
+    };
+
+    var json = JsonSerializer.Serialize(rows.Select(r => r.ToRes()), Web);
+
+    json.Should()
+      .Be(
+        "[{\"month\":\"08-2026\",\"deposits\":0,\"withdrawalCount\":0,"
+          + "\"withdrawalTotal\":0,\"withdrawalFeeIncome\":0,\"gatewayFees\":0,"
+          + "\"ticketRevenue\":45,\"ktmbCost\":20}]"
+      );
+  }
+
+  [Fact]
+  public void Pnl_query_binds_optional_after_and_before_as_dd_MM_yyyy()
+  {
+    var req = new BookingPnlAnalysisQueryReq("01-08-2026", null);
+
+    var domain = req.ToDomain();
+
+    domain.After.Should().Be(new DateOnly(2026, 8, 1));
+    domain.Before.Should().BeNull();
+  }
+}


### PR DESCRIPTION
## Summary
- add the admin-only monthly P&L endpoint at GET /api/v{version}/Booking/analysis/pnl
- aggregate deposits, completed withdrawals and fee income, gateway fees, ticket revenue, and actual KTMB cost by SGT month
- pin the flat JSON wire contract and cover pure monthly aggregation with unit tests

Withdrawal total intentionally sums the gross wallet debit. The payout received by the user is Amount minus Fee, while withdrawalFeeIncome reports Fee separately.

## Verification
- dotnet test (639 unit tests and 1 integration test passed)
- dotnet format --verify-no-changes for all touched files