### PR TITLE
feat: partner listing + per-user P&L

### DIFF
--- a/App/Modules/DomainServices.cs
+++ b/App/Modules/DomainServices.cs
@@ -44,6 +44,9 @@ public static class DomainServices
 
     s.AddScoped<IUserRepository, UserRepository>().AutoTrace<IUserRepository>();
 
+    s.AddScoped<IPartnerEconomicsRepository, PartnerEconomicsRepository>()
+      .AutoTrace<IPartnerEconomicsRepository>();
+
     // Passenger
     s.AddScoped<IPassengerService, PassengerService>().AutoTrace<IPassengerService>();
 

--- a/App/Modules/Users/API/V1/UserController.cs
+++ b/App/Modules/Users/API/V1/UserController.cs
@@ -19,6 +19,7 @@ namespace App.Modules.Users.API.V1;
 [Route("api/v{version:apiVersion}/[controller]")]
 public class UserController(
   IUserService service,
+  IPartnerEconomicsRepository partnerEconomicsRepo,
   CreateUserReqValidator createUserReqValidator,
   UpdateUserReqValidator updateUserReqValidator,
   UserSearchQueryValidator userSearchQueryValidator,
@@ -54,6 +55,33 @@ public class UserController(
       .ValidateAsyncResult(query, "Invalid SearchUserQuery")
       .ThenAwait(q => service.Search(q.ToDomain()))
       .Then(x => x.Select(u => u.ToRes()).ToResult());
+    return this.ReturnResult(x);
+  }
+
+  // Users explicitly tagged as partners through ExtraRoles. Role matching is
+  // case-insensitive so legacy/manual role casing cannot hide a partner.
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("partners")]
+  public async Task<ActionResult<IEnumerable<PartnerUserRes>>> Partners()
+  {
+    var x = await partnerEconomicsRepo
+      .ListPartners()
+      .Then(users => users.Select(u => u.ToRes()), Errors.MapAll);
+    return this.ReturnResult(x);
+  }
+
+  // Monthly economics for this user's wallet only. Each event is bucketed by
+  // its inclusive SGT source date; empty months are omitted.
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("{id}/pnl")]
+  public async Task<ActionResult<IEnumerable<PartnerPnlRowRes>>> PartnerPnl(
+    string id,
+    [FromQuery] PartnerPnlQueryReq query,
+    [FromServices] PartnerPnlQueryReqValidator partnerPnlValidator
+  )
+  {
+    var x = await partnerPnlValidator
+      .ValidateAsyncResult(query, "Invalid PartnerPnlQueryReq")
+      .ThenAwait(q => partnerEconomicsRepo.Pnl(id, q.ToDomain()))
+      .Then(rows => rows.Select(r => r.ToRes()), Errors.MapAll);
     return this.ReturnResult(x);
   }
 

--- a/App/Modules/Users/API/V1/UserMapper.cs
+++ b/App/Modules/Users/API/V1/UserMapper.cs
@@ -1,5 +1,6 @@
 using App.Modules.Common;
 using App.Modules.Wallets.API.V1;
+using App.Utility;
 using Domain.User;
 
 namespace App.Modules.Users.API.V1;
@@ -13,6 +14,20 @@ public static class UserMapper
       userPrincipal.Record.ExtraRoles);
 
   public static UserRes ToRes(this User user) => new(user.Principal.ToRes(), user.Wallet.ToRes());
+
+  public static PartnerUserRes ToRes(this PartnerUser user) =>
+    new(user.Id, user.Username, user.Email);
+
+  public static PartnerPnlRowRes ToRes(this PartnerPnlRow row) =>
+    new(
+      row.Month,
+      row.Bookings,
+      row.Collected,
+      row.KtmbCost,
+      row.Deposits,
+      row.WithdrawalGross,
+      row.WithdrawalFeeIncome
+    );
 
   // REQ
   public static UserRecord ToRecord(this CreateUserReq req, UserToken token) =>
@@ -42,4 +57,7 @@ public static class UserMapper
       Limit = query.Limit ?? 20,
       Skip = query.Skip ?? 0,
     };
+
+  public static PartnerPnlQuery ToDomain(this PartnerPnlQueryReq query) =>
+    new() { After = query.After?.ToDate(), Before = query.Before?.ToDate() };
 }

--- a/App/Modules/Users/API/V1/UserModel.cs
+++ b/App/Modules/Users/API/V1/UserModel.cs
@@ -9,8 +9,23 @@ public record CreateUserReq(string Username, string? IdToken, string? AccessToke
 
 public record UpdateUserReq(string Username, string? IdToken, string? AccessToken);
 
+// inclusive SGT source-event dates (dd-MM-yyyy); null = unbounded
+public record PartnerPnlQueryReq(string? After, string? Before);
+
 // RESP
 public record UserExistRes(bool Exists);
+
+public record PartnerUserRes(string Id, string Username, string Email);
+
+public record PartnerPnlRowRes(
+  string Month,
+  int Bookings,
+  decimal Collected,
+  decimal KtmbCost,
+  decimal Deposits,
+  decimal WithdrawalGross,
+  decimal WithdrawalFeeIncome
+);
 
 // ExtraRoles: admin-managed roles for discount/pricing targeting — distinct
 // from Roles (which mirror the Descope JWT and are overwritten by the token

--- a/App/Modules/Users/API/V1/UserValidator.cs
+++ b/App/Modules/Users/API/V1/UserValidator.cs
@@ -29,3 +29,12 @@ public class UserSearchQueryValidator : AbstractValidator<SearchUserQuery>
     this.RuleFor(x => x.Skip).Skip();
   }
 }
+
+public class PartnerPnlQueryReqValidator : AbstractValidator<PartnerPnlQueryReq>
+{
+  public PartnerPnlQueryReqValidator()
+  {
+    this.RuleFor(x => x.After).NullableDateValid();
+    this.RuleFor(x => x.Before).NullableDateValid();
+  }
+}

--- a/App/Modules/Users/Data/PartnerEconomicsRepository.cs
+++ b/App/Modules/Users/Data/PartnerEconomicsRepository.cs
@@ -1,0 +1,209 @@
+using App.StartUp.Database;
+using App.Utility;
+using CSharp_Result;
+using Domain;
+using Domain.Booking;
+using Domain.User;
+using Domain.Withdrawal;
+using Microsoft.EntityFrameworkCore;
+
+namespace App.Modules.Users.Data;
+
+// Read-only partner reporting. All source scans aggregate DB-side, with the
+// pure domain calculator owning the final inclusive filter, month merge and
+// chronological ordering.
+public class PartnerEconomicsRepository(
+  MainDbContext db,
+  ILogger<PartnerEconomicsRepository> logger
+) : IPartnerEconomicsRepository
+{
+  private sealed class PartnerDto
+  {
+    public string Id { get; set; } = string.Empty;
+
+    public string Username { get; set; } = string.Empty;
+
+    public string Email { get; set; } = string.Empty;
+  }
+
+  private sealed class PnlDayDto
+  {
+    public DateOnly Date { get; set; }
+
+    public int Bookings { get; set; }
+
+    public decimal Collected { get; set; }
+
+    public decimal KtmbCost { get; set; }
+
+    public decimal Deposits { get; set; }
+
+    public decimal WithdrawalGross { get; set; }
+
+    public decimal WithdrawalFeeIncome { get; set; }
+  }
+
+  public async Task<Result<PartnerUser[]>> ListPartners()
+  {
+    try
+    {
+      logger.LogInformation("Listing partner users");
+      var partners = await db
+        .Database.SqlQuery<PartnerDto>(
+          $"""
+          SELECT
+            u."Id" AS "Id",
+            u."Username" AS "Username",
+            COALESCE(u."Email", '') AS "Email"
+          FROM "Users" u
+          WHERE EXISTS (
+            SELECT 1
+            FROM unnest(u."ExtraRoles") AS r(role)
+            WHERE lower(r.role) = 'partner'
+          )
+          ORDER BY u."Username", u."Id"
+          """
+        )
+        .ToArrayAsync();
+
+      return partners
+        .Select(p => new PartnerUser
+        {
+          Id = p.Id,
+          Username = p.Username,
+          Email = p.Email,
+        })
+        .ToArray();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to list partner users");
+      return e;
+    }
+  }
+
+  public async Task<Result<PartnerPnlRow[]>> Pnl(string userId, PartnerPnlQuery query)
+  {
+    try
+    {
+      logger.LogInformation("Computing partner P&L for User '{UserId}' with {@Query}", userId, query.ToJson());
+      var sgt = TimeZoneInfo.FindSystemTimeZoneById("Asia/Singapore");
+      var afterUtc =
+        query.After?.ToZonedDateTime(TimeOnly.MinValue, sgt)
+        ?? DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc);
+      var beforeUtc =
+        query.Before?.AddDays(1).ToZonedDateTime(TimeOnly.MinValue, sgt)
+        ?? DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc);
+      var completedBooking = (byte)BookStatus.Completed;
+      var completedWithdrawal = (byte)WithdrawStatus.Completed;
+
+      // Resolve the user's wallet once, then scope every money source to it.
+      // Bookings carry UserId rather than WalletId, so their arm follows the
+      // same wallet -> user link before applying the standard request-
+      // transaction revenue attribution and per-booking FX LATERAL.
+      var days = await db
+        .Database.SqlQuery<PnlDayDto>(
+          $"""
+          WITH wallet AS (
+            SELECT w."Id", w."UserId"
+            FROM "Wallets" w
+            WHERE w."UserId" = {userId}
+          )
+          SELECT
+            CAST((b."CompletedAt" AT TIME ZONE 'UTC' + INTERVAL '8 hours') AS date) AS "Date",
+            CAST(COUNT(*) AS int) AS "Bookings",
+            SUM(t."Amount") AS "Collected",
+            SUM(
+              CASE
+                WHEN b."KtmbAmount" IS NOT NULL AND b."KtmbCurrency" = 'SGD'
+                  THEN b."KtmbAmount"
+                WHEN b."KtmbAmount" IS NOT NULL AND b."KtmbCurrency" = 'MYR'
+                  AND fx."Rate" IS NOT NULL
+                  THEN b."KtmbAmount" * fx."Rate"
+                ELSE 0
+              END
+            ) AS "KtmbCost",
+            CAST(0 AS numeric) AS "Deposits",
+            CAST(0 AS numeric) AS "WithdrawalGross",
+            CAST(0 AS numeric) AS "WithdrawalFeeIncome"
+          FROM "Bookings" b
+          JOIN wallet w ON w."UserId" = b."UserId"
+          JOIN "Transactions" t ON t."Id" = b."TransactionId"
+          LEFT JOIN LATERAL (
+            SELECT f."Rate"
+            FROM "KtmbFxRates" f
+            WHERE f."EffectiveAt" <= b."CompletedAt"
+            ORDER BY f."EffectiveAt" DESC, f."CreatedAt" DESC, f."Id" DESC
+            LIMIT 1
+          ) fx ON TRUE
+          WHERE b."Status" = {completedBooking}
+            AND b."CompletedAt" IS NOT NULL
+            AND b."CompletedAt" >= {afterUtc}
+            AND b."CompletedAt" < {beforeUtc}
+          GROUP BY 1
+
+          UNION ALL
+
+          SELECT
+            CAST((p."CreatedAt" AT TIME ZONE 'UTC' + INTERVAL '8 hours') AS date) AS "Date",
+            CAST(0 AS int) AS "Bookings",
+            CAST(0 AS numeric) AS "Collected",
+            CAST(0 AS numeric) AS "KtmbCost",
+            SUM(p."CapturedAmount") AS "Deposits",
+            CAST(0 AS numeric) AS "WithdrawalGross",
+            CAST(0 AS numeric) AS "WithdrawalFeeIncome"
+          FROM "Payments" p
+          JOIN wallet w ON w."Id" = p."WalletId"
+          WHERE p."Status" = 'SUCCEEDED'
+            AND p."CreatedAt" >= {afterUtc}
+            AND p."CreatedAt" < {beforeUtc}
+          GROUP BY 1
+
+          UNION ALL
+
+          SELECT
+            CAST((x."CompletedAt" AT TIME ZONE 'UTC' + INTERVAL '8 hours') AS date) AS "Date",
+            CAST(0 AS int) AS "Bookings",
+            CAST(0 AS numeric) AS "Collected",
+            CAST(0 AS numeric) AS "KtmbCost",
+            CAST(0 AS numeric) AS "Deposits",
+            SUM(x."Amount") AS "WithdrawalGross",
+            SUM(COALESCE(x."Fee", 0)) AS "WithdrawalFeeIncome"
+          FROM "Withdrawals" x
+          JOIN wallet w ON w."Id" = x."WalletId"
+          WHERE x."Status" = {completedWithdrawal}
+            AND x."CompletedAt" IS NOT NULL
+            AND x."CompletedAt" >= {afterUtc}
+            AND x."CompletedAt" < {beforeUtc}
+          GROUP BY 1
+          """
+        )
+        .ToArrayAsync();
+
+      return PartnerPnlCalculator.Analyze(
+        days.Select(d => new PartnerPnlDailySum
+        {
+          Date = d.Date,
+          Bookings = d.Bookings,
+          Collected = d.Collected,
+          KtmbCost = d.KtmbCost,
+          Deposits = d.Deposits,
+          WithdrawalGross = d.WithdrawalGross,
+          WithdrawalFeeIncome = d.WithdrawalFeeIncome,
+        }),
+        query.After,
+        query.Before
+      );
+    }
+    catch (Exception e)
+    {
+      logger.LogError(
+        e,
+        "Failed to compute partner P&L for User '{UserId}' with {@Query}",
+        userId,
+        query.ToJson()
+      );
+      return e;
+    }
+  }
+}

--- a/Domain/User/PartnerEconomics.cs
+++ b/Domain/User/PartnerEconomics.cs
@@ -1,0 +1,105 @@
+using CSharp_Result;
+
+namespace Domain.User;
+
+// Admin-facing users tagged through the case-insensitive "partner"
+// ExtraRole. Email is normalized to an empty string by the read repository
+// for the small number of legacy users that do not have one.
+public record PartnerUser
+{
+  public required string Id { get; init; }
+
+  public required string Username { get; init; }
+
+  public required string Email { get; init; }
+}
+
+// Inclusive SGT calendar-date range. Each source is filtered on its own
+// event timestamp before the daily subtotals are rolled into months.
+public record PartnerPnlQuery
+{
+  public DateOnly? After { get; init; }
+
+  public DateOnly? Before { get; init; }
+}
+
+// One DB-side daily subtotal from one source. UNION ALL emits sparse rows;
+// the pure calculator below merges them by SGT calendar month.
+public record PartnerPnlDailySum
+{
+  public required DateOnly Date { get; init; }
+
+  public required int Bookings { get; init; }
+
+  public required decimal Collected { get; init; }
+
+  public required decimal KtmbCost { get; init; }
+
+  public required decimal Deposits { get; init; }
+
+  public required decimal WithdrawalGross { get; init; }
+
+  public required decimal WithdrawalFeeIncome { get; init; }
+}
+
+// One non-empty SGT calendar month for a partner's wallet and bookings.
+public record PartnerPnlRow
+{
+  // "MM-yyyy"
+  public required string Month { get; init; }
+
+  public required int Bookings { get; init; }
+
+  public required decimal Collected { get; init; }
+
+  public required decimal KtmbCost { get; init; }
+
+  public required decimal Deposits { get; init; }
+
+  public required decimal WithdrawalGross { get; init; }
+
+  public required decimal WithdrawalFeeIncome { get; init; }
+}
+
+public static class PartnerPnlCalculator
+{
+  public static PartnerPnlRow[] Analyze(
+    IEnumerable<PartnerPnlDailySum> days,
+    DateOnly? after,
+    DateOnly? before
+  ) =>
+    [
+      .. days
+        .Where(d => (after is null || d.Date >= after) && (before is null || d.Date <= before))
+        .GroupBy(d => new { d.Date.Year, d.Date.Month })
+        .Select(g => new PartnerPnlRow
+        {
+          Month = new DateOnly(g.Key.Year, g.Key.Month, 1).ToString("MM-yyyy"),
+          Bookings = g.Sum(d => d.Bookings),
+          Collected = g.Sum(d => d.Collected),
+          KtmbCost = g.Sum(d => d.KtmbCost),
+          Deposits = g.Sum(d => d.Deposits),
+          WithdrawalGross = g.Sum(d => d.WithdrawalGross),
+          WithdrawalFeeIncome = g.Sum(d => d.WithdrawalFeeIncome),
+        })
+        .Where(r =>
+          r.Bookings != 0
+          || r.Collected != 0m
+          || r.KtmbCost != 0m
+          || r.Deposits != 0m
+          || r.WithdrawalGross != 0m
+          || r.WithdrawalFeeIncome != 0m
+        )
+        .OrderBy(r => r.Month[3..])
+        .ThenBy(r => r.Month[..2]),
+    ];
+}
+
+// Isolated read model: keeping these reporting queries out of IUserRepository
+// avoids coupling the core user service and its many test fakes to analytics.
+public interface IPartnerEconomicsRepository
+{
+  Task<Result<PartnerUser[]>> ListPartners();
+
+  Task<Result<PartnerPnlRow[]>> Pnl(string userId, PartnerPnlQuery query);
+}

--- a/UnitTest/Users/PartnerEconomicsWireContractTests.cs
+++ b/UnitTest/Users/PartnerEconomicsWireContractTests.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+using App.Modules.Users.API.V1;
+using Domain.User;
+using FluentAssertions;
+
+namespace UnitTest.Users;
+
+// Argon builds against these exact flat response shapes. Pin web-default
+// camelCase JSON so field additions, renames or reordering are visible.
+public class PartnerEconomicsWireContractTests
+{
+  private static readonly JsonSerializerOptions Web = new(JsonSerializerDefaults.Web);
+
+  [Fact]
+  public void Partner_user_serializes_as_id_username_email()
+  {
+    var user = new PartnerUser
+    {
+      Id = "user-1",
+      Username = "bunny",
+      Email = "bunny@example.com",
+    };
+
+    var json = JsonSerializer.Serialize(user.ToRes(), Web);
+
+    json.Should().Be("{\"id\":\"user-1\",\"username\":\"bunny\",\"email\":\"bunny@example.com\"}");
+  }
+
+  [Fact]
+  public void Partner_pnl_rows_serialize_with_the_pinned_fields_in_order()
+  {
+    var rows = new[]
+    {
+      new PartnerPnlRow
+      {
+        Month = "08-2026",
+        Bookings = 3,
+        Collected = 135.5m,
+        KtmbCost = 61.2m,
+        Deposits = 200m,
+        WithdrawalGross = 90m,
+        WithdrawalFeeIncome = 4m,
+      },
+    };
+
+    var json = JsonSerializer.Serialize(rows.Select(r => r.ToRes()), Web);
+
+    json.Should()
+      .Be(
+        "[{\"month\":\"08-2026\",\"bookings\":3,\"collected\":135.5,"
+          + "\"ktmbCost\":61.2,\"deposits\":200,\"withdrawalGross\":90,"
+          + "\"withdrawalFeeIncome\":4}]"
+      );
+  }
+
+  [Fact]
+  public void Partner_pnl_query_binds_optional_dates_as_dd_MM_yyyy()
+  {
+    var req = new PartnerPnlQueryReq("01-08-2026", null);
+
+    var domain = req.ToDomain();
+
+    domain.After.Should().Be(new DateOnly(2026, 8, 1));
+    domain.Before.Should().BeNull();
+  }
+
+  [Fact]
+  public async Task Partner_pnl_query_validator_rejects_non_standard_dates()
+  {
+    var validator = new PartnerPnlQueryReqValidator();
+
+    var invalid = await validator.ValidateAsync(new PartnerPnlQueryReq("2026-08-01", null));
+    var valid = await validator.ValidateAsync(new PartnerPnlQueryReq(null, "31-08-2026"));
+
+    invalid.IsValid.Should().BeFalse();
+    valid.IsValid.Should().BeTrue();
+  }
+}

--- a/UnitTest/Users/PartnerPnlCalculatorTests.cs
+++ b/UnitTest/Users/PartnerPnlCalculatorTests.cs
@@ -1,0 +1,91 @@
+using Domain.User;
+using FluentAssertions;
+
+namespace UnitTest.Users;
+
+// Pure rollup contract: sparse SGT daily source totals merge into
+// chronological, non-empty calendar months with inclusive bounds.
+public class PartnerPnlCalculatorTests
+{
+  private static PartnerPnlDailySum Day(
+    DateOnly? date = null,
+    int bookings = 0,
+    decimal collected = 0m,
+    decimal ktmbCost = 0m,
+    decimal deposits = 0m,
+    decimal withdrawalGross = 0m,
+    decimal withdrawalFeeIncome = 0m
+  ) =>
+    new()
+    {
+      Date = date ?? new DateOnly(2026, 8, 1),
+      Bookings = bookings,
+      Collected = collected,
+      KtmbCost = ktmbCost,
+      Deposits = deposits,
+      WithdrawalGross = withdrawalGross,
+      WithdrawalFeeIncome = withdrawalFeeIncome,
+    };
+
+  [Fact]
+  public void Sparse_sources_in_the_same_month_merge_all_measures()
+  {
+    var rows = PartnerPnlCalculator.Analyze(
+      [
+        Day(new DateOnly(2026, 8, 1), deposits: 200m),
+        Day(
+          new DateOnly(2026, 8, 7),
+          withdrawalGross: 90m,
+          withdrawalFeeIncome: 4m
+        ),
+        Day(new DateOnly(2026, 8, 31), bookings: 3, collected: 135m, ktmbCost: 61.2m),
+      ],
+      null,
+      null
+    );
+
+    rows.Should().ContainSingle();
+    rows[0]
+      .Should()
+      .BeEquivalentTo(
+        new PartnerPnlRow
+        {
+          Month = "08-2026",
+          Bookings = 3,
+          Collected = 135m,
+          KtmbCost = 61.2m,
+          Deposits = 200m,
+          WithdrawalGross = 90m,
+          WithdrawalFeeIncome = 4m,
+        }
+      );
+  }
+
+  [Fact]
+  public void Inclusive_bounds_filter_before_month_bucketing_and_months_sort_chronologically()
+  {
+    var rows = PartnerPnlCalculator.Analyze(
+      [
+        Day(new DateOnly(2026, 7, 31), deposits: 1m),
+        Day(new DateOnly(2027, 1, 1), deposits: 4m),
+        Day(new DateOnly(2026, 8, 1), deposits: 2m),
+        Day(new DateOnly(2026, 8, 31), deposits: 3m),
+        Day(new DateOnly(2026, 9, 1), bookings: 1),
+      ],
+      new DateOnly(2026, 8, 1),
+      new DateOnly(2027, 1, 1)
+    );
+
+    rows.Select(r => r.Month).Should().Equal("08-2026", "09-2026", "01-2027");
+    rows[0].Deposits.Should().Be(5m);
+    rows[1].Bookings.Should().Be(1, "a completed zero-price booking still makes the month non-empty");
+  }
+
+  [Fact]
+  public void Zero_only_months_are_omitted()
+  {
+    var rows = PartnerPnlCalculator.Analyze([Day()], null, null);
+
+    rows.Should().BeEmpty();
+  }
+}


### PR DESCRIPTION
## Summary

- add the admin-only partner listing sourced from case-insensitive ExtraRoles membership
- add per-user monthly wallet economics with inclusive SGT date bounds and actual KTMB FX conversion
- preserve the existing admin ExtraRoles add/remove API instead of duplicating role management
- pin the frontend JSON contracts and cover the pure monthly rollup

## Test plan

- sudo /usr/bin/docker run --rm -v "$PWD":/src -w /src -v zinc-nuget:/root/.nuget mcr.microsoft.com/dotnet/sdk:8.0 dotnet test
- narrowed dotnet format verification for every added or materially edited file
- git diff --check