### PR TITLE
feat: terminal-event P&L engine

### DIFF
--- a/App/Modules/Bookings/API/V1/BookingController.cs
+++ b/App/Modules/Bookings/API/V1/BookingController.cs
@@ -186,6 +186,28 @@ public class BookingController(
     return this.ReturnResult(x);
   }
 
+  // Terminal-event P&L for the admin P&L page: profit is recognized when
+  // money reaches a terminal state — a completed booking, a terminated
+  // booking or a completed withdrawal. Each month reports its deposits and
+  // payment gateway fees so every deposited dollar carries its gateway-fee
+  // share to its terminal event via the month's blended rate (gwRate,
+  // server-computed at 6dp); the client owns all profit formulas. Sources
+  // bucket on their SGT calendar month (payment CreatedAt,
+  // booking/withdrawal CompletedAt, gateway-fee TransactedAt); empty months
+  // are omitted, rows sort month-ascending.
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("pnl/terminal")]
+  public async Task<ActionResult<IEnumerable<BookingPnlTerminalRowRes>>> PnlTerminal(
+    [FromQuery] BookingPnlTerminalQueryReq query,
+    [FromServices] BookingPnlTerminalQueryReqValidator pnlTerminalValidator
+  )
+  {
+    var x = await pnlTerminalValidator
+      .ValidateAsyncResult(query, "Invalid BookingPnlTerminalQueryReq")
+      .ThenAwait(q => analysisRepo.PnlTerminal(q.ToDomain()))
+      .Then(rows => rows.Select(r => r.ToRes()), Errors.MapAll);
+    return this.ReturnResult(x);
+  }
+
   // The boost ledger: who prioritized which booking, when, for what fee (or
   // free). BoostedAt falls back to the booking's CreatedAt for boosts that
   // predate the PrioritizedAt stamp; GrantedBy identifies admin-granted

--- a/App/Modules/Bookings/API/V1/BookingMapper.cs
+++ b/App/Modules/Bookings/API/V1/BookingMapper.cs
@@ -198,6 +198,35 @@ public static class BookingMapper
       r.KtmbCost
     );
 
+  // terminal-event P&L view
+  public static PnlTerminalQuery ToDomain(this BookingPnlTerminalQueryReq req) =>
+    new() { After = req.After?.ToDate(), Before = req.Before?.ToDate() };
+
+  public static BookingPnlTerminalRowRes ToRes(this PnlTerminalRow r) =>
+    new(
+      r.Month,
+      r.Deposits,
+      r.PaymentFees,
+      r.GwRate,
+      new BookingPnlTerminalCompletedRes(
+        r.Completed.Count,
+        r.Completed.Collected,
+        r.Completed.KtmbCost
+      ),
+      new BookingPnlTerminalTerminatedRes(
+        r.Terminated.Count,
+        r.Terminated.Kept,
+        r.Terminated.KtmbCostNet,
+        r.Terminated.WithExactRefund
+      ),
+      new BookingPnlTerminalWithdrawalsRes(
+        r.Withdrawals.Count,
+        r.Withdrawals.Gross,
+        r.Withdrawals.FeeIncome,
+        r.Withdrawals.PayoutFees
+      )
+    );
+
   // boost ledger
   public static BookingBoostQuery ToDomain(this BookingBoostQueryReq req) =>
     new()

--- a/App/Modules/Bookings/API/V1/BookingModel.cs
+++ b/App/Modules/Bookings/API/V1/BookingModel.cs
@@ -42,6 +42,10 @@ public record BookingProfitAnalysisQueryReq(string? After, string? Before);
 // unbounded)
 public record BookingPnlAnalysisQueryReq(string? After, string? Before);
 
+// terminal-event P&L range (dd-MM-yyyy, inclusive SGT source-event dates;
+// null = unbounded)
+public record BookingPnlTerminalQueryReq(string? After, string? Before);
+
 // the boost ledger page (dd-MM-yyyy inclusive SGT dates; Limit default 50
 // max 200, Skip offset)
 public record BookingBoostQueryReq(string? After, string? Before, int? Limit, int? Skip);
@@ -239,6 +243,40 @@ public record BookingPnlAnalysisRowRes(
   decimal GatewayFees,
   decimal TicketRevenue,
   decimal KtmbCost
+);
+
+// Terminal-event P&L wire contract (PINNED — argon builds its P&L view
+// against these exact names/shapes). The client computes all profits:
+// completedProfit  = collected − ktmbCost − gwRate×collected
+// terminatedProfit = kept − ktmbCostNet − gwRate×kept
+// withdrawalProfit = feeIncome − gwRate×gross − payoutFees
+public record BookingPnlTerminalCompletedRes(int Count, decimal Collected, decimal KtmbCost);
+
+// Kept is straight from the ledger (collected − refunded-to-wallet);
+// WithExactRefund < Count means KtmbCostNet is partly estimated
+public record BookingPnlTerminalTerminatedRes(
+  int Count,
+  decimal Kept,
+  decimal KtmbCostNet,
+  int WithExactRefund
+);
+
+// Gross is the gross wallet debit (the user receives Gross - FeeIncome)
+public record BookingPnlTerminalWithdrawalsRes(
+  int Count,
+  decimal Gross,
+  decimal FeeIncome,
+  decimal PayoutFees
+);
+
+public record BookingPnlTerminalRowRes(
+  string Month,
+  decimal Deposits,
+  decimal PaymentFees,
+  decimal GwRate,
+  BookingPnlTerminalCompletedRes Completed,
+  BookingPnlTerminalTerminatedRes Terminated,
+  BookingPnlTerminalWithdrawalsRes Withdrawals
 );
 
 public record DepositSummaryRes(int Count, decimal Captured);

--- a/App/Modules/Bookings/API/V1/BookingValidator.cs
+++ b/App/Modules/Bookings/API/V1/BookingValidator.cs
@@ -130,6 +130,15 @@ public class BookingPnlAnalysisQueryReqValidator : AbstractValidator<BookingPnlA
   }
 }
 
+public class BookingPnlTerminalQueryReqValidator : AbstractValidator<BookingPnlTerminalQueryReq>
+{
+  public BookingPnlTerminalQueryReqValidator()
+  {
+    this.RuleFor(x => x.After).NullableDateValid();
+    this.RuleFor(x => x.Before).NullableDateValid();
+  }
+}
+
 public class BookingBoostQueryReqValidator : AbstractValidator<BookingBoostQueryReq>
 {
   public BookingBoostQueryReqValidator()

--- a/App/Modules/Bookings/Data/BookingAnalysisRepository.cs
+++ b/App/Modules/Bookings/Data/BookingAnalysisRepository.cs
@@ -104,6 +104,45 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
     public decimal KtmbCost { get; set; }
   }
 
+  // One daily subtotal from one terminal-P&L source. UNION ALL emits sparse
+  // rows and the pure calculator merges them into the pinned monthly response.
+  private sealed class PnlTerminalDayDto
+  {
+    public DateOnly Date { get; set; }
+
+    public decimal Deposits { get; set; }
+
+    public decimal PaymentFees { get; set; }
+
+    public decimal PayoutFees { get; set; }
+
+    public int CompletedCount { get; set; }
+
+    public decimal CompletedCollected { get; set; }
+
+    public decimal CompletedKtmbCost { get; set; }
+
+    public int TerminatedCount { get; set; }
+
+    public decimal TerminatedCollected { get; set; }
+
+    public decimal TerminationRefunds { get; set; }
+
+    public decimal TerminatedKtmbGrossExact { get; set; }
+
+    public decimal TerminatedKtmbRefund { get; set; }
+
+    public decimal TerminatedKtmbGrossEstimated { get; set; }
+
+    public int TerminatedWithExactRefund { get; set; }
+
+    public int WithdrawalCount { get; set; }
+
+    public decimal WithdrawalGross { get; set; }
+
+    public decimal WithdrawalFeeIncome { get; set; }
+  }
+
   // month-bucketed gateway fee sums (payments vs payouts)
   private sealed class GatewayMonthDto
   {
@@ -671,6 +710,312 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
     catch (Exception e)
     {
       logger.LogError(e, "Failed to compute P&L analysis with {@Query}", query.ToJson());
+      return e;
+    }
+  }
+
+  // Terminal-event P&L source scan. All timestamp sources use the same
+  // explicit SGT wall-clock arithmetic as Analyze's gateway-fee rollup. Each
+  // UNION arm is grouped by SGT date DB-side; the pure calculator applies the
+  // inclusive date contract again, merges sources into months (computing the
+  // blended gateway rate and the KTMB refund fallback) and omits empty months.
+  //
+  // COLLECTED (completed and terminated bookings) = the request-transaction
+  // amount (surcharges/discounts are baked into it — the persisted price
+  // breakdown never moves through separate ledger rows) + the priority-boost
+  // fee when charged: both Complete and Terminate keep the fee (the queue
+  // jump was consumed), only Refund/Cancel return it (see
+  // BookingService.RefundPriorityFeeIfAny).
+  //
+  // TERMINATION REFUNDS join by month, not per booking: the BookingTerminated
+  // ledger row carries no booking FK, but the Terminate flow writes it in the
+  // same DB transaction that stamps CompletedAt, so both land on the same SGT
+  // month (the same pairing Analyze's termination fee uses).
+  //
+  // TERMINATED KTMB COST splits by refund capture: bookings WITH a captured
+  // KTMB refund report gross and refund exactly (both SGD-converted with the
+  // FX rate effective at CompletedAt — an unconvertible side contributes 0,
+  // like Analyze); bookings WITHOUT one report their gross separately so the
+  // calculator can apply the named fallback estimate.
+  public async Task<Result<PnlTerminalRow[]>> PnlTerminal(PnlTerminalQuery query)
+  {
+    try
+    {
+      logger.LogInformation("Computing terminal-event P&L with {@Query}", query.ToJson());
+      var sgt = TimeZoneInfo.FindSystemTimeZoneById("Asia/Singapore");
+      var afterUtc =
+        query.After?.ToZonedDateTime(TimeOnly.MinValue, sgt)
+        ?? DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc);
+      var beforeUtc =
+        query.Before?.AddDays(1).ToZonedDateTime(TimeOnly.MinValue, sgt)
+        ?? DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc);
+      var completedBooking = (byte)BookStatus.Completed;
+      var terminatedBooking = (byte)BookStatus.Terminated;
+      var terminatedLedger = (short)TransactionType.BookingTerminated;
+      var payment = (byte)GatewayFeeSourceType.Payment;
+      var completedWithdrawal = (byte)Domain.Withdrawal.WithdrawStatus.Completed;
+
+      var days = await db
+        .Database.SqlQuery<PnlTerminalDayDto>(
+          $"""
+          SELECT
+            CAST((p."CreatedAt" AT TIME ZONE 'UTC' + INTERVAL '8 hours') AS date) AS "Date",
+            SUM(p."CapturedAmount") AS "Deposits",
+            CAST(0 AS numeric) AS "PaymentFees",
+            CAST(0 AS numeric) AS "PayoutFees",
+            CAST(0 AS int) AS "CompletedCount",
+            CAST(0 AS numeric) AS "CompletedCollected",
+            CAST(0 AS numeric) AS "CompletedKtmbCost",
+            CAST(0 AS int) AS "TerminatedCount",
+            CAST(0 AS numeric) AS "TerminatedCollected",
+            CAST(0 AS numeric) AS "TerminationRefunds",
+            CAST(0 AS numeric) AS "TerminatedKtmbGrossExact",
+            CAST(0 AS numeric) AS "TerminatedKtmbRefund",
+            CAST(0 AS numeric) AS "TerminatedKtmbGrossEstimated",
+            CAST(0 AS int) AS "TerminatedWithExactRefund",
+            CAST(0 AS int) AS "WithdrawalCount",
+            CAST(0 AS numeric) AS "WithdrawalGross",
+            CAST(0 AS numeric) AS "WithdrawalFeeIncome"
+          FROM "Payments" p
+          WHERE p."Status" = 'SUCCEEDED'
+            AND p."CreatedAt" >= {afterUtc}
+            AND p."CreatedAt" < {beforeUtc}
+          GROUP BY 1
+
+          UNION ALL
+
+          SELECT
+            CAST((g."TransactedAt" AT TIME ZONE 'UTC' + INTERVAL '8 hours') AS date) AS "Date",
+            CAST(0 AS numeric) AS "Deposits",
+            COALESCE(SUM(g."Fee") FILTER (WHERE g."SourceType" = {payment}), 0) AS "PaymentFees",
+            COALESCE(SUM(g."Fee") FILTER (WHERE g."SourceType" <> {payment}), 0) AS "PayoutFees",
+            CAST(0 AS int) AS "CompletedCount",
+            CAST(0 AS numeric) AS "CompletedCollected",
+            CAST(0 AS numeric) AS "CompletedKtmbCost",
+            CAST(0 AS int) AS "TerminatedCount",
+            CAST(0 AS numeric) AS "TerminatedCollected",
+            CAST(0 AS numeric) AS "TerminationRefunds",
+            CAST(0 AS numeric) AS "TerminatedKtmbGrossExact",
+            CAST(0 AS numeric) AS "TerminatedKtmbRefund",
+            CAST(0 AS numeric) AS "TerminatedKtmbGrossEstimated",
+            CAST(0 AS int) AS "TerminatedWithExactRefund",
+            CAST(0 AS int) AS "WithdrawalCount",
+            CAST(0 AS numeric) AS "WithdrawalGross",
+            CAST(0 AS numeric) AS "WithdrawalFeeIncome"
+          FROM "GatewayFees" g
+          WHERE g."TransactedAt" >= {afterUtc} AND g."TransactedAt" < {beforeUtc}
+          GROUP BY 1
+
+          UNION ALL
+
+          SELECT
+            CAST((b."CompletedAt" AT TIME ZONE 'UTC' + INTERVAL '8 hours') AS date) AS "Date",
+            CAST(0 AS numeric) AS "Deposits",
+            CAST(0 AS numeric) AS "PaymentFees",
+            CAST(0 AS numeric) AS "PayoutFees",
+            CAST(COUNT(*) AS int) AS "CompletedCount",
+            SUM(
+              t."Amount"
+              + CASE
+                WHEN b."Priority" AND COALESCE(b."PriorityFee", 0) > 0 THEN b."PriorityFee"
+                ELSE 0
+              END
+            ) AS "CompletedCollected",
+            SUM(
+              CASE
+                WHEN b."KtmbAmount" IS NOT NULL AND b."KtmbCurrency" = 'SGD'
+                  THEN b."KtmbAmount"
+                WHEN b."KtmbAmount" IS NOT NULL AND b."KtmbCurrency" = 'MYR'
+                  AND fx."Rate" IS NOT NULL
+                  THEN b."KtmbAmount" * fx."Rate"
+                ELSE 0
+              END
+            ) AS "CompletedKtmbCost",
+            CAST(0 AS int) AS "TerminatedCount",
+            CAST(0 AS numeric) AS "TerminatedCollected",
+            CAST(0 AS numeric) AS "TerminationRefunds",
+            CAST(0 AS numeric) AS "TerminatedKtmbGrossExact",
+            CAST(0 AS numeric) AS "TerminatedKtmbRefund",
+            CAST(0 AS numeric) AS "TerminatedKtmbGrossEstimated",
+            CAST(0 AS int) AS "TerminatedWithExactRefund",
+            CAST(0 AS int) AS "WithdrawalCount",
+            CAST(0 AS numeric) AS "WithdrawalGross",
+            CAST(0 AS numeric) AS "WithdrawalFeeIncome"
+          FROM "Bookings" b
+          JOIN "Transactions" t ON t."Id" = b."TransactionId"
+          LEFT JOIN LATERAL (
+            SELECT f."Rate"
+            FROM "KtmbFxRates" f
+            WHERE f."EffectiveAt" <= b."CompletedAt"
+            ORDER BY f."EffectiveAt" DESC, f."CreatedAt" DESC, f."Id" DESC
+            LIMIT 1
+          ) fx ON TRUE
+          WHERE b."Status" = {completedBooking}
+            AND b."CompletedAt" IS NOT NULL
+            AND b."CompletedAt" >= {afterUtc}
+            AND b."CompletedAt" < {beforeUtc}
+          GROUP BY 1
+
+          UNION ALL
+
+          SELECT
+            CAST((b."CompletedAt" AT TIME ZONE 'UTC' + INTERVAL '8 hours') AS date) AS "Date",
+            CAST(0 AS numeric) AS "Deposits",
+            CAST(0 AS numeric) AS "PaymentFees",
+            CAST(0 AS numeric) AS "PayoutFees",
+            CAST(0 AS int) AS "CompletedCount",
+            CAST(0 AS numeric) AS "CompletedCollected",
+            CAST(0 AS numeric) AS "CompletedKtmbCost",
+            CAST(COUNT(*) AS int) AS "TerminatedCount",
+            SUM(
+              t."Amount"
+              + CASE
+                WHEN b."Priority" AND COALESCE(b."PriorityFee", 0) > 0 THEN b."PriorityFee"
+                ELSE 0
+              END
+            ) AS "TerminatedCollected",
+            CAST(0 AS numeric) AS "TerminationRefunds",
+            COALESCE(
+              SUM(
+                CASE
+                  WHEN b."KtmbAmount" IS NOT NULL AND b."KtmbCurrency" = 'SGD'
+                    THEN b."KtmbAmount"
+                  WHEN b."KtmbAmount" IS NOT NULL AND b."KtmbCurrency" = 'MYR'
+                    AND fx."Rate" IS NOT NULL
+                    THEN b."KtmbAmount" * fx."Rate"
+                  ELSE 0
+                END
+              ) FILTER (WHERE b."KtmbRefundAmount" IS NOT NULL),
+              0
+            ) AS "TerminatedKtmbGrossExact",
+            SUM(
+              CASE
+                WHEN b."KtmbRefundAmount" IS NOT NULL AND b."KtmbRefundCurrency" = 'SGD'
+                  THEN b."KtmbRefundAmount"
+                WHEN b."KtmbRefundAmount" IS NOT NULL AND b."KtmbRefundCurrency" = 'MYR'
+                  AND fx."Rate" IS NOT NULL
+                  THEN b."KtmbRefundAmount" * fx."Rate"
+                ELSE 0
+              END
+            ) AS "TerminatedKtmbRefund",
+            COALESCE(
+              SUM(
+                CASE
+                  WHEN b."KtmbAmount" IS NOT NULL AND b."KtmbCurrency" = 'SGD'
+                    THEN b."KtmbAmount"
+                  WHEN b."KtmbAmount" IS NOT NULL AND b."KtmbCurrency" = 'MYR'
+                    AND fx."Rate" IS NOT NULL
+                    THEN b."KtmbAmount" * fx."Rate"
+                  ELSE 0
+                END
+              ) FILTER (WHERE b."KtmbRefundAmount" IS NULL),
+              0
+            ) AS "TerminatedKtmbGrossEstimated",
+            CAST(
+              COUNT(*) FILTER (WHERE b."KtmbRefundAmount" IS NOT NULL) AS int
+            ) AS "TerminatedWithExactRefund",
+            CAST(0 AS int) AS "WithdrawalCount",
+            CAST(0 AS numeric) AS "WithdrawalGross",
+            CAST(0 AS numeric) AS "WithdrawalFeeIncome"
+          FROM "Bookings" b
+          JOIN "Transactions" t ON t."Id" = b."TransactionId"
+          LEFT JOIN LATERAL (
+            SELECT f."Rate"
+            FROM "KtmbFxRates" f
+            WHERE f."EffectiveAt" <= b."CompletedAt"
+            ORDER BY f."EffectiveAt" DESC, f."CreatedAt" DESC, f."Id" DESC
+            LIMIT 1
+          ) fx ON TRUE
+          WHERE b."Status" = {terminatedBooking}
+            AND b."CompletedAt" IS NOT NULL
+            AND b."CompletedAt" >= {afterUtc}
+            AND b."CompletedAt" < {beforeUtc}
+          GROUP BY 1
+
+          UNION ALL
+
+          SELECT
+            CAST((x."CreatedAt" AT TIME ZONE 'UTC' + INTERVAL '8 hours') AS date) AS "Date",
+            CAST(0 AS numeric) AS "Deposits",
+            CAST(0 AS numeric) AS "PaymentFees",
+            CAST(0 AS numeric) AS "PayoutFees",
+            CAST(0 AS int) AS "CompletedCount",
+            CAST(0 AS numeric) AS "CompletedCollected",
+            CAST(0 AS numeric) AS "CompletedKtmbCost",
+            CAST(0 AS int) AS "TerminatedCount",
+            CAST(0 AS numeric) AS "TerminatedCollected",
+            SUM(x."Amount") AS "TerminationRefunds",
+            CAST(0 AS numeric) AS "TerminatedKtmbGrossExact",
+            CAST(0 AS numeric) AS "TerminatedKtmbRefund",
+            CAST(0 AS numeric) AS "TerminatedKtmbGrossEstimated",
+            CAST(0 AS int) AS "TerminatedWithExactRefund",
+            CAST(0 AS int) AS "WithdrawalCount",
+            CAST(0 AS numeric) AS "WithdrawalGross",
+            CAST(0 AS numeric) AS "WithdrawalFeeIncome"
+          FROM "Transactions" x
+          WHERE x."TransactionType" = {terminatedLedger}
+            AND x."CreatedAt" >= {afterUtc}
+            AND x."CreatedAt" < {beforeUtc}
+          GROUP BY 1
+
+          UNION ALL
+
+          SELECT
+            CAST((w."CompletedAt" AT TIME ZONE 'UTC' + INTERVAL '8 hours') AS date) AS "Date",
+            CAST(0 AS numeric) AS "Deposits",
+            CAST(0 AS numeric) AS "PaymentFees",
+            CAST(0 AS numeric) AS "PayoutFees",
+            CAST(0 AS int) AS "CompletedCount",
+            CAST(0 AS numeric) AS "CompletedCollected",
+            CAST(0 AS numeric) AS "CompletedKtmbCost",
+            CAST(0 AS int) AS "TerminatedCount",
+            CAST(0 AS numeric) AS "TerminatedCollected",
+            CAST(0 AS numeric) AS "TerminationRefunds",
+            CAST(0 AS numeric) AS "TerminatedKtmbGrossExact",
+            CAST(0 AS numeric) AS "TerminatedKtmbRefund",
+            CAST(0 AS numeric) AS "TerminatedKtmbGrossEstimated",
+            CAST(0 AS int) AS "TerminatedWithExactRefund",
+            CAST(COUNT(*) AS int) AS "WithdrawalCount",
+            SUM(w."Amount") AS "WithdrawalGross",
+            SUM(COALESCE(w."Fee", 0)) AS "WithdrawalFeeIncome"
+          FROM "Withdrawals" w
+          WHERE w."Status" = {completedWithdrawal}
+            AND w."CompletedAt" IS NOT NULL
+            AND w."CompletedAt" >= {afterUtc}
+            AND w."CompletedAt" < {beforeUtc}
+          GROUP BY 1
+          """
+        )
+        .ToArrayAsync();
+
+      return PnlTerminalCalculator.Analyze(
+        days.Select(d => new PnlTerminalDailySum
+        {
+          Date = d.Date,
+          Deposits = d.Deposits,
+          PaymentFees = d.PaymentFees,
+          PayoutFees = d.PayoutFees,
+          CompletedCount = d.CompletedCount,
+          CompletedCollected = d.CompletedCollected,
+          CompletedKtmbCost = d.CompletedKtmbCost,
+          TerminatedCount = d.TerminatedCount,
+          TerminatedCollected = d.TerminatedCollected,
+          TerminationRefunds = d.TerminationRefunds,
+          TerminatedKtmbGrossExact = d.TerminatedKtmbGrossExact,
+          TerminatedKtmbRefund = d.TerminatedKtmbRefund,
+          TerminatedKtmbGrossEstimated = d.TerminatedKtmbGrossEstimated,
+          TerminatedWithExactRefund = d.TerminatedWithExactRefund,
+          WithdrawalCount = d.WithdrawalCount,
+          WithdrawalGross = d.WithdrawalGross,
+          WithdrawalFeeIncome = d.WithdrawalFeeIncome,
+        }),
+        query.After,
+        query.Before
+      );
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to compute terminal-event P&L with {@Query}", query.ToJson());
       return e;
     }
   }

--- a/Domain/Booking/Analysis.cs
+++ b/Domain/Booking/Analysis.cs
@@ -641,6 +641,225 @@ public static class PnlAnalysisCalculator
     ];
 }
 
+// ---- terminal-event P&L view (GET Booking/pnl/terminal) ----
+
+// Terminal-event P&L for the admin P&L page: profit is recognized when money
+// reaches a terminal state — a completed booking, a terminated booking or a
+// completed withdrawal. Deposits and payment gateway fees are reported per
+// month so every deposited dollar can carry its gateway-fee share to its
+// terminal event via the month's blended rate (gwRate); the client owns the
+// profit formulas and no derived profit is returned.
+public record PnlTerminalQuery
+{
+  // inclusive SGT source-event dates (payment CreatedAt, booking/withdrawal
+  // CompletedAt, gateway-fee TransactedAt); null = unbounded
+  public DateOnly? After { get; init; }
+
+  public DateOnly? Before { get; init; }
+}
+
+// One DB-side daily subtotal, sparse per source (a UNION ALL arm fills only
+// its own measures). Keeping the SGT date until this pure boundary lets the
+// calculator own inclusive-range filtering, month bucketing, the blended
+// gateway rate and the KTMB refund fallback while the repository keeps all
+// source scans aggregated.
+public record PnlTerminalDailySum
+{
+  public required DateOnly Date { get; init; }
+
+  // captured payment amounts (Payments.Status = 'SUCCEEDED')
+  public required decimal Deposits { get; init; }
+
+  // gateway fees on captured payment intents (SourceType = Payment)
+  public required decimal PaymentFees { get; init; }
+
+  // gateway fees on payouts (SourceType = Transfer or Refund)
+  public required decimal PayoutFees { get; init; }
+
+  public required int CompletedCount { get; init; }
+
+  // EVERYTHING collected for the completed bookings: the request-transaction
+  // amount (surcharges and discounts are already baked into it — the price
+  // breakdown never moves through separate ledger rows) PLUS the kept
+  // priority-boost fee (Completed consumes the queue jump and keeps the fee)
+  public required decimal CompletedCollected { get; init; }
+
+  // actual KTMB cost in SGD (SGD as-is, MYR × the FX rate effective at
+  // CompletedAt; no actual or no rate = 0)
+  public required decimal CompletedKtmbCost { get; init; }
+
+  public required int TerminatedCount { get; init; }
+
+  // same collected notion for bookings that ended Terminated (Terminate also
+  // keeps the priority-boost fee — only Refund/Cancel return it)
+  public required decimal TerminatedCollected { get; init; }
+
+  // what the BookingTerminated ledger rows returned to wallets — the row the
+  // Terminate flow writes in the same DB transaction that stamps CompletedAt
+  public required decimal TerminationRefunds { get; init; }
+
+  // KtmbAmount×FX of terminated bookings WITH a captured KTMB refund
+  public required decimal TerminatedKtmbGrossExact { get; init; }
+
+  // KtmbRefundAmount×FX of those captured refunds
+  public required decimal TerminatedKtmbRefund { get; init; }
+
+  // KtmbAmount×FX of terminated bookings WITHOUT a captured refund — the
+  // calculator costs these at the named fallback rate
+  public required decimal TerminatedKtmbGrossEstimated { get; init; }
+
+  // how many terminated bookings carry a captured (exact) KTMB refund
+  public required int TerminatedWithExactRefund { get; init; }
+
+  public required int WithdrawalCount { get; init; }
+
+  // gross wallet debit (the user receives Amount - Fee)
+  public required decimal WithdrawalGross { get; init; }
+
+  // the withdrawal fee BunnyBooker keeps
+  public required decimal WithdrawalFeeIncome { get; init; }
+}
+
+// bookings reaching Completed in the month (by CompletedAt)
+public record PnlTerminalCompleted
+{
+  public required int Count { get; init; }
+
+  public required decimal Collected { get; init; }
+
+  public required decimal KtmbCost { get; init; }
+}
+
+// bookings reaching Terminated in the month (CompletedAt is stamped at
+// termination)
+public record PnlTerminalTerminated
+{
+  public required int Count { get; init; }
+
+  // the amount BunnyBooker retained: everything collected for the bookings
+  // minus what their BookingTerminated ledger rows refunded to wallets —
+  // straight from the ledger, never re-derived from policy math
+  public required decimal Kept { get; init; }
+
+  // KTMB cost net of KTMB's refund: exact when the refund is captured,
+  // else estimated at KtmbRefundFallbackRate — WithExactRefund lets the UI
+  // mark estimated months
+  public required decimal KtmbCostNet { get; init; }
+
+  public required int WithExactRefund { get; init; }
+}
+
+// withdrawals reaching Completed in the month (by CompletedAt)
+public record PnlTerminalWithdrawals
+{
+  public required int Count { get; init; }
+
+  public required decimal Gross { get; init; }
+
+  public required decimal FeeIncome { get; init; }
+
+  // gateway fees on payout transfers + card refunds in the month
+  public required decimal PayoutFees { get; init; }
+}
+
+// One non-empty SGT calendar month. The client computes:
+// completedProfit  = collected − ktmbCost − gwRate×collected
+// terminatedProfit = kept − ktmbCostNet − gwRate×kept
+// withdrawalProfit = feeIncome − gwRate×gross − payoutFees
+public record PnlTerminalRow
+{
+  // "MM-yyyy"
+  public required string Month { get; init; }
+
+  public required decimal Deposits { get; init; }
+
+  public required decimal PaymentFees { get; init; }
+
+  // the month's blended gateway rate: PaymentFees / Deposits (0 when the
+  // month has no deposits), rounded to 6dp
+  public required decimal GwRate { get; init; }
+
+  public required PnlTerminalCompleted Completed { get; init; }
+
+  public required PnlTerminalTerminated Terminated { get; init; }
+
+  public required PnlTerminalWithdrawals Withdrawals { get; init; }
+}
+
+public static class PnlTerminalCalculator
+{
+  // KTMB exposes no retroactive refund data, so terminations without a
+  // captured refund (all historical rows) are costed at this estimated
+  // refund share of the KTMB gross. Evidence suggests some historical
+  // terminations may never have been refunded by KTMB at all — this single
+  // named constant is the one place to revisit that estimate.
+  public const decimal KtmbRefundFallbackRate = 0.50m;
+
+  public static PnlTerminalRow[] Analyze(
+    IEnumerable<PnlTerminalDailySum> days,
+    DateOnly? after,
+    DateOnly? before
+  ) =>
+    [
+      .. days
+        .Where(d => (after is null || d.Date >= after) && (before is null || d.Date <= before))
+        .GroupBy(d => new { d.Date.Year, d.Date.Month })
+        .Select(g =>
+        {
+          var deposits = g.Sum(d => d.Deposits);
+          var paymentFees = g.Sum(d => d.PaymentFees);
+          return new PnlTerminalRow
+          {
+            Month = new DateOnly(g.Key.Year, g.Key.Month, 1).ToString("MM-yyyy"),
+            Deposits = deposits,
+            PaymentFees = paymentFees,
+            GwRate = deposits == 0m ? 0m : Math.Round(paymentFees / deposits, 6),
+            Completed = new PnlTerminalCompleted
+            {
+              Count = g.Sum(d => d.CompletedCount),
+              Collected = g.Sum(d => d.CompletedCollected),
+              KtmbCost = g.Sum(d => d.CompletedKtmbCost),
+            },
+            Terminated = new PnlTerminalTerminated
+            {
+              Count = g.Sum(d => d.TerminatedCount),
+              Kept = g.Sum(d => d.TerminatedCollected) - g.Sum(d => d.TerminationRefunds),
+              KtmbCostNet =
+                g.Sum(d => d.TerminatedKtmbGrossExact)
+                - g.Sum(d => d.TerminatedKtmbRefund)
+                + g.Sum(d => d.TerminatedKtmbGrossEstimated) * (1m - KtmbRefundFallbackRate),
+              WithExactRefund = g.Sum(d => d.TerminatedWithExactRefund),
+            },
+            Withdrawals = new PnlTerminalWithdrawals
+            {
+              Count = g.Sum(d => d.WithdrawalCount),
+              Gross = g.Sum(d => d.WithdrawalGross),
+              FeeIncome = g.Sum(d => d.WithdrawalFeeIncome),
+              PayoutFees = g.Sum(d => d.PayoutFees),
+            },
+          };
+        })
+        .Where(r =>
+          r.Deposits != 0m
+          || r.PaymentFees != 0m
+          || r.Completed.Count != 0
+          || r.Completed.Collected != 0m
+          || r.Completed.KtmbCost != 0m
+          || r.Terminated.Count != 0
+          || r.Terminated.Kept != 0m
+          || r.Terminated.KtmbCostNet != 0m
+          || r.Terminated.WithExactRefund != 0
+          || r.Withdrawals.Count != 0
+          || r.Withdrawals.Gross != 0m
+          || r.Withdrawals.FeeIncome != 0m
+          || r.Withdrawals.PayoutFees != 0m
+        )
+        // "MM-yyyy" sorts chronologically on (yyyy, MM)
+        .OrderBy(r => r.Month[3..])
+        .ThenBy(r => r.Month[..2]),
+    ];
+}
+
 public interface IBookingAnalysisRepository
 {
   Task<Result<BookingAnalysis>> Analyze(BookingAnalysisQuery query);
@@ -650,6 +869,8 @@ public interface IBookingAnalysisRepository
   Task<Result<ProfitAnalysisRow[]>> ProfitAnalysis(ProfitAnalysisQuery query);
 
   Task<Result<PnlAnalysisRow[]>> PnlAnalysis(PnlAnalysisQuery query);
+
+  Task<Result<PnlTerminalRow[]>> PnlTerminal(PnlTerminalQuery query);
 
   Task<Result<BookingBoostPage>> Boosts(BookingBoostQuery query);
 }

--- a/UnitTest/Bookings/PnlTerminalCalculatorTests.cs
+++ b/UnitTest/Bookings/PnlTerminalCalculatorTests.cs
@@ -1,0 +1,244 @@
+using Domain.Booking;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// Pure terminal-event P&L math: SGT daily subtotals merge across sources,
+// bounds are inclusive, months are chronological, the blended gateway rate
+// and the KTMB refund fallback are applied per month, and no zero-only month
+// leaks to the wire. Source-specific attribution (collected = request amount
+// + kept boost fee) and FX conversion happen in SQL.
+public class PnlTerminalCalculatorTests
+{
+  private static PnlTerminalDailySum Day(
+    DateOnly? date = null,
+    decimal deposits = 0m,
+    decimal paymentFees = 0m,
+    decimal payoutFees = 0m,
+    int completedCount = 0,
+    decimal completedCollected = 0m,
+    decimal completedKtmbCost = 0m,
+    int terminatedCount = 0,
+    decimal terminatedCollected = 0m,
+    decimal terminationRefunds = 0m,
+    decimal terminatedKtmbGrossExact = 0m,
+    decimal terminatedKtmbRefund = 0m,
+    decimal terminatedKtmbGrossEstimated = 0m,
+    int terminatedWithExactRefund = 0,
+    int withdrawalCount = 0,
+    decimal withdrawalGross = 0m,
+    decimal withdrawalFeeIncome = 0m
+  ) =>
+    new()
+    {
+      Date = date ?? new DateOnly(2026, 8, 1),
+      Deposits = deposits,
+      PaymentFees = paymentFees,
+      PayoutFees = payoutFees,
+      CompletedCount = completedCount,
+      CompletedCollected = completedCollected,
+      CompletedKtmbCost = completedKtmbCost,
+      TerminatedCount = terminatedCount,
+      TerminatedCollected = terminatedCollected,
+      TerminationRefunds = terminationRefunds,
+      TerminatedKtmbGrossExact = terminatedKtmbGrossExact,
+      TerminatedKtmbRefund = terminatedKtmbRefund,
+      TerminatedKtmbGrossEstimated = terminatedKtmbGrossEstimated,
+      TerminatedWithExactRefund = terminatedWithExactRefund,
+      WithdrawalCount = withdrawalCount,
+      WithdrawalGross = withdrawalGross,
+      WithdrawalFeeIncome = withdrawalFeeIncome,
+    };
+
+  [Fact]
+  public void Days_and_sparse_sources_in_the_same_month_merge_all_measures()
+  {
+    var rows = PnlTerminalCalculator.Analyze(
+      [
+        Day(new DateOnly(2026, 8, 1), deposits: 300m),
+        Day(new DateOnly(2026, 8, 3), paymentFees: 7m, payoutFees: 2.35m),
+        Day(
+          new DateOnly(2026, 8, 7),
+          completedCount: 3,
+          completedCollected: 135.5m,
+          completedKtmbCost: 60.25m
+        ),
+        Day(
+          new DateOnly(2026, 8, 12),
+          terminatedCount: 1,
+          terminatedCollected: 45m,
+          terminatedKtmbGrossExact: 20m,
+          terminatedKtmbRefund: 8m,
+          terminatedWithExactRefund: 1
+        ),
+        Day(new DateOnly(2026, 8, 12), terminationRefunds: 22.5m),
+        Day(
+          new DateOnly(2026, 8, 31),
+          withdrawalCount: 4,
+          withdrawalGross: 400m,
+          withdrawalFeeIncome: 16m
+        ),
+      ],
+      null,
+      null
+    );
+
+    rows.Should().ContainSingle();
+    rows[0]
+      .Should()
+      .BeEquivalentTo(
+        new PnlTerminalRow
+        {
+          Month = "08-2026",
+          Deposits = 300m,
+          PaymentFees = 7m,
+          GwRate = 0.023333m,
+          Completed = new PnlTerminalCompleted
+          {
+            Count = 3,
+            Collected = 135.5m,
+            KtmbCost = 60.25m,
+          },
+          Terminated = new PnlTerminalTerminated
+          {
+            Count = 1,
+            Kept = 22.5m,
+            KtmbCostNet = 12m,
+            WithExactRefund = 1,
+          },
+          Withdrawals = new PnlTerminalWithdrawals
+          {
+            Count = 4,
+            Gross = 400m,
+            FeeIncome = 16m,
+            PayoutFees = 2.35m,
+          },
+        }
+      );
+  }
+
+  [Fact]
+  public void Gw_rate_is_payment_fees_over_deposits_rounded_to_6dp()
+  {
+    var rows = PnlTerminalCalculator.Analyze(
+      [Day(deposits: 300m, paymentFees: 7m)],
+      null,
+      null
+    );
+
+    // 7 / 300 = 0.02333... -> 6dp
+    rows[0].GwRate.Should().Be(0.023333m);
+  }
+
+  [Fact]
+  public void Gw_rate_is_zero_when_the_month_has_no_deposits()
+  {
+    var rows = PnlTerminalCalculator.Analyze([Day(paymentFees: 5m)], null, null);
+
+    rows[0].GwRate.Should().Be(0m);
+  }
+
+  [Fact]
+  public void Kept_is_collected_minus_the_ledger_refunds()
+  {
+    var rows = PnlTerminalCalculator.Analyze(
+      [
+        Day(terminatedCount: 2, terminatedCollected: 100m),
+        Day(terminationRefunds: 70m),
+      ],
+      null,
+      null
+    );
+
+    rows[0].Terminated.Kept.Should().Be(30m);
+  }
+
+  [Fact]
+  public void Ktmb_cost_net_uses_exact_refunds_and_the_fallback_for_uncaptured_ones()
+  {
+    var rows = PnlTerminalCalculator.Analyze(
+      [
+        Day(
+          terminatedCount: 3,
+          terminatedCollected: 90m,
+          // 2 with a captured refund: gross 100 - refund 40 = 60 exact
+          terminatedKtmbGrossExact: 100m,
+          terminatedKtmbRefund: 40m,
+          terminatedWithExactRefund: 2,
+          // 1 without: gross 80 costed at the 0.50 fallback = 40
+          terminatedKtmbGrossEstimated: 80m
+        ),
+      ],
+      null,
+      null
+    );
+
+    rows[0].Terminated.KtmbCostNet.Should().Be(100m);
+    rows[0].Terminated.WithExactRefund.Should().Be(2);
+  }
+
+  [Fact]
+  public void The_ktmb_refund_fallback_rate_is_a_single_named_constant_at_50_percent()
+  {
+    PnlTerminalCalculator.KtmbRefundFallbackRate.Should().Be(0.50m);
+  }
+
+  [Fact]
+  public void Inclusive_date_bounds_filter_before_month_bucketing()
+  {
+    var rows = PnlTerminalCalculator.Analyze(
+      [
+        Day(new DateOnly(2026, 7, 31), deposits: 1m),
+        Day(new DateOnly(2026, 8, 1), deposits: 2m),
+        Day(new DateOnly(2026, 8, 31), deposits: 3m),
+        Day(new DateOnly(2026, 9, 1), deposits: 4m),
+      ],
+      new DateOnly(2026, 8, 1),
+      new DateOnly(2026, 8, 31)
+    );
+
+    rows.Should().ContainSingle();
+    rows[0].Month.Should().Be("08-2026");
+    rows[0].Deposits.Should().Be(5m);
+  }
+
+  [Fact]
+  public void Null_bounds_are_unbounded_and_months_sort_chronologically()
+  {
+    var rows = PnlTerminalCalculator.Analyze(
+      [
+        Day(new DateOnly(2027, 1, 1), deposits: 1m),
+        Day(new DateOnly(2026, 12, 1), deposits: 1m),
+        Day(new DateOnly(2026, 2, 1), deposits: 1m),
+      ],
+      null,
+      null
+    );
+
+    rows.Select(r => r.Month).Should().Equal("02-2026", "12-2026", "01-2027");
+  }
+
+  [Fact]
+  public void A_month_with_only_one_source_keeps_its_other_measures_at_zero()
+  {
+    var rows = PnlTerminalCalculator.Analyze(
+      [Day(withdrawalCount: 1, withdrawalGross: 50m, withdrawalFeeIncome: 2m)],
+      null,
+      null
+    );
+
+    rows.Should().ContainSingle();
+    rows[0].Deposits.Should().Be(0m);
+    rows[0].GwRate.Should().Be(0m);
+    rows[0].Completed.Count.Should().Be(0);
+    rows[0].Terminated.Count.Should().Be(0);
+    rows[0].Withdrawals.Gross.Should().Be(50m);
+  }
+
+  [Fact]
+  public void Empty_or_zero_only_inputs_produce_no_months()
+  {
+    PnlTerminalCalculator.Analyze([], null, null).Should().BeEmpty();
+    PnlTerminalCalculator.Analyze([Day()], null, null).Should().BeEmpty();
+  }
+}

--- a/UnitTest/Bookings/PnlTerminalWireContractTests.cs
+++ b/UnitTest/Bookings/PnlTerminalWireContractTests.cs
@@ -1,0 +1,82 @@
+using System.Text.Json;
+using App.Modules.Bookings.API.V1;
+using Domain.Booking;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// argon builds its P&L page against this EXACT wire shape — pin the
+// serialized JSON so a rename on our side can never silently break it.
+// ASP.NET Core serializes with JsonSerializerDefaults.Web (camelCase).
+public class PnlTerminalWireContractTests
+{
+  private static readonly JsonSerializerOptions Web = new(JsonSerializerDefaults.Web);
+
+  private static PnlTerminalRow Row() =>
+    new()
+    {
+      Month = "08-2026",
+      Deposits = 1000.5m,
+      PaymentFees = 23.45m,
+      GwRate = 0.023439m,
+      Completed = new PnlTerminalCompleted
+      {
+        Count = 3,
+        Collected = 135.5m,
+        KtmbCost = 60.25m,
+      },
+      Terminated = new PnlTerminalTerminated
+      {
+        Count = 2,
+        Kept = 30.5m,
+        KtmbCostNet = 25.75m,
+        WithExactRefund = 1,
+      },
+      Withdrawals = new PnlTerminalWithdrawals
+      {
+        Count = 4,
+        Gross = 400m,
+        FeeIncome = 16m,
+        PayoutFees = 2.35m,
+      },
+    };
+
+  [Fact]
+  public void Terminal_pnl_row_serializes_with_the_pinned_names_and_nesting()
+  {
+    var json = JsonSerializer.Serialize(Row().ToRes(), Web);
+
+    json.Should()
+      .Be(
+        "{\"month\":\"08-2026\",\"deposits\":1000.5,\"paymentFees\":23.45,"
+          + "\"gwRate\":0.023439,"
+          + "\"completed\":{\"count\":3,\"collected\":135.5,\"ktmbCost\":60.25},"
+          + "\"terminated\":{\"count\":2,\"kept\":30.5,\"ktmbCostNet\":25.75,"
+          + "\"withExactRefund\":1},"
+          + "\"withdrawals\":{\"count\":4,\"gross\":400,\"feeIncome\":16,"
+          + "\"payoutFees\":2.35}}"
+      );
+  }
+
+  [Fact]
+  public void Terminal_pnl_rows_serialize_as_a_flat_array()
+  {
+    var rows = new[] { Row() };
+
+    var json = JsonSerializer.Serialize(rows.Select(r => r.ToRes()), Web);
+
+    json.Should().StartWith("[{\"month\":\"08-2026\",");
+    json.Should().EndWith("}]");
+  }
+
+  [Fact]
+  public void Terminal_pnl_query_binds_optional_after_and_before_as_dd_MM_yyyy()
+  {
+    var req = new BookingPnlTerminalQueryReq("01-08-2026", null);
+
+    var domain = req.ToDomain();
+
+    domain.After.Should().Be(new DateOnly(2026, 8, 1));
+    domain.Before.Should().BeNull();
+  }
+}


### PR DESCRIPTION
## Summary

Adds the terminal-event P&L engine for the new admin P&L page: **`GET /api/v{version}/Booking/pnl/terminal`** (OnlyAdmin, optional inclusive SGT `After`/`Before` in `dd-MM-yyyy` like the analysis endpoints).

Profit is recognized when money reaches a terminal state — a completed booking, a terminated booking, or a completed withdrawal. Every deposited dollar carries its gateway-fee share to its terminal event via the month's blended rate (`gwRate = paymentFees / deposits`, server-computed at 6dp, 0 when the month has no deposits). No profit is derived server-side; the client owns the formulas:

- `completedProfit  = collected − ktmbCost − gwRate×collected`
- `terminatedProfit = kept − ktmbCostNet − gwRate×kept`
- `withdrawalProfit = feeIncome − gwRate×gross − payoutFees`

## Wire contract (PINNED — frontend built in parallel)

Array sorted by month ascending, empty months omitted:

```json
[{
  "month": "MM-yyyy",
  "deposits": 0, "paymentFees": 0, "gwRate": 0,
  "completed":   { "count": 0, "collected": 0, "ktmbCost": 0 },
  "terminated":  { "count": 0, "kept": 0, "ktmbCostNet": 0, "withExactRefund": 0 },
  "withdrawals": { "count": 0, "gross": 0, "feeIncome": 0, "payoutFees": 0 }
}]
```

Pinned by a wire-contract JSON serialization test.

## Semantics (ledger findings)

- **Collected = request-transaction amount + kept priority-boost fee.** Surcharges/discounts are baked into the request amount (the persisted price breakdown never moves through separate ledger rows); the priority boost is the only separate charge (`TransactionType.PriorityFee`, snapshotted on `Bookings.PriorityFee`). Both `Complete` and `Terminate` keep the boost fee — only `Refund`/`Cancel` return it (`BookingService.RefundPriorityFeeIfAny`) — so completed *and* terminated collected include it.
- **Terminated `kept` comes straight from the ledger:** collected minus what the `BookingTerminated` rows refunded to wallets. That row carries no booking FK, but the Terminate flow writes it in the same DB transaction that stamps `CompletedAt`, so both land on the same SGT month (the same pairing the analysis' termination fee uses). Never re-derived from policy math.
- **`ktmbCostNet`:** exact (`KtmbAmount×FX − KtmbRefundAmount×FX`) when the KTMB refund is captured; otherwise `KtmbAmount×FX × (1 − KtmbRefundFallbackRate)` with the fallback rate a **single named constant** (`PnlTerminalCalculator.KtmbRefundFallbackRate = 0.50m`) — KTMB exposes no retroactive refund data for historical terminations and evidence suggests some may never have been refunded at all, so this is an explicit, easy-to-revisit estimate. `withExactRefund` lets the UI mark estimated months.
- **Withdrawals:** Completed (`Status=1`) by `CompletedAt` month; `gross` = gross wallet debit, `feeIncome` = the fee we keep, `payoutFees` = gateway fees with `SourceType` Transfer or Refund by `TransactedAt` month.
- **Deposits/paymentFees:** captured amounts of `Payments.Status='SUCCEEDED'` by SGT `CreatedAt` month; gateway fees with `SourceType=Payment` by SGT `TransactedAt` month.

## Implementation

Mirrors the analysis end-to-end pattern: pinned wire records + validator + mapper + controller, a sparse `UNION ALL` day scan in `BookingAnalysisRepository.PnlTerminal` (same SGT wall-clock arithmetic and `KtmbFxRates` LATERAL as `Analyze`), and a pure `PnlTerminalCalculator` in Domain that owns range filtering, month bucketing, the blended rate and the refund fallback.

## Tests

- `PnlTerminalCalculatorTests` — merge across sparse sources, gwRate 6dp + zero-deposit guard, ledger-derived kept, exact/fallback ktmbCostNet mix, inclusive bounds, chronological ordering, empty-month omission.
- `PnlTerminalWireContractTests` — pinned JSON shape + `dd-MM-yyyy` query binding.
- Full unit suite: 726 passed; the only failure is the known wall-clock-sensitive `Terminate_keeps_the_priority_fee` (fails on clean origin/main locally, passes in CI).