### PR TITLE
fix: allow recording KTMB actual cost on terminated bookings

### DIFF
--- a/Domain/Booking/Service.cs
+++ b/Domain/Booking/Service.cs
@@ -591,12 +591,13 @@ public class BookingService(
               );
 
             // an actual paid amount only exists once the ticket was bought —
-            // the worklist pages Completed bookings, so anything else is a
-            // caller error, not a backfill
-            if (b.Principal.Status.Status != BookStatus.Completed)
+            // the worklist pages Completed and Terminated bookings (a
+            // terminated booking WAS bought before KTMB refunded it), so
+            // anything else is a caller error, not a backfill
+            if (b.Principal.Status.Status is not (BookStatus.Completed or BookStatus.Terminated))
             {
               var r = new InvalidBookingOperationException(
-                "Recording the actual KTMB cost requires a booking in 'Completed' Status",
+                "Recording the actual KTMB cost requires a booking in 'Completed' or 'Terminated' Status",
                 b.Principal.Status.Status,
                 BookingOperations.RecordKtmbCost
               );

--- a/UnitTest/Bookings/BookingServiceKtmbActualCostTests.cs
+++ b/UnitTest/Bookings/BookingServiceKtmbActualCostTests.cs
@@ -232,10 +232,9 @@ public class BookingServiceKtmbActualCostTests
   [InlineData(BookStatus.Recovering)]
   [InlineData(BookStatus.Cancelled)]
   [InlineData(BookStatus.Refunded)]
-  [InlineData(BookStatus.Terminated)]
   [InlineData(BookStatus.Duplicate)]
   [InlineData(BookStatus.RequireManualIntervention)]
-  public async Task Backfill_on_a_non_completed_booking_is_rejected(BookStatus status)
+  public async Task Backfill_on_a_never_bought_booking_is_rejected(BookStatus status)
   {
     var booking = BookingWith(status, Uncaptured);
     var (service, repo) = Make(booking);
@@ -245,6 +244,24 @@ public class BookingServiceKtmbActualCostTests
     result.IsSuccess().Should().BeFalse($"a '{status}' booking has no actual KTMB purchase to cost");
     result.FailureOrDefault().Should().BeOfType<InvalidBookingOperationException>();
     repo.UpdateCalls.Should().Be(0);
+  }
+
+  [Fact]
+  public async Task Backfill_on_a_terminated_booking_records_it()
+  {
+    // a terminated booking WAS bought (then refunded by KTMB) — its purchase
+    // cost is backfillable exactly like a completed one
+    var booking = BookingWith(BookStatus.Terminated, CompletedWithoutCost);
+    var (service, repo) = Make(booking);
+
+    var result = await service.RecordKtmbActualCost(booking.Principal.Id, NewCost);
+
+    result.IsSuccess().Should().BeTrue();
+    result.SuccessOrDefault()!.Amount.Should().Be(40m);
+    result.SuccessOrDefault()!.Currency.Should().Be("SGD");
+    repo.UpdateCalls.Should().Be(1);
+    repo.LastCompleteWritten!.KtmbAmount.Should().Be(40m);
+    repo.LastCompleteWritten!.KtmbCurrency.Should().Be("SGD");
   }
 
   [Fact]


### PR DESCRIPTION
The terminated-booking cost backfill (tin ktmb-cost-backfill --status terminated) failed for all 655 bookings: the ktmb-cost/missing worklist accepts Status=5 (Terminated) since #51, but POST Booking/{id}/ktmb-cost still guarded Status == Completed. A terminated booking WAS bought (then refunded), so its purchase cost is recordable — the guard now accepts Completed or Terminated. Adds a terminated-backfill test; the never-bought statuses stay rejected.

https://claude.ai/code/session_018kJbfRkYZXikAELSDPj7pX