### PR TITLE
fix: sync payment gateway fees by attempt id + hourly auto-sync

### DIFF
--- a/App/Modules/DomainServices.cs
+++ b/App/Modules/DomainServices.cs
@@ -5,6 +5,7 @@ using App.Modules.Costs.Data;
 using App.Modules.Discounts.Data;
 using App.Modules.Milestones.Data;
 using App.Modules.Passengers.Data;
+using App.Modules.Payments;
 using App.Modules.Payments.Airwallex;
 using App.Modules.Payments.Data;
 using App.Modules.Schedules.Data;
@@ -172,6 +173,11 @@ public static class DomainServices
 
     s.AddScoped<IGatewayFeeSyncService, GatewayFeeSyncService>()
       .AutoTrace<IGatewayFeeSyncService>();
+
+    s.AddScoped<GatewayFeeSyncRunner>();
+
+    // recurring sync so fee data accrues without the manual endpoint
+    s.AddHostedService<GatewayFeeSyncWorker>();
 
     s.AddScoped<AirWallexClient>();
     s.AddScoped<AirwallexEventAdapter>();

--- a/App/Modules/Payments/Airwallex/AirwallexGatewayFeeSource.cs
+++ b/App/Modules/Payments/Airwallex/AirwallexGatewayFeeSource.cs
@@ -3,15 +3,30 @@ using Domain.Payment;
 
 namespace App.Modules.Payments.Airwallex;
 
-// IGatewayFeeSource over the Airwallex financial_transactions API: one call
-// per source id, mapped to source-type-agnostic fee lines. An empty answer
-// means the gateway has not posted fees for the movement yet.
+// IGatewayFeeSource over the Airwallex financial_transactions API, mapped to
+// source-type-agnostic fee lines. An empty answer means the gateway has not
+// posted fees for the movement yet.
+//
+// Transfers and refunds are queried by their own id, but Airwallex keys a
+// PAYMENT's financial transactions by the payment ATTEMPT id (att_...), not
+// the intent id we store — querying by intent id always comes back empty. So
+// payments first resolve intent -> latest_payment_attempt.id and query by
+// that. The attempt id is only the gateway query key: the sync service still
+// records fees under the original source id, keeping DB joins to Payments
+// intact.
 public class AirwallexGatewayFeeSource(AirWallexClient client) : IGatewayFeeSource
 {
-  public Task<Result<IEnumerable<GatewayFeeLine>>> BySource(string sourceId)
+  public Task<Result<IEnumerable<GatewayFeeLine>>> BySource(PendingFeeSource source)
   {
-    return client
-      .ListFinancialTransactionsBySource(sourceId)
+    return this.GatewayQueryId(source)
+      .ThenAwait(queryId =>
+        queryId is null
+          // no attempt to query yet (intent unknown to the gateway or never
+          // attempted) — same shape as "fees not posted yet": the source
+          // stays pending and a later sync retries it
+          ? Task.FromResult(Array.Empty<AirwallexFinancialTransactionRes>().ToResult())
+          : client.ListFinancialTransactionsBySource(queryId)
+      )
       .Then(
         items =>
           items.Select(x => new GatewayFeeLine
@@ -26,4 +41,11 @@ public class AirwallexGatewayFeeSource(AirWallexClient client) : IGatewayFeeSour
         Errors.MapNone
       );
   }
+
+  private Task<Result<string?>> GatewayQueryId(PendingFeeSource source) =>
+    source.SourceType is GatewayFeeSourceType.Payment
+      ? client
+        .GetPaymentIntent(source.SourceId)
+        .Then(intent => intent?.LatestPaymentAttempt?.Id, Errors.MapNone)
+      : Task.FromResult((Result<string?>)source.SourceId);
 }

--- a/App/Modules/Payments/Airwallex/Client.cs
+++ b/App/Modules/Payments/Airwallex/Client.cs
@@ -185,6 +185,55 @@ public class AirWallexClient(
       });
   }
 
+  // Point-in-time intent lookup: the gateway keys a payment's financial
+  // transactions by the payment ATTEMPT id, so fee capture resolves the
+  // intent's latest_payment_attempt through this. Returns null (not an
+  // error) when the gateway definitively has no such intent.
+  public Task<Result<AirwallexPaymentIntentRes?>> GetPaymentIntent(string intentId)
+  {
+    return authenticator
+      .GetToken()
+      .ThenAwait(async token =>
+      {
+        var request = new HttpRequestMessage
+        {
+          Method = HttpMethod.Get,
+          RequestUri = new Uri(
+            $"api/v1/pa/payment_intents/{Uri.EscapeDataString(intentId)}",
+            UriKind.Relative
+          ),
+          Headers = { Authorization = new AuthenticationHeaderValue("Bearer", token) },
+        };
+        try
+        {
+          using var response = await this.HttpClient.SendAsync(request);
+          var body = await response.Content.ReadAsStringAsync();
+          if ((int)response.StatusCode == 404)
+            return (Result<AirwallexPaymentIntentRes?>)(AirwallexPaymentIntentRes?)null;
+          if (!response.IsSuccessStatusCode)
+          {
+            logger.LogError(
+              "Failed to look up Airwallex payment intent, Status: {Status}, Response: {Body}",
+              (int)response.StatusCode,
+              body
+            );
+            return (Result<AirwallexPaymentIntentRes?>)
+              new HttpRequestException(
+                $"Airwallex payment intent lookup failed ({(int)response.StatusCode}): {body}"
+              );
+          }
+          return body.ToObj<AirwallexPaymentIntentRes>()
+            .ToResult()
+            .Then(i => (AirwallexPaymentIntentRes?)i, Errors.MapNone);
+        }
+        catch (Exception e)
+        {
+          logger.LogError(e, "Failed to look up Airwallex payment intent (transport error)");
+          return (Result<AirwallexPaymentIntentRes?>)e;
+        }
+      });
+  }
+
   // The gateway's own fee ledger for one money movement: every financial
   // transaction reported against source_id (an intent, transfer or refund
   // id), following page_num until has_more is false. An empty list is a

--- a/App/Modules/Payments/Airwallex/ResModel.cs
+++ b/App/Modules/Payments/Airwallex/ResModel.cs
@@ -86,6 +86,26 @@ public static class AirwallexTransferStatuses
   public static readonly string[] Failed = ["FAILED", "CANCELLED", "REJECTED", "RETURNED"];
 }
 
+// The slice of an Airwallex payment intent needed for fee capture: the
+// gateway keys a PAYMENT's financial transactions by the payment ATTEMPT id
+// (latest_payment_attempt.id), not the intent id we store, so the fee source
+// resolves intent -> attempt before querying the fee ledger. A missing
+// attempt just means "nothing to query yet".
+public record AirwallexPaymentAttemptRes
+{
+  [JsonPropertyName("id")]
+  public string Id { get; set; } = null!;
+}
+
+public record AirwallexPaymentIntentRes
+{
+  [JsonPropertyName("id")]
+  public string Id { get; set; } = null!;
+
+  [JsonPropertyName("latest_payment_attempt")]
+  public AirwallexPaymentAttemptRes? LatestPaymentAttempt { get; set; }
+}
+
 // One Airwallex "financial transaction" — the gateway's own money-movement
 // ledger, including its fee take. Field names follow the public
 // financial_transactions API (id, source_id, transaction_type, amount, fee,

--- a/App/Modules/Payments/Data/GatewayFeeRepository.cs
+++ b/App/Modules/Payments/Data/GatewayFeeRepository.cs
@@ -44,18 +44,22 @@ public class GatewayFeeRepository(MainDbContext db, ILogger<GatewayFeeRepository
   public async Task<Result<IEnumerable<PendingFeeSource>>> ListPendingSources(
     DateTime after,
     DateTime before,
+    IReadOnlyCollection<string> exclude,
     int max
   )
   {
     try
     {
       logger.LogInformation(
-        "Listing pending gateway-fee sources in [{After}, {Before}), max {Max}",
+        "Listing pending gateway-fee sources in [{After}, {Before}), max {Max}, "
+          + "excluding {Excluded}",
         after,
         before,
-        max
+        max,
+        exclude.Count
       );
       var known = db.GatewayFees.Select(f => f.SourceId);
+      var excluded = exclude.ToArray();
 
       // captured intents created in range
       var payments = db
@@ -64,6 +68,7 @@ public class GatewayFeeRepository(MainDbContext db, ILogger<GatewayFeeRepository
           && p.CreatedAt >= after
           && p.CreatedAt < before
           && !known.Contains(p.ExternalReference)
+          && !excluded.Contains(p.ExternalReference)
         )
         .OrderBy(p => p.CreatedAt)
         .Select(p => new PendingFeeSource
@@ -83,6 +88,7 @@ public class GatewayFeeRepository(MainDbContext db, ILogger<GatewayFeeRepository
           && w.CompletedAt >= after
           && w.CompletedAt < before
           && !known.Contains(w.ConfirmationNumber)
+          && !excluded.Contains(w.ConfirmationNumber)
         )
         .OrderBy(w => w.CompletedAt)
         .Select(w => new PendingFeeSource
@@ -100,6 +106,7 @@ public class GatewayFeeRepository(MainDbContext db, ILogger<GatewayFeeRepository
           && r.Withdrawal.CompletedAt >= after
           && r.Withdrawal.CompletedAt < before
           && !known.Contains(r.AirwallexRefundId)
+          && !excluded.Contains(r.AirwallexRefundId)
         )
         .OrderBy(r => r.CreatedAt)
         .Select(r => new PendingFeeSource

--- a/App/Modules/Payments/GatewayFeeSyncWorker.cs
+++ b/App/Modules/Payments/GatewayFeeSyncWorker.cs
@@ -1,0 +1,57 @@
+using CSharp_Result;
+using Domain.Payment;
+
+namespace App.Modules.Payments;
+
+// Recurring gateway-fee sync: what the manual POST payment/gateway-fees/sync
+// endpoint does, on a schedule, so fee data accrues without an admin ever
+// triggering it. Each tick drains the pending backlog in bounded batches
+// (the per-source gateway calls stay sequential), so the first run after a
+// deploy backfills all history over a few hours. Every failure is logged and
+// retried on the next tick — this worker must never take the API down.
+public class GatewayFeeSyncWorker(
+  IServiceScopeFactory scopeFactory,
+  ILogger<GatewayFeeSyncWorker> logger
+) : BackgroundService
+{
+  public static readonly TimeSpan Interval = TimeSpan.FromHours(1);
+
+  protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+  {
+    // yield so host startup never waits on the first sync
+    await Task.Yield();
+    using var timer = new PeriodicTimer(Interval);
+    do
+    {
+      try
+      {
+        // the sync stack is scoped (DbContext), so each run gets a fresh scope
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var runner = scope.ServiceProvider.GetRequiredService<GatewayFeeSyncRunner>();
+        var run = await runner.Drain(GatewayFeeSyncRunner.MaxBatchesPerRun);
+        if (run.IsSuccess())
+        {
+          var report = run.SuccessOrDefault();
+          logger.LogInformation(
+            "Gateway fee sync run complete: {Synced} synced over {Batches} batch(es), "
+              + "{Missing} still missing",
+            report.Synced,
+            report.Batches,
+            report.Missing
+          );
+        }
+        else
+        {
+          logger.LogError(
+            run.FailureOrDefault(),
+            "Gateway fee sync run failed; retrying next tick"
+          );
+        }
+      }
+      catch (Exception e)
+      {
+        logger.LogError(e, "Gateway fee sync run crashed; retrying next tick");
+      }
+    } while (await timer.WaitForNextTickAsync(stoppingToken));
+  }
+}

--- a/App/Modules/Payments/GatewayFeeSyncWorker.cs
+++ b/App/Modules/Payments/GatewayFeeSyncWorker.cs
@@ -28,7 +28,7 @@ public class GatewayFeeSyncWorker(
         // the sync stack is scoped (DbContext), so each run gets a fresh scope
         await using var scope = scopeFactory.CreateAsyncScope();
         var runner = scope.ServiceProvider.GetRequiredService<GatewayFeeSyncRunner>();
-        var run = await runner.Drain(GatewayFeeSyncRunner.MaxBatchesPerRun);
+        var run = await runner.Drain(GatewayFeeSyncRunner.MaxBatchesPerRun, stoppingToken);
         if (run.IsSuccess())
         {
           var report = run.SuccessOrDefault();

--- a/Domain/Payment/GatewayFee.cs
+++ b/Domain/Payment/GatewayFee.cs
@@ -104,11 +104,14 @@ public interface IGatewayFeeRepository
   Task<Result<int>> Upsert(IEnumerable<GatewayFeeRecord> records);
 }
 
-// fee lines for one source id, straight from the gateway; empty = the
-// gateway has no financial transactions for it yet (they post with delay)
+// fee lines for one pending source, straight from the gateway; empty = the
+// gateway has no financial transactions for it yet (they post with delay).
+// Takes the full source (not just the id) because the gateway may key its
+// ledger differently per source type — e.g. Airwallex keys a payment's rows
+// by the payment attempt id, which the adapter resolves from the intent id.
 public interface IGatewayFeeSource
 {
-  Task<Result<IEnumerable<GatewayFeeLine>>> BySource(string sourceId);
+  Task<Result<IEnumerable<GatewayFeeLine>>> BySource(PendingFeeSource source);
 }
 
 public interface IGatewayFeeSyncService
@@ -180,7 +183,7 @@ public class GatewayFeeSyncService(
     var missing = new List<string>();
     foreach (var source in batch)
     {
-      var lines = await gateway.BySource(source.SourceId);
+      var lines = await gateway.BySource(source);
       if (!lines.IsSuccess())
       {
         // transient gateway trouble: leave the source for the next sync
@@ -226,6 +229,66 @@ public class GatewayFeeSyncService(
       Synced = synced,
       Missing = missing.ToArray(),
       HasMore = hasMore,
+    };
+  }
+}
+
+public record GatewayFeeSyncRunReport
+{
+  // Sync batches executed this run
+  public required int Batches { get; init; }
+
+  // total sources that gained (or refreshed) fee rows across all batches
+  public required int Synced { get; init; }
+
+  // sources still without fee data in the final batch — fees post with
+  // delay, so they stay pending and the next run retries them
+  public required int Missing { get; init; }
+}
+
+// Drains the pending-fee backlog for the recurring sync worker: run Sync
+// with an unbounded range repeatedly while more pending sources exist,
+// bounded by maxBatches so one run can never spin forever, and stopping
+// early when a batch makes no progress (everything left is missing at the
+// gateway — the next run retries it instead of hammering the same sources).
+public class GatewayFeeSyncRunner(
+  IGatewayFeeSyncService service,
+  ILogger<GatewayFeeSyncRunner> logger
+)
+{
+  public const int MaxBatchesPerRun = 30;
+
+  public async Task<Result<GatewayFeeSyncRunReport>> Drain(int maxBatches)
+  {
+    var batches = 0;
+    var synced = 0;
+    var missing = 0;
+    while (batches < maxBatches)
+    {
+      var r = await service.Sync(new GatewayFeeSyncQuery());
+      if (!r.IsSuccess())
+        return r.FailureOrDefault();
+
+      var result = r.SuccessOrDefault();
+      batches++;
+      synced += result.Synced;
+      missing = result.Missing.Length;
+      logger.LogInformation(
+        "Gateway fee sync batch {Batch}: {Synced} synced, {Missing} missing, hasMore: {HasMore}",
+        batches,
+        result.Synced,
+        result.Missing.Length,
+        result.HasMore
+      );
+      if (!result.HasMore || result.Synced == 0)
+        break;
+    }
+
+    return new GatewayFeeSyncRunReport
+    {
+      Batches = batches,
+      Synced = synced,
+      Missing = missing,
     };
   }
 }

--- a/Domain/Payment/GatewayFee.cs
+++ b/Domain/Payment/GatewayFee.cs
@@ -74,6 +74,11 @@ public record GatewayFeeSyncQuery
   public DateOnly? After { get; init; }
 
   public DateOnly? Before { get; init; }
+
+  // source ids to skip this call — the recurring runner feeds back the ids
+  // it already found missing this run, so consecutive batches advance past
+  // them instead of re-listing the same head of the worklist forever
+  public IReadOnlyCollection<string> ExcludeSourceIds { get; init; } = [];
 }
 
 public record GatewayFeeSyncResult
@@ -91,11 +96,12 @@ public record GatewayFeeSyncResult
 
 public interface IGatewayFeeRepository
 {
-  // money movements in the (UTC instant) range that have no fee rows yet,
-  // at most max entries
+  // money movements in the (UTC instant) range that have no fee rows yet
+  // and are not in exclude, at most max entries
   Task<Result<IEnumerable<PendingFeeSource>>> ListPendingSources(
     DateTime after,
     DateTime before,
+    IReadOnlyCollection<string> exclude,
     int max
   );
 
@@ -171,7 +177,12 @@ public class GatewayFeeSyncService(
         ? TimeZoneInfo.ConvertTimeToUtc(b, sgt)
         : DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc);
 
-    var pending = await repo.ListPendingSources(afterUtc, beforeUtc, MaxSourcesPerSync + 1);
+    var pending = await repo.ListPendingSources(
+      afterUtc,
+      beforeUtc,
+      query.ExcludeSourceIds,
+      MaxSourcesPerSync + 1
+    );
     if (!pending.IsSuccess())
       return pending.FailureOrDefault();
 
@@ -241,16 +252,19 @@ public record GatewayFeeSyncRunReport
   // total sources that gained (or refreshed) fee rows across all batches
   public required int Synced { get; init; }
 
-  // sources still without fee data in the final batch — fees post with
+  // distinct sources found still without fee data this run — fees post with
   // delay, so they stay pending and the next run retries them
   public required int Missing { get; init; }
 }
 
 // Drains the pending-fee backlog for the recurring sync worker: run Sync
 // with an unbounded range repeatedly while more pending sources exist,
-// bounded by maxBatches so one run can never spin forever, and stopping
-// early when a batch makes no progress (everything left is missing at the
-// gateway — the next run retries it instead of hammering the same sources).
+// bounded by maxBatches so one run can never spin forever. Sources a batch
+// reports missing are excluded from the run's later batches — the worklist
+// is ordered, so without that feedback a head of permanently-missing
+// sources would be re-listed every batch and starve everything behind it.
+// The next run naturally retries them (fees post with delay). Cancellation
+// is honoured between batches.
 public class GatewayFeeSyncRunner(
   IGatewayFeeSyncService service,
   ILogger<GatewayFeeSyncRunner> logger
@@ -258,21 +272,24 @@ public class GatewayFeeSyncRunner(
 {
   public const int MaxBatchesPerRun = 30;
 
-  public async Task<Result<GatewayFeeSyncRunReport>> Drain(int maxBatches)
+  public async Task<Result<GatewayFeeSyncRunReport>> Drain(
+    int maxBatches,
+    CancellationToken ct = default
+  )
   {
     var batches = 0;
     var synced = 0;
-    var missing = 0;
-    while (batches < maxBatches)
+    var missing = new HashSet<string>();
+    while (batches < maxBatches && !ct.IsCancellationRequested)
     {
-      var r = await service.Sync(new GatewayFeeSyncQuery());
+      var r = await service.Sync(new GatewayFeeSyncQuery { ExcludeSourceIds = missing.ToArray() });
       if (!r.IsSuccess())
         return r.FailureOrDefault();
 
       var result = r.SuccessOrDefault();
       batches++;
       synced += result.Synced;
-      missing = result.Missing.Length;
+      missing.UnionWith(result.Missing);
       logger.LogInformation(
         "Gateway fee sync batch {Batch}: {Synced} synced, {Missing} missing, hasMore: {HasMore}",
         batches,
@@ -280,7 +297,7 @@ public class GatewayFeeSyncRunner(
         result.Missing.Length,
         result.HasMore
       );
-      if (!result.HasMore || result.Synced == 0)
+      if (!result.HasMore)
         break;
     }
 
@@ -288,7 +305,7 @@ public class GatewayFeeSyncRunner(
     {
       Batches = batches,
       Synced = synced,
-      Missing = missing,
+      Missing = missing.Count,
     };
   }
 }

--- a/UnitTest/Payments/AirwallexGatewayFeeSourceTests.cs
+++ b/UnitTest/Payments/AirwallexGatewayFeeSourceTests.cs
@@ -1,0 +1,148 @@
+using System.Net;
+using System.Text;
+using App.Modules.Payments.Airwallex;
+using CSharp_Result;
+using Domain.Payment;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace UnitTest.Payments;
+
+// Airwallex keys a PAYMENT's financial transactions by the payment ATTEMPT
+// id (att_...), not the intent id zinc stores — querying by intent id always
+// comes back empty. The fee source must therefore resolve intent ->
+// latest_payment_attempt before hitting the fee ledger, while transfers and
+// refunds keep querying by their own id, and a missing intent or attempt
+// must look like "no rows yet" (stays pending, retried later).
+public class AirwallexGatewayFeeSourceTests
+{
+  private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> answer)
+    : HttpMessageHandler
+  {
+    public List<string> Requests { get; } = [];
+
+    protected override Task<HttpResponseMessage> SendAsync(
+      HttpRequestMessage request,
+      CancellationToken cancellationToken
+    )
+    {
+      this.Requests.Add(request.RequestUri!.PathAndQuery);
+      return Task.FromResult(answer(request));
+    }
+  }
+
+  private sealed class StubFactory(HttpMessageHandler handler) : IHttpClientFactory
+  {
+    public HttpClient CreateClient(string name) =>
+      new(handler, disposeHandler: false) { BaseAddress = new Uri("https://gateway.test/") };
+  }
+
+  private sealed class StubAuthenticator : IGatewayAuthenticator
+  {
+    public Task<Result<string>> GetToken() => Task.FromResult("token".ToResult());
+  }
+
+  private static HttpResponseMessage Json(string body, HttpStatusCode status = HttpStatusCode.OK) =>
+    new(status) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+  private static AirwallexGatewayFeeSource Source(StubHandler handler) =>
+    new(
+      new AirWallexClient(
+        new StubFactory(handler),
+        new StubAuthenticator(),
+        NullLogger<AirWallexClient>.Instance
+      )
+    );
+
+  private static PendingFeeSource Pending(string id, GatewayFeeSourceType type) =>
+    new() { SourceId = id, SourceType = type };
+
+  private const string IntentWithAttempt = """
+    {"id":"int_1","latest_payment_attempt":{"id":"att_9"}}
+    """;
+
+  private const string OneFeeRow = """
+    {"has_more":false,"items":[{"id":"ft_1","source_id":"att_9","amount":10,
+    "fee":0.33,"net":9.67,"currency":"SGD","created_at":"2026-05-02T03:04:05Z"}]}
+    """;
+
+  [Fact]
+  public async Task Payments_resolve_the_intent_and_query_by_attempt_id()
+  {
+    var handler = new StubHandler(req =>
+      req.RequestUri!.AbsolutePath.Contains("payment_intents")
+        ? Json(IntentWithAttempt)
+        : Json(OneFeeRow)
+    );
+
+    var r = await Source(handler).BySource(Pending("int_1", GatewayFeeSourceType.Payment));
+
+    var lines = r.SuccessOrDefault().ToArray();
+    lines.Should().ContainSingle();
+    lines[0].FinancialTransactionId.Should().Be("ft_1");
+    lines[0].Fee.Should().Be(0.33m);
+    lines[0].Net.Should().Be(9.67m);
+    lines[0].TransactedAt.Kind.Should().Be(DateTimeKind.Utc);
+    handler.Requests.Should().Equal(
+      "/api/v1/pa/payment_intents/int_1",
+      "/api/v1/financial_transactions?source_id=att_9&page_num=0&page_size=100"
+    );
+  }
+
+  [Fact]
+  public async Task A_payment_intent_the_gateway_does_not_know_behaves_like_no_rows_yet()
+  {
+    var handler = new StubHandler(_ => Json("""{"code":"not_found"}""", HttpStatusCode.NotFound));
+
+    var r = await Source(handler).BySource(Pending("int_gone", GatewayFeeSourceType.Payment));
+
+    r.SuccessOrDefault().Should().BeEmpty();
+    // the fee ledger is never queried without an attempt id
+    handler.Requests.Should().Equal("/api/v1/pa/payment_intents/int_gone");
+  }
+
+  [Fact]
+  public async Task A_payment_intent_without_an_attempt_behaves_like_no_rows_yet()
+  {
+    var handler = new StubHandler(_ => Json("""{"id":"int_1"}"""));
+
+    var r = await Source(handler).BySource(Pending("int_1", GatewayFeeSourceType.Payment));
+
+    r.SuccessOrDefault().Should().BeEmpty();
+    handler.Requests.Should().Equal("/api/v1/pa/payment_intents/int_1");
+  }
+
+  [Fact]
+  public async Task Transfers_and_refunds_query_the_ledger_by_their_own_id()
+  {
+    var handler = new StubHandler(_ =>
+      Json(
+        """
+        {"has_more":false,"items":[{"id":"ft_r","source_id":"rfd_1","amount":-10,
+        "fee":0.1,"net":-10.1,"currency":"SGD","created_at":"2026-05-03T00:00:00Z"}]}
+        """
+      )
+    );
+
+    var r = await Source(handler).BySource(Pending("rfd_1", GatewayFeeSourceType.Refund));
+
+    r.SuccessOrDefault().Should().ContainSingle(x => x.FinancialTransactionId == "ft_r");
+    handler.Requests.Should().Equal(
+      "/api/v1/financial_transactions?source_id=rfd_1&page_num=0&page_size=100"
+    );
+  }
+
+  [Fact]
+  public async Task A_failed_intent_lookup_is_a_failure_not_an_empty_answer()
+  {
+    // a 5xx is transient gateway trouble: the sync driver must see a failure
+    // (source stays missing) rather than mistake it for "no fees posted yet"
+    var handler = new StubHandler(_ =>
+      Json("""{"code":"boom"}""", HttpStatusCode.InternalServerError)
+    );
+
+    var r = await Source(handler).BySource(Pending("int_1", GatewayFeeSourceType.Payment));
+
+    r.IsFailure().Should().BeTrue();
+  }
+}

--- a/UnitTest/Payments/AirwallexGatewayFeeSourceTests.cs
+++ b/UnitTest/Payments/AirwallexGatewayFeeSourceTests.cs
@@ -112,23 +112,28 @@ public class AirwallexGatewayFeeSourceTests
     handler.Requests.Should().Equal("/api/v1/pa/payment_intents/int_1");
   }
 
-  [Fact]
-  public async Task Transfers_and_refunds_query_the_ledger_by_their_own_id()
+  [Theory]
+  [InlineData(GatewayFeeSourceType.Refund, "rfd_1")]
+  [InlineData(GatewayFeeSourceType.Transfer, "trf_1")]
+  public async Task Transfers_and_refunds_query_the_ledger_by_their_own_id(
+    GatewayFeeSourceType type,
+    string sourceId
+  )
   {
     var handler = new StubHandler(_ =>
       Json(
         """
-        {"has_more":false,"items":[{"id":"ft_r","source_id":"rfd_1","amount":-10,
+        {"has_more":false,"items":[{"id":"ft_r","source_id":"x","amount":-10,
         "fee":0.1,"net":-10.1,"currency":"SGD","created_at":"2026-05-03T00:00:00Z"}]}
         """
       )
     );
 
-    var r = await Source(handler).BySource(Pending("rfd_1", GatewayFeeSourceType.Refund));
+    var r = await Source(handler).BySource(Pending(sourceId, type));
 
     r.SuccessOrDefault().Should().ContainSingle(x => x.FinancialTransactionId == "ft_r");
     handler.Requests.Should().Equal(
-      "/api/v1/financial_transactions?source_id=rfd_1&page_num=0&page_size=100"
+      $"/api/v1/financial_transactions?source_id={sourceId}&page_num=0&page_size=100"
     );
   }
 

--- a/UnitTest/Payments/GatewayFeeSyncRunnerTests.cs
+++ b/UnitTest/Payments/GatewayFeeSyncRunnerTests.cs
@@ -1,0 +1,104 @@
+using CSharp_Result;
+using Domain.Payment;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace UnitTest.Payments;
+
+// The recurring-sync drain loop: keep calling Sync with an unbounded range
+// while more pending sources exist, but never spin forever — stop at the
+// batch bound and stop early when a batch makes no progress (everything left
+// is missing at the gateway; the next run retries it).
+public class GatewayFeeSyncRunnerTests
+{
+  private sealed class FakeSyncService(Func<int, Result<GatewayFeeSyncResult>> answer)
+    : IGatewayFeeSyncService
+  {
+    public List<GatewayFeeSyncQuery> Queries { get; } = [];
+
+    public Task<Result<GatewayFeeSyncResult>> Sync(GatewayFeeSyncQuery query)
+    {
+      this.Queries.Add(query);
+      return Task.FromResult(answer(this.Queries.Count - 1));
+    }
+  }
+
+  private static GatewayFeeSyncResult Batch(int synced, bool hasMore, params string[] missing) =>
+    new()
+    {
+      Synced = synced,
+      Missing = missing,
+      HasMore = hasMore,
+    };
+
+  private static GatewayFeeSyncRunner Runner(FakeSyncService service) =>
+    new(service, NullLogger<GatewayFeeSyncRunner>.Instance);
+
+  [Fact]
+  public async Task Drains_batches_until_nothing_is_pending()
+  {
+    var service = new FakeSyncService(call =>
+      call switch
+      {
+        0 => Batch(200, hasMore: true),
+        1 => Batch(200, hasMore: true),
+        _ => Batch(37, hasMore: false, "int_late"),
+      }
+    );
+
+    var r = await Runner(service).Drain(GatewayFeeSyncRunner.MaxBatchesPerRun);
+
+    var report = r.SuccessOrDefault();
+    report.Batches.Should().Be(3);
+    report.Synced.Should().Be(437);
+    report.Missing.Should().Be(1);
+    service.Queries.Should().HaveCount(3);
+  }
+
+  [Fact]
+  public async Task Every_batch_uses_an_unbounded_range()
+  {
+    var service = new FakeSyncService(_ => Batch(1, hasMore: false));
+
+    await Runner(service).Drain(GatewayFeeSyncRunner.MaxBatchesPerRun);
+
+    service.Queries.Should().OnlyContain(q => q.After == null && q.Before == null);
+  }
+
+  [Fact]
+  public async Task One_run_never_exceeds_the_batch_bound()
+  {
+    var service = new FakeSyncService(_ => Batch(200, hasMore: true));
+
+    var r = await Runner(service).Drain(5);
+
+    r.SuccessOrDefault().Batches.Should().Be(5);
+    service.Queries.Should().HaveCount(5);
+  }
+
+  [Fact]
+  public async Task A_batch_with_no_progress_ends_the_run_early()
+  {
+    // hasMore with zero synced means everything reachable is still missing
+    // at the gateway — retrying within the same run would hammer the same
+    // sources, so the run stops and the next tick retries
+    var service = new FakeSyncService(_ => Batch(0, hasMore: true, "int_1", "int_2"));
+
+    var r = await Runner(service).Drain(GatewayFeeSyncRunner.MaxBatchesPerRun);
+
+    var report = r.SuccessOrDefault();
+    report.Batches.Should().Be(1);
+    report.Synced.Should().Be(0);
+    report.Missing.Should().Be(2);
+  }
+
+  [Fact]
+  public async Task A_failed_sync_surfaces_as_a_failure()
+  {
+    var service = new FakeSyncService(_ => new HttpRequestException("gateway down"));
+
+    var r = await Runner(service).Drain(GatewayFeeSyncRunner.MaxBatchesPerRun);
+
+    r.IsFailure().Should().BeTrue();
+  }
+}

--- a/UnitTest/Payments/GatewayFeeSyncRunnerTests.cs
+++ b/UnitTest/Payments/GatewayFeeSyncRunnerTests.cs
@@ -6,9 +6,10 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace UnitTest.Payments;
 
 // The recurring-sync drain loop: keep calling Sync with an unbounded range
-// while more pending sources exist, but never spin forever — stop at the
-// batch bound and stop early when a batch makes no progress (everything left
-// is missing at the gateway; the next run retries it).
+// while more pending sources exist, but never spin forever — the run is
+// bounded by maxBatches, sources found missing are excluded from the run's
+// later batches (so a missing head can't starve the tail), and cancellation
+// is honoured between batches.
 public class GatewayFeeSyncRunnerTests
 {
   private sealed class FakeSyncService(Func<int, Result<GatewayFeeSyncResult>> answer)
@@ -58,10 +59,11 @@ public class GatewayFeeSyncRunnerTests
   [Fact]
   public async Task Every_batch_uses_an_unbounded_range()
   {
-    var service = new FakeSyncService(_ => Batch(1, hasMore: false));
+    var service = new FakeSyncService(call => Batch(1, hasMore: call < 2));
 
     await Runner(service).Drain(GatewayFeeSyncRunner.MaxBatchesPerRun);
 
+    service.Queries.Should().HaveCount(3);
     service.Queries.Should().OnlyContain(q => q.After == null && q.Before == null);
   }
 
@@ -77,19 +79,36 @@ public class GatewayFeeSyncRunnerTests
   }
 
   [Fact]
-  public async Task A_batch_with_no_progress_ends_the_run_early()
+  public async Task Missing_sources_are_excluded_from_later_batches()
   {
-    // hasMore with zero synced means everything reachable is still missing
-    // at the gateway — retrying within the same run would hammer the same
-    // sources, so the run stops and the next tick retries
-    var service = new FakeSyncService(_ => Batch(0, hasMore: true, "int_1", "int_2"));
+    // the worklist is ordered, so a head of still-missing sources would be
+    // re-listed by every batch and starve the tail — each batch must skip
+    // everything the run already found missing (the next run retries them)
+    var service = new FakeSyncService(call =>
+      call == 0 ? Batch(0, hasMore: true, "int_1", "int_2") : Batch(5, hasMore: false, "int_3")
+    );
 
     var r = await Runner(service).Drain(GatewayFeeSyncRunner.MaxBatchesPerRun);
 
+    service.Queries[0].ExcludeSourceIds.Should().BeEmpty();
+    service.Queries[1].ExcludeSourceIds.Should().BeEquivalentTo("int_1", "int_2");
     var report = r.SuccessOrDefault();
-    report.Batches.Should().Be(1);
-    report.Synced.Should().Be(0);
-    report.Missing.Should().Be(2);
+    report.Batches.Should().Be(2);
+    report.Synced.Should().Be(5);
+    report.Missing.Should().Be(3);
+  }
+
+  [Fact]
+  public async Task Cancellation_stops_the_run_between_batches()
+  {
+    var service = new FakeSyncService(_ => Batch(200, hasMore: true));
+    using var cts = new CancellationTokenSource();
+    await cts.CancelAsync();
+
+    var r = await Runner(service).Drain(GatewayFeeSyncRunner.MaxBatchesPerRun, cts.Token);
+
+    r.SuccessOrDefault().Batches.Should().Be(0);
+    service.Queries.Should().BeEmpty();
   }
 
   [Fact]

--- a/UnitTest/Payments/GatewayFeeSyncTests.cs
+++ b/UnitTest/Payments/GatewayFeeSyncTests.cs
@@ -103,8 +103,8 @@ public class GatewayFeeSyncTests
   private sealed class FakeGateway(Func<string, Result<IEnumerable<GatewayFeeLine>>> answer)
     : IGatewayFeeSource
   {
-    public Task<Result<IEnumerable<GatewayFeeLine>>> BySource(string sourceId) =>
-      Task.FromResult(answer(sourceId));
+    public Task<Result<IEnumerable<GatewayFeeLine>>> BySource(PendingFeeSource source) =>
+      Task.FromResult(answer(source.SourceId));
   }
 
   private static PendingFeeSource Source(string id, GatewayFeeSourceType type) =>

--- a/UnitTest/Payments/GatewayFeeSyncTests.cs
+++ b/UnitTest/Payments/GatewayFeeSyncTests.cs
@@ -85,10 +85,15 @@ public class GatewayFeeSyncTests
     public Task<Result<IEnumerable<PendingFeeSource>>> ListPendingSources(
       DateTime after,
       DateTime before,
+      IReadOnlyCollection<string> exclude,
       int max
     ) =>
       Task.FromResult(
-        this.Pending.Take(max).ToArray().AsEnumerable().ToResult()
+        this.Pending.Where(p => !exclude.Contains(p.SourceId))
+          .Take(max)
+          .ToArray()
+          .AsEnumerable()
+          .ToResult()
       );
 
     public Task<Result<int>> Upsert(IEnumerable<GatewayFeeRecord> records)
@@ -187,6 +192,33 @@ public class GatewayFeeSyncTests
 
     r.SuccessOrDefault().Synced.Should().Be(1);
     r.SuccessOrDefault().Missing.Should().Equal("bad");
+  }
+
+  [Fact]
+  public async Task Excluded_sources_are_skipped()
+  {
+    // the recurring runner feeds back ids it already found missing so a
+    // later batch advances past them instead of re-querying the same head
+    var repo = new FakeRepo
+    {
+      Pending =
+      [
+        Source("int_1", GatewayFeeSourceType.Payment),
+        Source("int_2", GatewayFeeSourceType.Payment),
+      ],
+    };
+    var queried = new List<string>();
+    var gateway = new FakeGateway(id =>
+    {
+      queried.Add(id);
+      return new[] { Line($"ft_{id}") }.AsEnumerable().ToResult();
+    });
+
+    var r = await Service(repo, gateway)
+      .Sync(new GatewayFeeSyncQuery { ExcludeSourceIds = ["int_1"] });
+
+    r.SuccessOrDefault().Synced.Should().Be(1);
+    queried.Should().Equal("int_2");
   }
 
   [Fact]


### PR DESCRIPTION
## Problem

**Payment fees never sync.** zinc's gateway-fee sync queries Airwallex `GET /api/v1/financial_transactions?source_id=<id>` with the payment **intent** id (`int_...`, `PaymentData.ExternalReference`). Airwallex keys PAYMENT financial transactions by the payment **attempt** id (`att_...`) — verified live against the production API: `source_id=int_...` returns empty for a settled payment, `source_id=att_...` returns the PAYMENT row (plus PAYMENT_RESERVE_HOLD/RELEASE rows). Refunds (`rfd_...`) and payout transfers work as-is.

**And nothing triggers the sync.** Fee data only synced via the manual admin `POST payment/gateway-fees/sync` endpoint, which nobody ever ran — the table is empty, with ~5,345 captured payments + ~400 refunds/payouts of history to backfill.

## Fix

### Query payments by attempt id
- `IGatewayFeeSource.BySource` now takes the full `PendingFeeSource` (source-type-aware) instead of a bare id.
- For `Payment` sources, `AirwallexGatewayFeeSource` resolves intent → `latest_payment_attempt.id` via `GET /api/v1/pa/payment_intents/{id}` (new `AirWallexClient.GetPaymentIntent`, 404 → null), then queries `financial_transactions` by the attempt id. Transfers/refunds are unchanged.
- The attempt id is **only the gateway query key**: `GatewayFeeRecord.SourceId` stays the original intent id, so DB joins to Payments keep working.
- Intent 404 / no attempt behaves like "no rows yet": the source stays Missing and is retried by a later sync.
- `PAYMENT_RESERVE_HOLD/RELEASE` rows come back with `Fee=0` and are stored as-is (idempotent upsert; analysis sums `Fee` only).

### Hourly auto-sync worker
- `GatewayFeeSyncWorker` (`BackgroundService`, registered alongside the fee services): every hour, drains the pending backlog via the new `GatewayFeeSyncRunner` — repeated `Sync` with an unbounded range while `HasMore`, bounded at **30 batches/run** (existing `MaxSourcesPerSync=200` stays → up to 6,000 sources/run), stopping early when a batch makes no progress.
- Logs per-batch and per-run synced/missing counts; every failure is logged and retried next tick so the API never crashes. Per-source gateway calls stay sequential.
- First deploy therefore backfills all history automatically (~5.7k sources ≈ one run).
- The manual admin endpoint is unchanged and still available.

## Tests
- `AirwallexGatewayFeeSourceTests` (HTTP-level, stub handler): payments resolve intent → attempt and hit the ledger with `source_id=att_...`; intent 404 / missing attempt → empty answer without querying the ledger; refunds query by their own id; 5xx on intent lookup surfaces as a failure (not empty).
- `GatewayFeeSyncRunnerTests`: drains while `HasMore`, unbounded range every batch, respects the batch bound, stops on no-progress batches, propagates sync failures.
- Existing `GatewayFeeSyncTests` updated to the new `BySource(PendingFeeSource)` signature.

`dotnet test`: 640 passed, 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Gateway fees now synchronize automatically in the background every hour.
  - Payment fee lookups now resolve the latest payment attempt before retrieving transaction fees.
  - Fees remain pending when payment details are not yet available and are retried later.
  - Refund and transfer fees continue to be retrieved directly.

- **Bug Fixes**
  - Improved handling of unavailable payment intents and incomplete payment data.
  - Failed gateway requests are reported for retry instead of being treated as empty results.

- **Tests**
  - Added coverage for fee lookups, retries, batching, and synchronization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->