### PR TITLE
feat: capture KTMB termination refunds

### DIFF
--- a/App/Migrations/20260715000412_AddKtmbRefundCapture.Designer.cs
+++ b/App/Migrations/20260715000412_AddKtmbRefundCapture.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using App.StartUp.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace App.Migrations
 {
     [DbContext(typeof(MainDbContext))]
-    partial class MainDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260715000412_AddKtmbRefundCapture")]
+    partial class AddKtmbRefundCapture
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/App/Migrations/20260715000412_AddKtmbRefundCapture.cs
+++ b/App/Migrations/20260715000412_AddKtmbRefundCapture.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace App.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddKtmbRefundCapture : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "KtmbRefundAmount",
+                table: "Bookings",
+                type: "numeric(16,8)",
+                precision: 16,
+                scale: 8,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "KtmbRefundCurrency",
+                table: "Bookings",
+                type: "character varying(8)",
+                maxLength: 8,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "KtmbRefundAmount",
+                table: "Bookings");
+
+            migrationBuilder.DropColumn(
+                name: "KtmbRefundCurrency",
+                table: "Bookings");
+        }
+    }
+}

--- a/App/Modules/Bookings/API/V1/BookingController.cs
+++ b/App/Modules/Bookings/API/V1/BookingController.cs
@@ -392,9 +392,10 @@ public class BookingController(
     );
   }
 
-  // The tin backfill worklist: Completed bookings that captured a KTMB
-  // reservation (BookingNo + TicketNo present) but have no actual paid
-  // amount recorded yet, oldest CompletedAt first
+  // The tin backfill worklist: bookings of the queried status (default
+  // Completed; Terminated for terminated-then-refunded history) that
+  // captured a KTMB reservation (BookingNo + TicketNo present) but have no
+  // actual paid amount recorded yet, oldest CompletedAt first
   [Authorize(Policy = AuthPolicies.AdminOrTin), HttpGet("ktmb-cost/missing")]
   public async Task<ActionResult<IEnumerable<KtmbCostMissingRes>>> MissingKtmbCost(
     [FromQuery] KtmbCostMissingQuery query,
@@ -403,7 +404,29 @@ public class BookingController(
   {
     var x = await missingValidator
       .ValidateAsyncResult(query, "Invalid KtmbCostMissingQuery")
-      .ThenAwait(q => service.ListMissingKtmbActualCost(q.Limit ?? 100, q.Skip ?? 0))
+      .ThenAwait(q =>
+        service.ListMissingKtmbActualCost(
+          (BookStatus)(q.Status ?? (int)BookStatus.Completed),
+          q.Limit ?? 100,
+          q.Skip ?? 0
+        )
+      )
+      .Then(rows => rows.Select(m => m.ToRes()), Errors.MapAll);
+    return this.ReturnResult(x);
+  }
+
+  // The tin refund-backfill worklist: Terminated bookings with a recorded
+  // actual KTMB cost but no captured KTMB termination refund yet, oldest
+  // CompletedAt first (same row shape as ktmb-cost/missing)
+  [Authorize(Policy = AuthPolicies.AdminOrTin), HttpGet("ktmb-refund/missing")]
+  public async Task<ActionResult<IEnumerable<KtmbCostMissingRes>>> MissingKtmbRefund(
+    [FromQuery] KtmbRefundMissingQuery query,
+    [FromServices] KtmbRefundMissingQueryValidator refundMissingValidator
+  )
+  {
+    var x = await refundMissingValidator
+      .ValidateAsyncResult(query, "Invalid KtmbRefundMissingQuery")
+      .ThenAwait(q => service.ListMissingKtmbRefund(q.Limit ?? 100, q.Skip ?? 0))
       .Then(rows => rows.Select(m => m.ToRes()), Errors.MapAll);
     return this.ReturnResult(x);
   }
@@ -422,6 +445,26 @@ public class BookingController(
       .ValidateAsyncResult(req, "Invalid SetBookingKtmbCostReq")
       .ThenAwait(r => service.RecordKtmbActualCost(id, r.ToDomain()))
       .Then(c => c?.ToRes(id), Errors.MapAll);
+    return this.ReturnNullableResult(
+      x,
+      new EntityNotFound("Booking not found", typeof(Booking), id.ToString())
+    );
+  }
+
+  // Capture the actual KTMB termination refund of a booking (tin's
+  // terminator sends KTMB's GetRefundPolicy amount; the backfill records it
+  // for historical terminations). Upsert: a repeat call overwrites.
+  [Authorize(Policy = AuthPolicies.AdminOrTin), HttpPost("{id:guid}/ktmb-refund")]
+  public async Task<ActionResult<BookingKtmbRefundRes>> RecordKtmbRefund(
+    Guid id,
+    [FromBody] SetBookingKtmbRefundReq req,
+    [FromServices] SetBookingKtmbRefundReqValidator ktmbRefundValidator
+  )
+  {
+    var x = await ktmbRefundValidator
+      .ValidateAsyncResult(req, "Invalid SetBookingKtmbRefundReq")
+      .ThenAwait(r => service.RecordKtmbRefund(id, r.ToDomain()))
+      .Then(r => r?.ToRes(id), Errors.MapAll);
     return this.ReturnNullableResult(
       x,
       new EntityNotFound("Booking not found", typeof(Booking), id.ToString())

--- a/App/Modules/Bookings/API/V1/BookingMapper.cs
+++ b/App/Modules/Bookings/API/V1/BookingMapper.cs
@@ -247,6 +247,13 @@ public static class BookingMapper
   public static BookingKtmbCostRes ToRes(this BookingKtmbCost c, Guid id) =>
     new(id, c.Amount, c.Currency);
 
+  // actual KTMB termination refund (terminator capture + backfill)
+  public static BookingKtmbRefund ToDomain(this SetBookingKtmbRefundReq req) =>
+    new() { Amount = req.RefundAmount, Currency = req.RefundCurrency };
+
+  public static BookingKtmbRefundRes ToRes(this BookingKtmbRefund r, Guid id) =>
+    new(id, r.Amount, r.Currency);
+
   public static KtmbCostMissingRes ToRes(this BookingKtmbCostMissing m) =>
     new(m.Id, m.BookingNo, m.TicketNo, m.CompletedAt);
 

--- a/App/Modules/Bookings/API/V1/BookingModel.cs
+++ b/App/Modules/Bookings/API/V1/BookingModel.cs
@@ -61,11 +61,26 @@ public record SetBookingKtmbCostReq(decimal Amount, string Currency);
 
 public record BookingKtmbCostRes(Guid Id, decimal Amount, string Currency);
 
-// the tin backfill worklist page: Limit/Skip paging, oldest CompletedAt first
-public record KtmbCostMissingQuery(int? Limit, int? Skip);
+// capture the actual KTMB termination refund (tin's terminator sends KTMB's
+// GetRefundPolicy amount; the backfill records it for history) — PINNED wire
+// shape with the parallel tin PR: refundAmount >= 0, refundCurrency 3-8
+// chars.
+// Upsert: a repeat call overwrites
+public record SetBookingKtmbRefundReq(decimal RefundAmount, string RefundCurrency);
 
-// one worklist row: a Completed booking with KTMB identifiers but no actual
-// paid amount recorded yet
+public record BookingKtmbRefundRes(Guid Id, decimal RefundAmount, string RefundCurrency);
+
+// the tin backfill worklist page: Limit/Skip paging, oldest CompletedAt
+// first; Status picks the worklist (2 = Completed, the default; 5 =
+// Terminated for terminated-then-refunded history)
+public record KtmbCostMissingQuery(int? Limit, int? Skip, int? Status);
+
+// the tin refund-backfill worklist page: Limit/Skip paging, oldest
+// CompletedAt first
+public record KtmbRefundMissingQuery(int? Limit, int? Skip);
+
+// one worklist row: a booking with KTMB identifiers but no actual paid
+// amount (or no captured KTMB refund) recorded yet
 public record KtmbCostMissingRes(Guid Id, string BookingNo, string TicketNo, DateTime CompletedAt);
 
 // KTMB FX: queue an MYR -> SGD rate change (SGD per 1 MYR); EffectiveAt

--- a/App/Modules/Bookings/API/V1/BookingValidator.cs
+++ b/App/Modules/Bookings/API/V1/BookingValidator.cs
@@ -208,9 +208,44 @@ public class SetBookingKtmbCostReqValidator : AbstractValidator<SetBookingKtmbCo
   }
 }
 
+// the KTMB termination-refund capture — PINNED wire contract with the
+// parallel tin PR: refundAmount >= 0 (KTMB can refund nothing) within the
+// stored precision, refundCurrency 3-8 chars (e.g. MYR)
+public class SetBookingKtmbRefundReqValidator : AbstractValidator<SetBookingKtmbRefundReq>
+{
+  public SetBookingKtmbRefundReqValidator()
+  {
+    this.RuleFor(x => x.RefundAmount)
+      .GreaterThanOrEqualTo(0)
+      .WithMessage("RefundAmount must be greater than or equal to 0");
+    // stay within the stored precision (numeric(16,8))
+    this.RuleFor(x => x.RefundAmount)
+      .LessThanOrEqualTo(10_000_000)
+      .WithMessage("RefundAmount must be at most 10000000");
+    this.RuleFor(x => x.RefundCurrency)
+      .NotNull()
+      .Length(3, 8)
+      .WithMessage("RefundCurrency must be 3 to 8 characters");
+  }
+}
+
 public class KtmbCostMissingQueryValidator : AbstractValidator<KtmbCostMissingQuery>
 {
   public KtmbCostMissingQueryValidator()
+  {
+    this.RuleFor(x => x.Limit).Limit();
+    this.RuleFor(x => x.Skip).Skip();
+    // only the two worklists that exist: Completed (2, the default) for the
+    // completion backfill, Terminated (5) for terminated-then-refunded history
+    this.RuleFor(x => x.Status)
+      .Must(s => s is null or (int)BookStatus.Completed or (int)BookStatus.Terminated)
+      .WithMessage("Status must be 2 (Completed) or 5 (Terminated)");
+  }
+}
+
+public class KtmbRefundMissingQueryValidator : AbstractValidator<KtmbRefundMissingQuery>
+{
+  public KtmbRefundMissingQueryValidator()
   {
     this.RuleFor(x => x.Limit).Limit();
     this.RuleFor(x => x.Skip).Skip();

--- a/App/Modules/Bookings/Data/BookingData.cs
+++ b/App/Modules/Bookings/Data/BookingData.cs
@@ -110,6 +110,16 @@ public class BookingData
   [MaxLength(8)]
   public string? KtmbCurrency { get; set; }
 
+  // what KTMB ACTUALLY refunded for this booking when it was terminated,
+  // captured by tin's terminator or backfilled after the fact; both set
+  // together or both NULL (NULL = not recorded)
+  [Precision(16, 8)]
+  public decimal? KtmbRefundAmount { get; set; }
+
+  // ISO currency of KtmbRefundAmount (e.g. "MYR")
+  [MaxLength(8)]
+  public string? KtmbRefundCurrency { get; set; }
+
   public BookingPassengerData Passenger { get; set; } = null!;
 
   // FK

--- a/App/Modules/Bookings/Data/BookingMapper.cs
+++ b/App/Modules/Bookings/Data/BookingMapper.cs
@@ -44,6 +44,8 @@ public static class BookingMapper
       TicketNumber = data.TicketNo,
       KtmbAmount = data.KtmbAmount,
       KtmbCurrency = data.KtmbCurrency,
+      KtmbRefundAmount = data.KtmbRefundAmount,
+      KtmbRefundCurrency = data.KtmbRefundCurrency,
     };
 
   public static BookingPrincipal ToPrincipal(this BookingData data) =>
@@ -126,6 +128,8 @@ public static class BookingMapper
     data.TicketNo = complete.TicketNumber;
     data.KtmbAmount = complete.KtmbAmount;
     data.KtmbCurrency = complete.KtmbCurrency;
+    data.KtmbRefundAmount = complete.KtmbRefundAmount;
+    data.KtmbRefundCurrency = complete.KtmbRefundCurrency;
     return data;
   }
 

--- a/App/Modules/Bookings/Data/BookingRepository.cs
+++ b/App/Modules/Bookings/Data/BookingRepository.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Linq.Expressions;
 using App.Error.V1;
 using App.Modules.Timings.Data;
 using App.StartUp.Database;
@@ -617,6 +618,7 @@ public class BookingRepository(
   }
 
   public async Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(
+    BookStatus status,
     int limit,
     int skip
   )
@@ -624,42 +626,73 @@ public class BookingRepository(
     try
     {
       logger.LogInformation(
-        "Listing bookings missing actual KTMB cost with limit {Limit} skip {Skip}",
+        "Listing '{Status}' bookings missing actual KTMB cost with limit {Limit} skip {Skip}",
+        status,
         limit,
         skip
       );
-      // oldest fulfilment first so the backfill drains the historical tail;
-      // Id keeps Skip/Take pagination stable across equal CompletedAt values
-      var rows = await db
-        .Bookings.Where(KtmbBackfill.Missing)
-        .OrderBy(x => x.CompletedAt)
-        .ThenBy(x => x.Id)
-        .Skip(skip)
-        .Take(limit)
-        .Select(x => new
-        {
-          x.Id,
-          x.BookingNo,
-          x.TicketNo,
-          x.CompletedAt,
-        })
-        .ToArrayAsync();
-
-      return rows
-        .Select(x => new BookingKtmbCostMissing
-        {
-          Id = x.Id,
-          BookingNo = x.BookingNo!,
-          TicketNo = x.TicketNo!,
-          CompletedAt = x.CompletedAt!.Value,
-        })
-        .ToResult();
+      return await ListWorklist(KtmbBackfill.MissingFor(status), limit, skip);
     }
     catch (Exception e)
     {
       logger.LogError(e, "Failed to list bookings missing actual KTMB cost");
       return e;
     }
+  }
+
+  public async Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbRefund(
+    int limit,
+    int skip
+  )
+  {
+    try
+    {
+      logger.LogInformation(
+        "Listing terminated bookings missing KTMB refund with limit {Limit} skip {Skip}",
+        limit,
+        skip
+      );
+      return await ListWorklist(KtmbBackfill.RefundMissing, limit, skip);
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to list terminated bookings missing KTMB refund");
+      return e;
+    }
+  }
+
+  private async Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListWorklist(
+    Expression<Func<BookingData, bool>> predicate,
+    int limit,
+    int skip
+  )
+  {
+    // oldest fulfilment first so the backfill drains the historical tail;
+    // Id keeps Skip/Take pagination stable across equal CompletedAt values
+    var rows = await db
+      .Bookings.Where(predicate)
+      .OrderBy(x => x.CompletedAt)
+      .ThenBy(x => x.Id)
+      .Skip(skip)
+      .Take(limit)
+      .Select(x => new
+      {
+        x.Id,
+        x.BookingNo,
+        x.TicketNo,
+        x.CompletedAt,
+      })
+      .ToArrayAsync();
+
+    return rows
+      .Select(x => new BookingKtmbCostMissing
+      {
+        Id = x.Id,
+        BookingNo = x.BookingNo!,
+        TicketNo = x.TicketNo!,
+        CompletedAt = x.CompletedAt!.Value,
+      })
+      .ToResult();
   }
 
   public async Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id)

--- a/App/Modules/Bookings/Data/KtmbBackfill.cs
+++ b/App/Modules/Bookings/Data/KtmbBackfill.cs
@@ -3,17 +3,37 @@ using Domain.Booking;
 
 namespace App.Modules.Bookings.Data;
 
-// The tin backfill worklist predicate in one place (the BookingQueue
-// convention): Completed bookings that captured a KTMB reservation (both
-// identifiers present) but have no actual paid amount recorded yet.
-// ListMissingKtmbCost pages with it DB-side and the unit tests pin it
-// in-memory — they must always agree.
+// The tin backfill worklist predicates in one place (the BookingQueue
+// convention): bookings that captured a KTMB reservation (both identifiers
+// present) but have no actual paid amount (or no captured termination
+// refund) recorded yet. ListMissingKtmbCost/ListMissingKtmbRefund page with
+// them DB-side and the unit tests pin them in-memory — they must always
+// agree.
 public static class KtmbBackfill
 {
-  public static readonly Expression<Func<BookingData, bool>> Missing = x =>
-    x.Status == (byte)BookStatus.Completed
+  // the actual-cost worklist for one status: Completed for the original
+  // completion backfill, Terminated for terminated-then-refunded history
+  // (a termination still bought a ticket first, so its cost is a fact too)
+  public static Expression<Func<BookingData, bool>> MissingFor(BookStatus status) =>
+    x =>
+      x.Status == (byte)status
+      && x.CompletedAt != null
+      && x.BookingNo != null
+      && x.TicketNo != null
+      && x.KtmbAmount == null;
+
+  public static readonly Expression<Func<BookingData, bool>> Missing = MissingFor(
+    BookStatus.Completed
+  );
+
+  // the refund worklist: Terminated bookings whose actual KTMB cost is
+  // recorded (without it the refund is uninterpretable for P&L) but whose
+  // KTMB termination refund has not been captured yet
+  public static readonly Expression<Func<BookingData, bool>> RefundMissing = x =>
+    x.Status == (byte)BookStatus.Terminated
     && x.CompletedAt != null
     && x.BookingNo != null
     && x.TicketNo != null
-    && x.KtmbAmount == null;
+    && x.KtmbAmount != null
+    && x.KtmbRefundAmount == null;
 }

--- a/Domain/Booking/IService.cs
+++ b/Domain/Booking/IService.cs
@@ -72,12 +72,23 @@ public interface IBookingService
   // returned as-is, never overwritten; null when the booking does not exist
   Task<Result<BookingKtmbCost?>> RecordKtmbActualCost(Guid id, BookingKtmbCost cost);
 
-  // the tin backfill worklist: Completed bookings with KTMB identifiers but
-  // no actual cost yet, oldest CompletedAt first
+  // the tin backfill worklist: bookings of the given status (Completed or
+  // Terminated) with KTMB identifiers but no actual cost yet, oldest
+  // CompletedAt first
   Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbActualCost(
+    BookStatus status,
     int limit,
     int skip
   );
+
+  // record the actual KTMB termination refund of a booking (tin's terminator
+  // capture + the historical backfill). Upsert: a repeated capture overwrites
+  // the stored values; null when the booking does not exist
+  Task<Result<BookingKtmbRefund?>> RecordKtmbRefund(Guid id, BookingKtmbRefund refund);
+
+  // the tin refund-backfill worklist: Terminated bookings with a recorded
+  // actual KTMB cost but no captured KTMB refund yet, oldest CompletedAt first
+  Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbRefund(int limit, int skip);
 
   Task<Result<BookingPrincipal?>> CompleteNoCollect(Guid id,
     string bookingNo,

--- a/Domain/Booking/Model.cs
+++ b/Domain/Booking/Model.cs
@@ -140,10 +140,28 @@ public record BookingComplete
 
   // ISO currency of KtmbAmount ("MYR" or "SGD")
   public string? KtmbCurrency { get; init; }
+
+  // what KTMB ACTUALLY refunded BunnyBooker when the booking was terminated,
+  // captured by tin's terminator (or backfilled after the fact). Both set
+  // together or both null; null = not recorded. Unlike KtmbAmount this is an
+  // upsert — a repeated capture overwrites the stored values.
+  public decimal? KtmbRefundAmount { get; init; }
+
+  // ISO currency of KtmbRefundAmount (e.g. "MYR")
+  public string? KtmbRefundCurrency { get; init; }
 }
 
 // the actual KTMB-paid cost of one booking (see BookingComplete.KtmbAmount)
 public record BookingKtmbCost
+{
+  public required decimal Amount { get; init; }
+
+  public required string Currency { get; init; }
+}
+
+// the actual KTMB termination refund of one booking (see
+// BookingComplete.KtmbRefundAmount)
+public record BookingKtmbRefund
 {
   public required decimal Amount { get; init; }
 

--- a/Domain/Booking/Repository.cs
+++ b/Domain/Booking/Repository.cs
@@ -56,10 +56,20 @@ public interface IBookingRepository
     string? grantedBy
   );
 
-  // the tin backfill worklist: Completed bookings that captured a KTMB
+  // the tin backfill worklist: bookings of the given status (Completed, or
+  // Terminated for terminated-then-refunded history) that captured a KTMB
   // reservation (BookingNo + TicketNo present) but have no actual paid
   // amount recorded yet, oldest CompletedAt first (Id as the stable tiebreak)
-  Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(int limit, int skip);
+  Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(
+    BookStatus status,
+    int limit,
+    int skip
+  );
+
+  // the tin refund-backfill worklist: Terminated bookings with a recorded
+  // actual KTMB cost but no captured KTMB refund yet, oldest CompletedAt
+  // first (Id as the stable tiebreak)
+  Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbRefund(int limit, int skip);
 
   // bumps the recovery retry counter by one; null when the booking does not
   // exist. Runs inside the caller's RecoverRevert transaction so the counter

--- a/Domain/Booking/Service.cs
+++ b/Domain/Booking/Service.cs
@@ -617,11 +617,55 @@ public class BookingService(
   }
 
   public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbActualCost(
+    BookStatus status,
     int limit,
     int skip
   )
   {
-    return repo.ListMissingKtmbCost(limit, skip);
+    return repo.ListMissingKtmbCost(status, limit, skip);
+  }
+
+  // Capture what KTMB ACTUALLY refunded when the booking was terminated
+  // (tin's terminator sends the exact amount from KTMB's GetRefundPolicy; the
+  // backfill records it for historical terminations). Unlike the actual-cost
+  // capture this is an UPSERT — the refund is re-derivable from KTMB, so a
+  // repeated capture simply overwrites the stored values. No status guard:
+  // the wire contract pins 200 on success / 404 on unknown booking only, and
+  // the terminator may capture while the termination is still settling. The
+  // read and the write run in ONE transaction, mirroring the cost capture.
+  public Task<Result<BookingKtmbRefund?>> RecordKtmbRefund(Guid id, BookingKtmbRefund refund)
+  {
+    return transaction.Start(
+      () =>
+        repo.Get(null, id)
+          .ThenAwait(b =>
+          {
+            if (b == null)
+              return Task.FromResult((Result<BookingKtmbRefund?>)(BookingKtmbRefund?)null);
+
+            return repo.Update(
+                null,
+                id,
+                null,
+                null,
+                b.Principal.Complete with
+                {
+                  KtmbRefundAmount = refund.Amount,
+                  KtmbRefundCurrency = refund.Currency,
+                }
+              )
+              .NullToError(id.ToString())
+              .Then(BookingKtmbRefund? (_) => refund, Errors.MapNone);
+          })
+    );
+  }
+
+  public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbRefund(
+    int limit,
+    int skip
+  )
+  {
+    return repo.ListMissingKtmbRefund(limit, skip);
   }
 
   // AttachTicket repairs the ticket artefacts of an already-Completed booking

--- a/Domain/Booking/Service.cs
+++ b/Domain/Booking/Service.cs
@@ -1042,7 +1042,11 @@ public class BookingService(
         DoType.Ignore,
         b =>
           terminatorRepository.Terminate(
-            new BookingTermination(b.Principal.Complete.BookingNumber!, b.Principal.Complete.TicketNumber!)
+            new BookingTermination(
+              b.Principal.Complete.BookingNumber!,
+              b.Principal.Complete.TicketNumber!,
+              b.Principal.Id
+            )
           )
       )
       .DoAwait(DoType.Ignore, _ => cdcRepository.Add("reserve"))

--- a/Domain/Booking/TerminatorModel.cs
+++ b/Domain/Booking/TerminatorModel.cs
@@ -1,3 +1,7 @@
 namespace Domain.Booking;
 
-public record BookingTermination(string BookingNo, string TicketNo);
+// the Redis 'BookingTermination' queue payload tin's terminator consumes:
+// the KTMB identifiers to terminate, plus the zinc booking Id so the
+// terminator can capture the KTMB refund back through
+// POST Booking/{id}/ktmb-refund (additive — old tin builds ignore it)
+public record BookingTermination(string BookingNo, string TicketNo, Guid Id);

--- a/UnitTest/Bookings/BookingServiceAttachTicketTests.cs
+++ b/UnitTest/Bookings/BookingServiceAttachTicketTests.cs
@@ -249,8 +249,16 @@ public class BookingServiceAttachTicketTests
       return Task.FromResult((Result<BookingPrincipal?>)principal);
     }
 
-    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(int limit, int skip) =>
-      throw new NotImplementedException();
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(
+      BookStatus status,
+      int limit,
+      int skip
+    ) => throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbRefund(
+      int limit,
+      int skip
+    ) => throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>
       throw new NotImplementedException();

--- a/UnitTest/Bookings/BookingServiceBuyingGuardTests.cs
+++ b/UnitTest/Bookings/BookingServiceBuyingGuardTests.cs
@@ -220,8 +220,16 @@ public class BookingServiceBuyingGuardTests
     public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee, string? grantedBy = null) =>
       throw new NotImplementedException();
 
-    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(int limit, int skip) =>
-      throw new NotImplementedException();
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(
+      BookStatus status,
+      int limit,
+      int skip
+    ) => throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbRefund(
+      int limit,
+      int skip
+    ) => throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>
       throw new NotImplementedException();

--- a/UnitTest/Bookings/BookingServiceCompleteNoCollectTests.cs
+++ b/UnitTest/Bookings/BookingServiceCompleteNoCollectTests.cs
@@ -215,8 +215,16 @@ public class BookingServiceCompleteNoCollectTests
     public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee, string? grantedBy = null) =>
       throw new NotImplementedException();
 
-    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(int limit, int skip) =>
-      throw new NotImplementedException();
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(
+      BookStatus status,
+      int limit,
+      int skip
+    ) => throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbRefund(
+      int limit,
+      int skip
+    ) => throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>
       throw new NotImplementedException();

--- a/UnitTest/Bookings/BookingServiceKtmbActualCostTests.cs
+++ b/UnitTest/Bookings/BookingServiceKtmbActualCostTests.cs
@@ -16,7 +16,10 @@ namespace UnitTest.Bookings;
 // amount/currency tin sends alongside the ticket; RecordKtmbActualCost() is
 // the after-the-fact backfill — Completed-only, and IDEMPOTENT: once a cost
 // is recorded the stored values are returned as-is and never overwritten (a
-// retried backfill must not rewrite history). AttachTicket() repairs ticket
+// retried backfill must not rewrite history). RecordKtmbRefund() captures
+// the KTMB termination refund — an UPSERT (the refund is re-derivable from
+// KTMB, so a repeat capture overwrites) with no status guard (the pinned
+// wire contract knows only 200/404). AttachTicket() repairs ticket
 // artefacts without disturbing a recorded cost.
 public class BookingServiceKtmbActualCostTests
 {
@@ -130,7 +133,20 @@ public class BookingServiceKtmbActualCostTests
     KtmbCurrency = "MYR",
   };
 
+  private static readonly BookingComplete TerminatedWithRefund = new()
+  {
+    Ticket = "ticket-file",
+    BookingNumber = "BN-1",
+    TicketNumber = "TN-1",
+    KtmbAmount = 35.5m,
+    KtmbCurrency = "MYR",
+    KtmbRefundAmount = 20m,
+    KtmbRefundCurrency = "MYR",
+  };
+
   private static readonly BookingKtmbCost NewCost = new() { Amount = 40m, Currency = "SGD" };
+
+  private static readonly BookingKtmbRefund NewRefund = new() { Amount = 21.3m, Currency = "MYR" };
 
   // ---- Complete() capture ----
 
@@ -237,6 +253,103 @@ public class BookingServiceKtmbActualCostTests
     var (service, _) = Make(null!);
 
     var result = await service.RecordKtmbActualCost(Guid.NewGuid(), NewCost);
+
+    result.IsSuccess().Should().BeTrue();
+    result.SuccessOrDefault().Should().BeNull();
+  }
+
+  // ---- RecordKtmbRefund() capture ----
+
+  [Fact]
+  public async Task Refund_capture_on_a_terminated_booking_records_it()
+  {
+    var booking = BookingWith(BookStatus.Terminated, CompletedWithCost);
+    var (service, repo) = Make(booking);
+
+    var result = await service.RecordKtmbRefund(booking.Principal.Id, NewRefund);
+
+    result.IsSuccess().Should().BeTrue();
+    result.SuccessOrDefault()!.Amount.Should().Be(21.3m);
+    result.SuccessOrDefault()!.Currency.Should().Be("MYR");
+    repo.UpdateCalls.Should().Be(1);
+    repo.LastCompleteWritten!.KtmbRefundAmount.Should().Be(21.3m);
+    repo.LastCompleteWritten!.KtmbRefundCurrency.Should().Be("MYR");
+    // the ticket artefacts and the recorded cost must survive untouched
+    repo.LastCompleteWritten!.Ticket.Should().Be("ticket-file");
+    repo.LastCompleteWritten!.BookingNumber.Should().Be("BN-1");
+    repo.LastCompleteWritten!.TicketNumber.Should().Be("TN-1");
+    repo.LastCompleteWritten!.KtmbAmount.Should().Be(35.5m);
+    repo.LastCompleteWritten!.KtmbCurrency.Should().Be("MYR");
+  }
+
+  [Fact]
+  public async Task Refund_capture_is_an_upsert_and_overwrites_a_previous_capture()
+  {
+    var booking = BookingWith(BookStatus.Terminated, TerminatedWithRefund);
+    var (service, repo) = Make(booking);
+
+    var result = await service.RecordKtmbRefund(
+      booking.Principal.Id,
+      new BookingKtmbRefund { Amount = 18.75m, Currency = "SGD" }
+    );
+
+    // unlike the cost backfill, a repeated refund capture overwrites — the
+    // refund is re-derivable from KTMB, so the latest capture wins
+    result.IsSuccess().Should().BeTrue();
+    result.SuccessOrDefault()!.Amount.Should().Be(18.75m);
+    result.SuccessOrDefault()!.Currency.Should().Be("SGD");
+    repo.UpdateCalls.Should().Be(1);
+    repo.LastCompleteWritten!.KtmbRefundAmount.Should().Be(18.75m);
+    repo.LastCompleteWritten!.KtmbRefundCurrency.Should().Be("SGD");
+  }
+
+  [Fact]
+  public async Task Refund_capture_of_a_zero_refund_is_recorded()
+  {
+    var booking = BookingWith(BookStatus.Terminated, CompletedWithCost);
+    var (service, repo) = Make(booking);
+
+    var result = await service.RecordKtmbRefund(
+      booking.Principal.Id,
+      new BookingKtmbRefund { Amount = 0m, Currency = "MYR" }
+    );
+
+    // KTMB can refund nothing — zero is a fact worth recording (it takes the
+    // booking off the refund worklist)
+    result.IsSuccess().Should().BeTrue();
+    repo.LastCompleteWritten!.KtmbRefundAmount.Should().Be(0m);
+    repo.LastCompleteWritten!.KtmbRefundCurrency.Should().Be("MYR");
+  }
+
+  [Theory]
+  [InlineData(BookStatus.Pending)]
+  [InlineData(BookStatus.Buying)]
+  [InlineData(BookStatus.Completed)]
+  [InlineData(BookStatus.Recovering)]
+  [InlineData(BookStatus.Cancelled)]
+  [InlineData(BookStatus.Refunded)]
+  [InlineData(BookStatus.Duplicate)]
+  [InlineData(BookStatus.RequireManualIntervention)]
+  public async Task Refund_capture_has_no_status_guard(BookStatus status)
+  {
+    // the pinned wire contract knows only 200 (success) and 404 (unknown
+    // booking) — tin's terminator may capture while the termination is still
+    // settling, so any existing booking accepts the upsert
+    var booking = BookingWith(status, CompletedWithCost);
+    var (service, repo) = Make(booking);
+
+    var result = await service.RecordKtmbRefund(booking.Principal.Id, NewRefund);
+
+    result.IsSuccess().Should().BeTrue();
+    repo.UpdateCalls.Should().Be(1);
+  }
+
+  [Fact]
+  public async Task Refund_capture_on_a_missing_booking_returns_null()
+  {
+    var (service, _) = Make(null!);
+
+    var result = await service.RecordKtmbRefund(Guid.NewGuid(), NewRefund);
 
     result.IsSuccess().Should().BeTrue();
     result.SuccessOrDefault().Should().BeNull();
@@ -349,6 +462,12 @@ public class BookingServiceKtmbActualCostTests
     }
 
     public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(
+      BookStatus status,
+      int limit,
+      int skip
+    ) => throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbRefund(
       int limit,
       int skip
     ) => throw new NotImplementedException();

--- a/UnitTest/Bookings/BookingServicePrioritizeTests.cs
+++ b/UnitTest/Bookings/BookingServicePrioritizeTests.cs
@@ -955,8 +955,16 @@ public class BookingServicePrioritizeTests
       return Task.FromResult((Result<BookingPrincipal?>)Current()!.Principal);
     }
 
-    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(int limit, int skip) =>
-      throw new NotImplementedException();
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(
+      BookStatus status,
+      int limit,
+      int skip
+    ) => throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbRefund(
+      int limit,
+      int skip
+    ) => throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>
       throw new NotImplementedException();

--- a/UnitTest/Bookings/BookingServiceRecoverRevertTests.cs
+++ b/UnitTest/Bookings/BookingServiceRecoverRevertTests.cs
@@ -244,8 +244,16 @@ public class BookingServiceRecoverRevertTests
     public Task<Result<Booking?>> Get(string? userId, Guid id) =>
       Task.FromResult((Result<Booking?>)Current());
 
-    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(int limit, int skip) =>
-      throw new NotImplementedException();
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(
+      BookStatus status,
+      int limit,
+      int skip
+    ) => throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbRefund(
+      int limit,
+      int skip
+    ) => throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id)
     {

--- a/UnitTest/Bookings/BookingServiceRevertGuardTests.cs
+++ b/UnitTest/Bookings/BookingServiceRevertGuardTests.cs
@@ -353,8 +353,16 @@ public class BookingServiceRevertGuardTests
     public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee, string? grantedBy = null) =>
       throw new NotImplementedException();
 
-    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(int limit, int skip) =>
-      throw new NotImplementedException();
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(
+      BookStatus status,
+      int limit,
+      int skip
+    ) => throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbRefund(
+      int limit,
+      int skip
+    ) => throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>
       throw new NotImplementedException();

--- a/UnitTest/Bookings/BookingServiceTerminateTests.cs
+++ b/UnitTest/Bookings/BookingServiceTerminateTests.cs
@@ -27,7 +27,13 @@ public class BookingServiceTerminateTests
     BookingService Service,
     FakeWalletRepository Wallet,
     FakeTransactionRepository Txn
-  ) Make(Booking booking, decimal? percentage = null, decimal? flat = null, decimal? cap = null)
+  ) Make(
+    Booking booking,
+    decimal? percentage = null,
+    decimal? flat = null,
+    decimal? cap = null,
+    FakeTerminator? terminator = null
+  )
   {
     var wallet = new FakeWalletRepository();
     var txn = new FakeTransactionRepository();
@@ -39,7 +45,7 @@ public class BookingServiceTerminateTests
       new PassThroughTransactionManager(),
       new TransactionGenerator(),
       new FeeCalculator(new FixedTerminationFeeRepository(percentage, flat, cap)),
-      new FakeTerminator(),
+      terminator ?? new FakeTerminator(),
       new FakeCdc(),
       new FakeNotifier(),
       null!,
@@ -182,6 +188,24 @@ public class BookingServiceTerminateTests
   }
 
   [Fact]
+  public async Task Terminate_enqueues_the_booking_id_with_the_ktmb_identifiers()
+  {
+    var b = CompletedBooking();
+    var terminator = new FakeTerminator();
+    var (service, _, _) = Make(b, terminator: terminator);
+
+    var result = await service.Terminate("user-1", b.Principal.Id, BeforeDeparture);
+
+    result.IsSuccess().Should().BeTrue();
+    // tin's terminator needs the zinc booking Id to capture the KTMB refund
+    // back through POST Booking/{id}/ktmb-refund after refunding
+    terminator.LastTermination.Should().NotBeNull();
+    terminator.LastTermination!.BookingNo.Should().Be("BN-1");
+    terminator.LastTermination!.TicketNo.Should().Be("TN-1");
+    terminator.LastTermination!.Id.Should().Be(b.Principal.Id);
+  }
+
+  [Fact]
   public async Task Refund_plus_fee_always_equals_the_reserved_amount()
   {
     var b = CompletedBooking();
@@ -245,8 +269,13 @@ public class BookingServiceTerminateTests
 
   private sealed class FakeTerminator : IBookingTerminatorRepository
   {
-    public Task<Result<Unit>> Terminate(BookingTermination termination) =>
-      Task.FromResult((Result<Unit>)new Unit());
+    public BookingTermination? LastTermination { get; private set; }
+
+    public Task<Result<Unit>> Terminate(BookingTermination termination)
+    {
+      LastTermination = termination;
+      return Task.FromResult((Result<Unit>)new Unit());
+    }
   }
 
   private sealed class FakeNotifier : IBookingNotificationService

--- a/UnitTest/Bookings/BookingServiceTerminateTests.cs
+++ b/UnitTest/Bookings/BookingServiceTerminateTests.cs
@@ -308,8 +308,16 @@ public class BookingServiceTerminateTests
     public Task<Result<BookingPrincipal?>> Prioritize(string? userId, Guid id, decimal? fee, string? grantedBy = null) =>
       throw new NotImplementedException();
 
-    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(int limit, int skip) =>
-      throw new NotImplementedException();
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(
+      BookStatus status,
+      int limit,
+      int skip
+    ) => throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbRefund(
+      int limit,
+      int skip
+    ) => throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>
       throw new NotImplementedException();

--- a/UnitTest/Bookings/BookingServiceTicketHealthTests.cs
+++ b/UnitTest/Bookings/BookingServiceTicketHealthTests.cs
@@ -177,8 +177,16 @@ public class BookingServiceTicketHealthTests
       BookingComplete? complete
     ) => throw new NotImplementedException();
 
-    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(int limit, int skip) =>
-      throw new NotImplementedException();
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(
+      BookStatus status,
+      int limit,
+      int skip
+    ) => throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbRefund(
+      int limit,
+      int skip
+    ) => throw new NotImplementedException();
 
     public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>
       throw new NotImplementedException();

--- a/UnitTest/Bookings/KtmbBackfillWorklistTests.cs
+++ b/UnitTest/Bookings/KtmbBackfillWorklistTests.cs
@@ -4,20 +4,29 @@ using FluentAssertions;
 
 namespace UnitTest.Bookings;
 
-// The tin backfill worklist predicate (KtmbBackfill.Missing): Completed
-// bookings that captured a KTMB reservation (BookingNo + TicketNo present)
-// but have no actual paid amount recorded yet. ListMissingKtmbCost pages
-// with it DB-side — these tests pin the filter in-memory.
+// The tin backfill worklist predicates (KtmbBackfill): bookings that
+// captured a KTMB reservation (BookingNo + TicketNo present) but have no
+// actual paid amount (Missing/MissingFor) or no captured termination refund
+// (RefundMissing) recorded yet. ListMissingKtmbCost/ListMissingKtmbRefund
+// page with them DB-side — these tests pin the filters in-memory.
 public class KtmbBackfillWorklistTests
 {
   private static readonly Func<BookingData, bool> Missing = KtmbBackfill.Missing.Compile();
+
+  private static readonly Func<BookingData, bool> MissingTerminated = KtmbBackfill
+    .MissingFor(BookStatus.Terminated)
+    .Compile();
+
+  private static readonly Func<BookingData, bool> RefundMissing =
+    KtmbBackfill.RefundMissing.Compile();
 
   private static BookingData Booking(
     BookStatus status = BookStatus.Completed,
     string? bookingNo = "BN-1",
     string? ticketNo = "TN-1",
     decimal? ktmbAmount = null,
-    DateTime? completedAt = null
+    DateTime? completedAt = null,
+    decimal? ktmbRefundAmount = null
   ) =>
     new()
     {
@@ -28,6 +37,8 @@ public class KtmbBackfillWorklistTests
       TicketNo = ticketNo,
       KtmbAmount = ktmbAmount,
       KtmbCurrency = ktmbAmount == null ? null : "MYR",
+      KtmbRefundAmount = ktmbRefundAmount,
+      KtmbRefundCurrency = ktmbRefundAmount == null ? null : "MYR",
     };
 
   [Fact]
@@ -75,5 +86,84 @@ public class KtmbBackfillWorklistTests
     var b = Booking();
     b.CompletedAt = null;
     Missing(b).Should().BeFalse();
+  }
+
+  // ---- MissingFor(Terminated): the terminated-history cost worklist ----
+
+  [Fact]
+  public void A_terminated_booking_with_identifiers_and_no_actual_cost_is_on_the_terminated_worklist()
+  {
+    MissingTerminated(Booking(BookStatus.Terminated)).Should().BeTrue();
+  }
+
+  [Fact]
+  public void A_completed_booking_is_off_the_terminated_worklist()
+  {
+    // the status-parameterized worklists never overlap — each status pages
+    // its own backfill
+    MissingTerminated(Booking()).Should().BeFalse();
+  }
+
+  [Fact]
+  public void A_terminated_booking_with_a_recorded_actual_cost_is_off_the_terminated_worklist()
+  {
+    MissingTerminated(Booking(BookStatus.Terminated, ktmbAmount: 35.5m)).Should().BeFalse();
+  }
+
+  // ---- RefundMissing: the termination-refund worklist ----
+
+  [Fact]
+  public void A_terminated_booking_with_a_cost_but_no_refund_is_on_the_refund_worklist()
+  {
+    RefundMissing(Booking(BookStatus.Terminated, ktmbAmount: 35.5m)).Should().BeTrue();
+  }
+
+  [Fact]
+  public void A_terminated_booking_with_a_captured_refund_is_off_the_refund_worklist()
+  {
+    RefundMissing(Booking(BookStatus.Terminated, ktmbAmount: 35.5m, ktmbRefundAmount: 20m))
+      .Should()
+      .BeFalse();
+  }
+
+  [Fact]
+  public void A_terminated_booking_without_a_recorded_cost_is_off_the_refund_worklist()
+  {
+    // without the actual cost the refund is uninterpretable for P&L — the
+    // cost backfill (ktmb-cost/missing?status=5) must run first
+    RefundMissing(Booking(BookStatus.Terminated)).Should().BeFalse();
+  }
+
+  [Theory]
+  [InlineData(BookStatus.Pending)]
+  [InlineData(BookStatus.Buying)]
+  [InlineData(BookStatus.Completed)]
+  [InlineData(BookStatus.Recovering)]
+  [InlineData(BookStatus.Cancelled)]
+  [InlineData(BookStatus.Refunded)]
+  [InlineData(BookStatus.Duplicate)]
+  [InlineData(BookStatus.RequireManualIntervention)]
+  public void A_non_terminated_booking_is_off_the_refund_worklist(BookStatus status)
+  {
+    RefundMissing(Booking(status, ktmbAmount: 35.5m)).Should().BeFalse();
+  }
+
+  [Fact]
+  public void A_terminated_booking_without_identifiers_is_off_the_refund_worklist()
+  {
+    RefundMissing(Booking(BookStatus.Terminated, bookingNo: null, ktmbAmount: 35.5m))
+      .Should()
+      .BeFalse();
+    RefundMissing(Booking(BookStatus.Terminated, ticketNo: null, ktmbAmount: 35.5m))
+      .Should()
+      .BeFalse();
+  }
+
+  [Fact]
+  public void A_terminated_booking_without_a_completion_instant_is_off_the_refund_worklist()
+  {
+    var b = Booking(BookStatus.Terminated, ktmbAmount: 35.5m);
+    b.CompletedAt = null;
+    RefundMissing(b).Should().BeFalse();
   }
 }

--- a/UnitTest/Bookings/KtmbRefundValidatorTests.cs
+++ b/UnitTest/Bookings/KtmbRefundValidatorTests.cs
@@ -1,0 +1,122 @@
+using App.Modules.Bookings.API.V1;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// The request validation around the KTMB termination-refund capture: the
+// PINNED refund body (refundAmount >= 0, refundCurrency 3-8 chars), the
+// Status selector the cost worklist gained (2 = Completed, 5 = Terminated),
+// and the refund worklist paging.
+public class KtmbRefundValidatorTests
+{
+  // ---- the refund capture body ----
+
+  private readonly SetBookingKtmbRefundReqValidator refundValidator = new();
+
+  [Theory]
+  [InlineData(0, "MYR")]
+  [InlineData(21.3, "MYR")]
+  [InlineData(21.3, "SGD")]
+  [InlineData(10_000_000, "POINTS")]
+  public void Refund_with_non_negative_amount_and_sane_currency_is_valid(
+    decimal amount,
+    string currency
+  )
+  {
+    // zero included — KTMB can refund nothing, and recording that fact takes
+    // the booking off the refund worklist
+    refundValidator
+      .Validate(new SetBookingKtmbRefundReq(amount, currency))
+      .IsValid.Should()
+      .BeTrue();
+  }
+
+  [Fact]
+  public void Refund_with_negative_amount_is_rejected()
+  {
+    refundValidator
+      .Validate(new SetBookingKtmbRefundReq(-0.01m, "MYR"))
+      .IsValid.Should()
+      .BeFalse();
+  }
+
+  [Fact]
+  public void Refund_beyond_the_stored_precision_is_rejected()
+  {
+    refundValidator
+      .Validate(new SetBookingKtmbRefundReq(10_000_001m, "MYR"))
+      .IsValid.Should()
+      .BeFalse();
+  }
+
+  [Theory]
+  [InlineData(null)]
+  [InlineData("")]
+  [InlineData("MY")]
+  [InlineData("TOOLONGCUR")]
+  public void Refund_with_a_currency_outside_3_to_8_chars_is_rejected(string? currency)
+  {
+    refundValidator
+      .Validate(new SetBookingKtmbRefundReq(21.3m, currency!))
+      .IsValid.Should()
+      .BeFalse();
+  }
+
+  // ---- the cost worklist Status selector ----
+
+  private readonly KtmbCostMissingQueryValidator costMissingValidator = new();
+
+  [Theory]
+  [InlineData(null)]
+  [InlineData(2)]
+  [InlineData(5)]
+  public void Cost_worklist_status_omitted_completed_or_terminated_is_valid(int? status)
+  {
+    costMissingValidator
+      .Validate(new KtmbCostMissingQuery(100, 0, status))
+      .IsValid.Should()
+      .BeTrue();
+  }
+
+  [Theory]
+  [InlineData(0)]
+  [InlineData(1)]
+  [InlineData(3)]
+  [InlineData(4)]
+  [InlineData(6)]
+  [InlineData(7)]
+  public void Cost_worklist_status_of_any_other_book_status_is_rejected(int status)
+  {
+    // only the two worklists that exist: the completion backfill (2) and the
+    // terminated-then-refunded history (5)
+    costMissingValidator
+      .Validate(new KtmbCostMissingQuery(100, 0, status))
+      .IsValid.Should()
+      .BeFalse();
+  }
+
+  // ---- the refund worklist paging ----
+
+  private readonly KtmbRefundMissingQueryValidator refundMissingValidator = new();
+
+  [Fact]
+  public void Refund_worklist_with_omitted_paging_is_valid()
+  {
+    refundMissingValidator
+      .Validate(new KtmbRefundMissingQuery(null, null))
+      .IsValid.Should()
+      .BeTrue();
+  }
+
+  [Theory]
+  [InlineData(-1, 0)]
+  [InlineData(101, 0)]
+  [InlineData(100, -1)]
+  public void Refund_worklist_with_out_of_bounds_paging_is_rejected(int limit, int skip)
+  {
+    refundMissingValidator
+      .Validate(new KtmbRefundMissingQuery(limit, skip))
+      .IsValid.Should()
+      .BeFalse();
+  }
+}

--- a/UnitTest/Bookings/KtmbWireContractTests.cs
+++ b/UnitTest/Bookings/KtmbWireContractTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using App.Modules.Bookings.API.V1;
+using Domain.Booking;
 using FluentAssertions;
 
 namespace UnitTest.Bookings;
@@ -99,6 +100,22 @@ public class KtmbWireContractTests
     json.Should().Be(
       "{\"id\":\"11111111-2222-3333-4444-555555555555\","
         + "\"refundAmount\":21.3,\"refundCurrency\":\"MYR\"}"
+    );
+  }
+
+  [Fact]
+  public void Termination_queue_payload_serializes_with_the_booking_id()
+  {
+    // the Redis 'BookingTermination' queue payload tin's terminator consumes
+    // (OtelRedis serializes camelCase, like the HTTP wire) — the added id is
+    // what lets the terminator call POST Booking/{id}/ktmb-refund
+    var id = Guid.Parse("11111111-2222-3333-4444-555555555555");
+
+    var json = JsonSerializer.Serialize(new BookingTermination("BN-1", "TN-1", id), Web);
+
+    json.Should().Be(
+      "{\"bookingNo\":\"BN-1\",\"ticketNo\":\"TN-1\","
+        + "\"id\":\"11111111-2222-3333-4444-555555555555\"}"
     );
   }
 }

--- a/UnitTest/Bookings/KtmbWireContractTests.cs
+++ b/UnitTest/Bookings/KtmbWireContractTests.cs
@@ -76,4 +76,29 @@ public class KtmbWireContractTests
     req!.Rate.Should().Be(0.32m);
     req.EffectiveAt.Should().BeNull();
   }
+
+  [Fact]
+  public void Refund_body_binds_refundAmount_and_refundCurrency()
+  {
+    var req = JsonSerializer.Deserialize<SetBookingKtmbRefundReq>(
+      "{\"refundAmount\": 21.3, \"refundCurrency\": \"MYR\"}",
+      Web
+    );
+
+    req!.RefundAmount.Should().Be(21.3m);
+    req.RefundCurrency.Should().Be("MYR");
+  }
+
+  [Fact]
+  public void Refund_res_serializes_as_id_refundAmount_refundCurrency()
+  {
+    var id = Guid.Parse("11111111-2222-3333-4444-555555555555");
+
+    var json = JsonSerializer.Serialize(new BookingKtmbRefundRes(id, 21.3m, "MYR"), Web);
+
+    json.Should().Be(
+      "{\"id\":\"11111111-2222-3333-4444-555555555555\","
+        + "\"refundAmount\":21.3,\"refundCurrency\":\"MYR\"}"
+    );
+  }
 }


### PR DESCRIPTION
## Summary

Terminated bookings (\`BookStatus.Terminated = 5\`) get a partial refund from KTMB; tin's terminator receives the exact refund amount from KTMB's \`GetRefundPolicy\` but discards it today. This PR adds capture + backfill support on zinc's side, against the wire contract pinned with the parallel tin PR (nitroso.tin#46).

### New endpoints

- **\`POST /api/v{version}/Booking/{id}/ktmb-refund\`** (AdminOrTin) — body \`{ "refundAmount": decimal >= 0, "refundCurrency": string (3-8 chars) }\`. 200 on success, 404 on unknown booking. **Upsert**: a repeat call overwrites (unlike \`{id}/ktmb-cost\`, which is write-once — the refund is re-derivable from KTMB). No status guard: the pinned contract knows only 200/404, and the terminator may capture while the termination is still settling.
- **\`GET /api/v{version}/Booking/ktmb-refund/missing?limit=n\`** (AdminOrTin) — Terminated bookings that HAVE \`KtmbAmount\` but lack \`KtmbRefundAmount\`, same row shape as \`ktmb-cost/missing\` (\`id\`, \`bookingNo\`, \`ticketNo\`, \`completedAt\`), for the historical refund backfill. Also supports \`skip\` like its sibling.

### Changed endpoint

- **\`GET /api/v{version}/Booking/ktmb-cost/missing\`** gains an optional \`Status\` query param (default \`2\` = Completed; also \`5\` = Terminated; anything else rejected) so the actual-cost backfill can also drain terminated history.

### Termination queue payload

- The Redis \`BookingTermination\` queue payload zinc produces for tin's terminator now carries the zinc booking \`id\` alongside \`bookingNo\`/\`ticketNo\` (additive, camelCase like the rest of the payload) so the terminator can call \`POST Booking/{id}/ktmb-refund\` after refunding. Old tin builds ignore the extra field.

### Storage

- Migration **\`20260715000412_AddKtmbRefundCapture\`**: nullable \`Bookings.KtmbRefundAmount numeric(16,8)\` + \`Bookings.KtmbRefundCurrency varchar(8)\`, mirroring the \`AddKtmbActualCostAndFxRates\` style.

### Tests

- Worklist predicates pinned in-memory (\`MissingFor(Terminated)\`, \`RefundMissing\`): identifiers present, cost recorded, refund absent, Terminated-only.
- Service: refund capture records, overwrites on repeat, records zero refunds, succeeds for any existing booking (no status guard), null for missing bookings; existing cost/ticket fields survive untouched.
- Validators: refund body bounds (>= 0, precision cap, 3-8 char currency), \`Status\` restricted to 2/5, refund worklist paging.
- Wire contract: refund req/res JSON shapes and the \`BookingTermination\` payload (with \`id\`) pinned exactly.

Analysis endpoints untouched.