### PR TITLE
feat: partner boost counts, account-fee capture, owner-gated history

### DIFF
--- a/App/Modules/Bookings/API/V1/BookingController.cs
+++ b/App/Modules/Bookings/API/V1/BookingController.cs
@@ -8,6 +8,7 @@ using App.StartUp.Services.Auth;
 using App.Utility;
 using Asp.Versioning;
 using CSharp_Result;
+using Domain;
 using Domain.Booking;
 using Domain.Cost;
 using Domain.User;
@@ -126,9 +127,13 @@ public class BookingController(
     [FromServices] BookingAnalysisQueryReqValidator analysisValidator
   )
   {
+    // non-owners only see history from RangeClamp.NonOwnerFloor onward — a
+    // clamp, not an error (same gate on every analysis/P&L endpoint)
     var x = await analysisValidator
       .ValidateAsyncResult(query, "Invalid BookingAnalysisQueryReq")
-      .ThenAwait(q => analysisRepo.Analyze(q.ToDomain()))
+      .ThenAwait(q =>
+        analysisRepo.Analyze(q.ToDomain().ClampHistory(this.HasRoleIgnoreCase(AuthRoles.Owner)))
+      )
       .Then(a => a.ToRes(), Errors.MapAll);
     return this.ReturnResult(x);
   }
@@ -146,7 +151,11 @@ public class BookingController(
   {
     var x = await travelValidator
       .ValidateAsyncResult(query, "Invalid BookingTravelAnalysisQueryReq")
-      .ThenAwait(q => analysisRepo.TravelAnalysis(q.ToDomain()))
+      .ThenAwait(q =>
+        analysisRepo.TravelAnalysis(
+          q.ToDomain().ClampHistory(this.HasRoleIgnoreCase(AuthRoles.Owner))
+        )
+      )
       .Then(rows => rows.Select(r => r.ToRes()), Errors.MapAll);
     return this.ReturnResult(x);
   }
@@ -166,7 +175,11 @@ public class BookingController(
   {
     var x = await profitValidator
       .ValidateAsyncResult(query, "Invalid BookingProfitAnalysisQueryReq")
-      .ThenAwait(q => analysisRepo.ProfitAnalysis(q.ToDomain()))
+      .ThenAwait(q =>
+        analysisRepo.ProfitAnalysis(
+          q.ToDomain().ClampHistory(this.HasRoleIgnoreCase(AuthRoles.Owner))
+        )
+      )
       .Then(rows => rows.Select(r => r.ToRes()), Errors.MapAll);
     return this.ReturnResult(x);
   }
@@ -181,7 +194,9 @@ public class BookingController(
   {
     var x = await pnlValidator
       .ValidateAsyncResult(query, "Invalid BookingPnlAnalysisQueryReq")
-      .ThenAwait(q => analysisRepo.PnlAnalysis(q.ToDomain()))
+      .ThenAwait(q =>
+        analysisRepo.PnlAnalysis(q.ToDomain().ClampHistory(this.HasRoleIgnoreCase(AuthRoles.Owner)))
+      )
       .Then(rows => rows.Select(r => r.ToRes()), Errors.MapAll);
     return this.ReturnResult(x);
   }
@@ -203,7 +218,9 @@ public class BookingController(
   {
     var x = await pnlTerminalValidator
       .ValidateAsyncResult(query, "Invalid BookingPnlTerminalQueryReq")
-      .ThenAwait(q => analysisRepo.PnlTerminal(q.ToDomain()))
+      .ThenAwait(q =>
+        analysisRepo.PnlTerminal(q.ToDomain().ClampHistory(this.HasRoleIgnoreCase(AuthRoles.Owner)))
+      )
       .Then(rows => rows.Select(r => r.ToRes()), Errors.MapAll);
     return this.ReturnResult(x);
   }
@@ -220,7 +237,9 @@ public class BookingController(
   {
     var x = await boostValidator
       .ValidateAsyncResult(query, "Invalid BookingBoostQueryReq")
-      .ThenAwait(q => analysisRepo.Boosts(q.ToDomain()))
+      .ThenAwait(q =>
+        analysisRepo.Boosts(q.ToDomain().ClampHistory(this.HasRoleIgnoreCase(AuthRoles.Owner)))
+      )
       .Then(p => p.ToRes(), Errors.MapAll);
     return this.ReturnResult(x);
   }

--- a/App/Modules/Bookings/Data/BookingAnalysisRepository.cs
+++ b/App/Modules/Bookings/Data/BookingAnalysisRepository.cs
@@ -368,11 +368,16 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
         TerminationRefunds = LedgerSum(TransactionType.BookingTerminated),
       };
 
-      var payment = (byte)GatewayFeeSourceType.Payment;
+      // payments-vs-payouts split per GatewayFeeBuckets: account-level fee
+      // billings are deposit-acceptance costs and bucket with payments
       var gatewayFees = new GatewayFeeSummary
       {
-        Payments = gatewayMonths.Where(x => x.SourceType == payment).Sum(x => x.Fee),
-        Payouts = gatewayMonths.Where(x => x.SourceType != payment).Sum(x => x.Fee),
+        Payments = gatewayMonths
+          .Where(x => GatewayFeeBuckets.IsPaymentSide((GatewayFeeSourceType)x.SourceType))
+          .Sum(x => x.Fee),
+        Payouts = gatewayMonths
+          .Where(x => GatewayFeeBuckets.IsPayoutSide((GatewayFeeSourceType)x.SourceType))
+          .Sum(x => x.Fee),
         Coverage = new GatewayFeeCoverage
         {
           PaymentsWithFee = paymentsWithFee,
@@ -404,8 +409,14 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
                 .Sum(x => x.Sum);
             return new MonthlyExternalSums
             {
-              GatewayPaymentFees = g.Where(x => x.SourceType == payment).Sum(x => x.Fee),
-              GatewayPayoutFees = g.Where(x => x.SourceType != payment).Sum(x => x.Fee),
+              GatewayPaymentFees = g.Where(x =>
+                  GatewayFeeBuckets.IsPaymentSide((GatewayFeeSourceType)x.SourceType)
+                )
+                .Sum(x => x.Fee),
+              GatewayPayoutFees = g.Where(x =>
+                  GatewayFeeBuckets.IsPayoutSide((GatewayFeeSourceType)x.SourceType)
+                )
+                .Sum(x => x.Fee),
               InternalFees =
                 MonthLedger(TransactionType.DepositFee)
                 + MonthLedger(TransactionType.WithdrawFee)
@@ -752,7 +763,12 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
       var completedBooking = (byte)BookStatus.Completed;
       var terminatedBooking = (byte)BookStatus.Terminated;
       var terminatedLedger = (short)TransactionType.BookingTerminated;
+      // paymentFees = Payment + AccountFee (deposit-acceptance costs feeding
+      // gwRate); payoutFees = Transfer + Refund ONLY — see GatewayFeeBuckets
       var payment = (byte)GatewayFeeSourceType.Payment;
+      var accountFee = (byte)GatewayFeeSourceType.AccountFee;
+      var transfer = (byte)GatewayFeeSourceType.Transfer;
+      var refund = (byte)GatewayFeeSourceType.Refund;
       var completedWithdrawal = (byte)Domain.Withdrawal.WithdrawStatus.Completed;
 
       var days = await db
@@ -787,8 +803,12 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
           SELECT
             CAST((g."TransactedAt" AT TIME ZONE 'UTC' + INTERVAL '8 hours') AS date) AS "Date",
             CAST(0 AS numeric) AS "Deposits",
-            COALESCE(SUM(g."Fee") FILTER (WHERE g."SourceType" = {payment}), 0) AS "PaymentFees",
-            COALESCE(SUM(g."Fee") FILTER (WHERE g."SourceType" <> {payment}), 0) AS "PayoutFees",
+            COALESCE(
+              SUM(g."Fee") FILTER (WHERE g."SourceType" IN ({payment}, {accountFee})), 0
+            ) AS "PaymentFees",
+            COALESCE(
+              SUM(g."Fee") FILTER (WHERE g."SourceType" IN ({transfer}, {refund})), 0
+            ) AS "PayoutFees",
             CAST(0 AS int) AS "CompletedCount",
             CAST(0 AS numeric) AS "CompletedCollected",
             CAST(0 AS numeric) AS "CompletedKtmbCost",

--- a/App/Modules/Common/BaseController.cs
+++ b/App/Modules/Common/BaseController.cs
@@ -191,4 +191,11 @@ public class AtomiControllerBase(IAuthHelper h) : ControllerBase
   }
 
   protected string? Sub() => this.HttpContext.User?.Identity?.Name;
+
+  // case-insensitive JWT role probe (legacy/manual Descope role casing is
+  // not guaranteed) — for data-scoping decisions like the analysis history
+  // clamp, never for endpoint authorization (policies own that)
+  protected bool HasRoleIgnoreCase(string role) =>
+    h.FieldToScope(this.HttpContext.User, AuthRoles.Field)
+      .Any(r => string.Equals(r, role, StringComparison.OrdinalIgnoreCase));
 }

--- a/App/Modules/DomainServices.cs
+++ b/App/Modules/DomainServices.cs
@@ -179,6 +179,12 @@ public static class DomainServices
 
     s.AddScoped<GatewayFeeSyncRunner>();
 
+    // account-level FEE sweep (fees billed against no movement we track)
+    s.AddScoped<IGatewayAccountFeeSource, AirwallexAccountFeeSource>()
+      .AutoTrace<IGatewayAccountFeeSource>();
+
+    s.AddScoped<GatewayAccountFeeSweep>();
+
     // recurring sync so fee data accrues without the manual endpoint
     s.AddHostedService<GatewayFeeSyncWorker>();
 

--- a/App/Modules/Payments/Airwallex/AirwallexAccountFeeSource.cs
+++ b/App/Modules/Payments/Airwallex/AirwallexAccountFeeSource.cs
@@ -1,0 +1,36 @@
+using CSharp_Result;
+using Domain.Payment;
+
+namespace App.Modules.Payments.Airwallex;
+
+// IGatewayAccountFeeSource over the Airwallex financial_transactions API:
+// FEE-type transactions in a created-at window, mapped to account-fee lines.
+// The API already filters by transaction_type; the defensive re-check keeps a
+// lenient gateway from ever writing non-FEE rows as account fees.
+public class AirwallexAccountFeeSource(AirWallexClient client) : IGatewayAccountFeeSource
+{
+  public const string FeeTransactionType = "FEE";
+
+  public Task<Result<IEnumerable<GatewayAccountFeeLine>>> InRange(DateTime fromUtc, DateTime toUtc)
+  {
+    return client
+      .ListFinancialTransactionsByType(FeeTransactionType, fromUtc, toUtc)
+      .Then(
+        items =>
+          items
+            .Where(x =>
+              string.Equals(x.TransactionType, FeeTransactionType, StringComparison.OrdinalIgnoreCase)
+            )
+            .Select(x => new GatewayAccountFeeLine
+            {
+              SourceId = x.SourceId ?? string.Empty,
+              FinancialTransactionId = x.Id,
+              Amount = x.Amount,
+              Net = x.Net,
+              Currency = x.Currency,
+              TransactedAt = DateTime.SpecifyKind(x.CreatedAt, DateTimeKind.Utc),
+            }),
+        Errors.MapNone
+      );
+  }
+}

--- a/App/Modules/Payments/Airwallex/Client.cs
+++ b/App/Modules/Payments/Airwallex/Client.cs
@@ -301,6 +301,80 @@ public class AirWallexClient(
       });
   }
 
+  // The gateway's ledger filtered by transaction type over a created-at
+  // window: every financial transaction of the given type (e.g. FEE — the
+  // account-level fee billings that own no movement we track) created in
+  // [fromUtc, toUtc), following page_num until has_more is false. Same
+  // endpoint and paging as the source_id listing above; from_created_at /
+  // to_created_at are the API's documented window params.
+  public Task<Result<AirwallexFinancialTransactionRes[]>> ListFinancialTransactionsByType(
+    string transactionType,
+    DateTime fromUtc,
+    DateTime toUtc
+  )
+  {
+    return authenticator
+      .GetToken()
+      .ThenAwait(async token =>
+      {
+        try
+        {
+          var from = Uri.EscapeDataString(fromUtc.ToString("yyyy-MM-ddTHH:mm:ssZ"));
+          var to = Uri.EscapeDataString(toUtc.ToString("yyyy-MM-ddTHH:mm:ssZ"));
+          var items = new List<AirwallexFinancialTransactionRes>();
+          var page = 0;
+          while (true)
+          {
+            var request = new HttpRequestMessage
+            {
+              Method = HttpMethod.Get,
+              RequestUri = new Uri(
+                $"api/v1/financial_transactions?transaction_type={Uri.EscapeDataString(transactionType)}"
+                  + $"&from_created_at={from}&to_created_at={to}"
+                  + $"&page_num={page}&page_size=100",
+                UriKind.Relative
+              ),
+              Headers = { Authorization = new AuthenticationHeaderValue("Bearer", token) },
+            };
+            using var response = await this.HttpClient.SendAsync(request);
+            var body = await response.Content.ReadAsStringAsync();
+            // a 404 is "no rows in this window" — a normal empty answer
+            if ((int)response.StatusCode == 404)
+              return (Result<AirwallexFinancialTransactionRes[]>)items.ToArray();
+            if (!response.IsSuccessStatusCode)
+            {
+              logger.LogError(
+                "Failed to list Airwallex financial transactions of type '{Type}', "
+                  + "Status: {Status}, Response: {Body}",
+                transactionType,
+                (int)response.StatusCode,
+                body
+              );
+              return (Result<AirwallexFinancialTransactionRes[]>)
+                new HttpRequestException(
+                  $"Airwallex financial transaction listing failed ({(int)response.StatusCode}): {body}"
+                );
+            }
+
+            var list = body.ToObj<AirwallexFinancialTransactionListRes>();
+            items.AddRange(list.Items ?? []);
+            if (!list.HasMore || list.Items is not { Length: > 0 })
+              return (Result<AirwallexFinancialTransactionRes[]>)items.ToArray();
+            page++;
+          }
+        }
+        catch (Exception e)
+        {
+          logger.LogError(
+            e,
+            "Failed to list Airwallex financial transactions of type '{Type}' (transport error)",
+            transactionType
+          );
+          return (Result<AirwallexFinancialTransactionRes[]>)e;
+        }
+      });
+  }
+
   // Point-in-time lookup for reconciliation. Returns null (not an error) when
   // the gateway definitively has no such transfer.
   public Task<Result<AirwallexTransferRes?>> GetTransfer(string transferId)

--- a/App/Modules/Payments/Data/GatewayFeeData.cs
+++ b/App/Modules/Payments/Data/GatewayFeeData.cs
@@ -7,7 +7,8 @@ namespace App.Modules.Payments.Data;
 // captured after the fact by the gateway-fee sync. FinancialTransactionId is
 // the gateway's globally unique id and the idempotent upsert key; SourceId
 // ties the row back to the object that moved the money (a payment intent, a
-// payout transfer or a card refund — see SourceType).
+// payout transfer or a card refund — see SourceType) or, for account-level
+// fees, the gateway's own billing source.
 public class GatewayFeeData
 {
   public Guid Id { get; set; }
@@ -18,7 +19,8 @@ public class GatewayFeeData
   [MaxLength(256)]
   public string SourceId { get; set; } = string.Empty;
 
-  // Domain.Payment.GatewayFeeSourceType: 0 Payment, 1 Transfer, 2 Refund
+  // Domain.Payment.GatewayFeeSourceType: 0 Payment, 1 Transfer, 2 Refund,
+  // 3 AccountFee
   public byte SourceType { get; set; }
 
   // Airwallex financial transaction id — unique, the upsert key

--- a/App/Modules/Payments/Data/GatewayFeeRepository.cs
+++ b/App/Modules/Payments/Data/GatewayFeeRepository.cs
@@ -133,6 +133,23 @@ public class GatewayFeeRepository(MainDbContext db, ILogger<GatewayFeeRepository
     }
   }
 
+  public async Task<Result<DateTime?>> LatestAccountFeeTransactedAt()
+  {
+    try
+    {
+      var accountFee = (byte)GatewayFeeSourceType.AccountFee;
+      var latest = await db
+        .GatewayFees.Where(f => f.SourceType == accountFee)
+        .MaxAsync(f => (DateTime?)f.TransactedAt);
+      return latest;
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to read the account-fee sweep watermark");
+      return e;
+    }
+  }
+
   public async Task<Result<int>> Upsert(IEnumerable<GatewayFeeRecord> records)
   {
     try

--- a/App/Modules/Payments/GatewayFeeSyncWorker.cs
+++ b/App/Modules/Payments/GatewayFeeSyncWorker.cs
@@ -7,8 +7,11 @@ namespace App.Modules.Payments;
 // endpoint does, on a schedule, so fee data accrues without an admin ever
 // triggering it. Each tick drains the pending backlog in bounded batches
 // (the per-source gateway calls stay sequential), so the first run after a
-// deploy backfills all history over a few hours. Every failure is logged and
-// retried on the next tick — this worker must never take the API down.
+// deploy backfills all history over a few hours. Each tick then sweeps
+// account-level FEE transactions (fees billed against no movement we track —
+// see GatewayAccountFeeSweep): full history on the first run, incremental
+// with an overlap window after. Every failure is logged and retried on the
+// next tick — this worker must never take the API down.
 public class GatewayFeeSyncWorker(
   IServiceScopeFactory scopeFactory,
   ILogger<GatewayFeeSyncWorker> logger
@@ -45,6 +48,29 @@ public class GatewayFeeSyncWorker(
           logger.LogError(
             run.FailureOrDefault(),
             "Gateway fee sync run failed; retrying next tick"
+          );
+        }
+
+        // second sweep: account-level fees. Independent of the per-source
+        // drain above — one failing must not stop the other.
+        var sweep = scope.ServiceProvider.GetRequiredService<GatewayAccountFeeSweep>();
+        var swept = await sweep.Sweep(DateTime.UtcNow);
+        if (swept.IsSuccess())
+        {
+          var report = swept.SuccessOrDefault();
+          logger.LogInformation(
+            "Account-level gateway fee sweep complete: {Wrote} row(s) written for "
+              + "[{From}, {To})",
+            report.Wrote,
+            report.FromUtc,
+            report.ToUtc
+          );
+        }
+        else
+        {
+          logger.LogError(
+            swept.FailureOrDefault(),
+            "Account-level gateway fee sweep failed; retrying next tick"
           );
         }
       }

--- a/App/Modules/Users/API/V1/UserController.cs
+++ b/App/Modules/Users/API/V1/UserController.cs
@@ -7,6 +7,7 @@ using App.StartUp.Services.Auth;
 using App.Utility;
 using Asp.Versioning;
 using CSharp_Result;
+using Domain;
 using Domain.User;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -78,9 +79,16 @@ public class UserController(
     [FromServices] PartnerPnlQueryReqValidator partnerPnlValidator
   )
   {
+    // non-owners only see history from RangeClamp.NonOwnerFloor onward — a
+    // clamp, not an error (same gate as the booking analysis endpoints)
     var x = await partnerPnlValidator
       .ValidateAsyncResult(query, "Invalid PartnerPnlQueryReq")
-      .ThenAwait(q => partnerEconomicsRepo.Pnl(id, q.ToDomain()))
+      .ThenAwait(q =>
+        partnerEconomicsRepo.Pnl(
+          id,
+          q.ToDomain().ClampHistory(this.HasRoleIgnoreCase(AuthRoles.Owner))
+        )
+      )
       .Then(rows => rows.Select(r => r.ToRes()), Errors.MapAll);
     return this.ReturnResult(x);
   }

--- a/App/Modules/Users/API/V1/UserMapper.cs
+++ b/App/Modules/Users/API/V1/UserMapper.cs
@@ -26,7 +26,9 @@ public static class UserMapper
       row.KtmbCost,
       row.Deposits,
       row.WithdrawalGross,
-      row.WithdrawalFeeIncome
+      row.WithdrawalFeeIncome,
+      row.BoostCount,
+      row.BoostAmount
     );
 
   // REQ

--- a/App/Modules/Users/API/V1/UserModel.cs
+++ b/App/Modules/Users/API/V1/UserModel.cs
@@ -17,6 +17,8 @@ public record UserExistRes(bool Exists);
 
 public record PartnerUserRes(string Id, string Username, string Email);
 
+// Bookings is the full ticket count; BoostCount/BoostAmount cover the subset
+// with a consumed priority boost (appended fields — additive wire change)
 public record PartnerPnlRowRes(
   string Month,
   int Bookings,
@@ -24,7 +26,9 @@ public record PartnerPnlRowRes(
   decimal KtmbCost,
   decimal Deposits,
   decimal WithdrawalGross,
-  decimal WithdrawalFeeIncome
+  decimal WithdrawalFeeIncome,
+  int BoostCount,
+  decimal BoostAmount
 );
 
 // ExtraRoles: admin-managed roles for discount/pricing targeting — distinct

--- a/App/Modules/Users/Data/PartnerEconomicsRepository.cs
+++ b/App/Modules/Users/Data/PartnerEconomicsRepository.cs
@@ -41,6 +41,10 @@ public class PartnerEconomicsRepository(
     public decimal WithdrawalGross { get; set; }
 
     public decimal WithdrawalFeeIncome { get; set; }
+
+    public int BoostCount { get; set; }
+
+    public decimal BoostAmount { get; set; }
   }
 
   public async Task<Result<PartnerUser[]>> ListPartners()
@@ -125,7 +129,16 @@ public class PartnerEconomicsRepository(
             ) AS "KtmbCost",
             CAST(0 AS numeric) AS "Deposits",
             CAST(0 AS numeric) AS "WithdrawalGross",
-            CAST(0 AS numeric) AS "WithdrawalFeeIncome"
+            CAST(0 AS numeric) AS "WithdrawalFeeIncome",
+            CAST(
+              COUNT(*) FILTER (WHERE b."Priority" AND COALESCE(b."PriorityFee", 0) > 0) AS int
+            ) AS "BoostCount",
+            SUM(
+              CASE
+                WHEN b."Priority" AND COALESCE(b."PriorityFee", 0) > 0 THEN b."PriorityFee"
+                ELSE 0
+              END
+            ) AS "BoostAmount"
           FROM "Bookings" b
           JOIN wallet w ON w."UserId" = b."UserId"
           JOIN "Transactions" t ON t."Id" = b."TransactionId"
@@ -151,7 +164,9 @@ public class PartnerEconomicsRepository(
             CAST(0 AS numeric) AS "KtmbCost",
             SUM(p."CapturedAmount") AS "Deposits",
             CAST(0 AS numeric) AS "WithdrawalGross",
-            CAST(0 AS numeric) AS "WithdrawalFeeIncome"
+            CAST(0 AS numeric) AS "WithdrawalFeeIncome",
+            CAST(0 AS int) AS "BoostCount",
+            CAST(0 AS numeric) AS "BoostAmount"
           FROM "Payments" p
           JOIN wallet w ON w."Id" = p."WalletId"
           WHERE p."Status" = 'SUCCEEDED'
@@ -168,7 +183,9 @@ public class PartnerEconomicsRepository(
             CAST(0 AS numeric) AS "KtmbCost",
             CAST(0 AS numeric) AS "Deposits",
             SUM(x."Amount") AS "WithdrawalGross",
-            SUM(COALESCE(x."Fee", 0)) AS "WithdrawalFeeIncome"
+            SUM(COALESCE(x."Fee", 0)) AS "WithdrawalFeeIncome",
+            CAST(0 AS int) AS "BoostCount",
+            CAST(0 AS numeric) AS "BoostAmount"
           FROM "Withdrawals" x
           JOIN wallet w ON w."Id" = x."WalletId"
           WHERE x."Status" = {completedWithdrawal}
@@ -190,6 +207,8 @@ public class PartnerEconomicsRepository(
           Deposits = d.Deposits,
           WithdrawalGross = d.WithdrawalGross,
           WithdrawalFeeIncome = d.WithdrawalFeeIncome,
+          BoostCount = d.BoostCount,
+          BoostAmount = d.BoostAmount,
         }),
         query.After,
         query.Before

--- a/App/StartUp/Registry/AuthPolicies.cs
+++ b/App/StartUp/Registry/AuthPolicies.cs
@@ -12,4 +12,8 @@ public class AuthRoles
   public const string Field = "roles";
   public const string Admin = "admin";
   public const string Tin = "tin";
+
+  // unlocks full analysis/P&L history; admins without it are clamped to
+  // RangeClamp.NonOwnerFloor onward (matched case-insensitively)
+  public const string Owner = "owner";
 }

--- a/Domain/Booking/Analysis.cs
+++ b/Domain/Booking/Analysis.cs
@@ -90,7 +90,8 @@ public record GatewayFeeSummary
   // fees on captured payment intents (money in)
   public required decimal Payments { get; init; }
 
-  // fees on payout transfers + card refunds (money out)
+  // fees on money out: payout transfers + card refunds + account-level fee
+  // billings (SourceType Transfer, Refund and AccountFee)
   public required decimal Payouts { get; init; }
 
   public required GatewayFeeCoverage Coverage { get; init; }
@@ -576,6 +577,8 @@ public record PnlAnalysisDailySum
 
   public required decimal WithdrawalFeeIncome { get; init; }
 
+  // every synced gateway-fee row regardless of SourceType — payment,
+  // transfer, refund and account-level fee billings all count here
   public required decimal GatewayFees { get; init; }
 
   public required decimal TicketRevenue { get; init; }
@@ -673,7 +676,8 @@ public record PnlTerminalDailySum
   // gateway fees on captured payment intents (SourceType = Payment)
   public required decimal PaymentFees { get; init; }
 
-  // gateway fees on payouts (SourceType = Transfer or Refund)
+  // gateway fees on payouts (SourceType = Transfer, Refund or AccountFee —
+  // everything that is not a payment-intent fee)
   public required decimal PayoutFees { get; init; }
 
   public required int CompletedCount { get; init; }
@@ -758,7 +762,8 @@ public record PnlTerminalWithdrawals
 
   public required decimal FeeIncome { get; init; }
 
-  // gateway fees on payout transfers + card refunds in the month
+  // gateway fees on payout transfers + card refunds + account-level fee
+  // billings in the month (payoutFees = Transfer + Refund + AccountFee)
   public required decimal PayoutFees { get; init; }
 }
 

--- a/Domain/Booking/Analysis.cs
+++ b/Domain/Booking/Analysis.cs
@@ -87,11 +87,13 @@ public record GatewayFeeCoverage
 // bucketed by which direction the money moved
 public record GatewayFeeSummary
 {
-  // fees on captured payment intents (money in)
+  // fees on accepting money in: captured payment intents + account-level fee
+  // billings, which are dominated by per-attempt gateway/3DS fees (SourceType
+  // Payment and AccountFee — see GatewayFeeBuckets)
   public required decimal Payments { get; init; }
 
-  // fees on money out: payout transfers + card refunds + account-level fee
-  // billings (SourceType Transfer, Refund and AccountFee)
+  // fees on money out: payout transfers + card refunds ONLY (SourceType
+  // Transfer and Refund)
   public required decimal Payouts { get; init; }
 
   public required GatewayFeeCoverage Coverage { get; init; }
@@ -673,11 +675,13 @@ public record PnlTerminalDailySum
   // captured payment amounts (Payments.Status = 'SUCCEEDED')
   public required decimal Deposits { get; init; }
 
-  // gateway fees on captured payment intents (SourceType = Payment)
+  // gateway fees on accepting deposits (SourceType = Payment or AccountFee —
+  // account-level billings are dominated by per-attempt gateway/3DS fees, so
+  // the blended gwRate absorbs them and every terminal event carries its
+  // share pro-rata)
   public required decimal PaymentFees { get; init; }
 
-  // gateway fees on payouts (SourceType = Transfer, Refund or AccountFee —
-  // everything that is not a payment-intent fee)
+  // gateway fees on payouts (SourceType = Transfer or Refund ONLY)
   public required decimal PayoutFees { get; init; }
 
   public required int CompletedCount { get; init; }
@@ -762,8 +766,9 @@ public record PnlTerminalWithdrawals
 
   public required decimal FeeIncome { get; init; }
 
-  // gateway fees on payout transfers + card refunds + account-level fee
-  // billings in the month (payoutFees = Transfer + Refund + AccountFee)
+  // gateway fees on payout transfers + card refunds in the month
+  // (payoutFees = Transfer + Refund ONLY; account-level fee billings are
+  // payment-side and live in paymentFees / gwRate instead)
   public required decimal PayoutFees { get; init; }
 }
 
@@ -781,7 +786,9 @@ public record PnlTerminalRow
   public required decimal PaymentFees { get; init; }
 
   // the month's blended gateway rate: PaymentFees / Deposits (0 when the
-  // month has no deposits), rounded to 6dp
+  // month has no deposits), rounded to 6dp. PaymentFees includes the
+  // account-level fee billings, so every deposited dollar carries its share
+  // of those pro-rata too.
   public required decimal GwRate { get; init; }
 
   public required PnlTerminalCompleted Completed { get; init; }

--- a/Domain/Payment/GatewayFee.cs
+++ b/Domain/Payment/GatewayFee.cs
@@ -20,12 +20,30 @@ public enum GatewayFeeSourceType : byte
   Refund = 2,
 
   // an account-level FEE financial transaction with no owning money movement
-  // in our DB — e.g. Airwallex bills card-refund fees (S$0.30/refund) not on
-  // the refund's own financial transaction (fee = 0 there) but as aggregate
-  // FEE-type rows against an internal source (SourceId = the transaction's
-  // reported source_id). Captured by the account-fee sweep; counts as a
-  // payout-side fee in the analysis views.
+  // in our DB: Airwallex bills these as aggregate FEE-type rows against an
+  // internal source (SourceId = the transaction's reported source_id). A
+  // production sweep showed the batches are DOMINATED by per-payment-attempt
+  // fees (gateway + 3DS on every checkout attempt, including failed ones),
+  // with per-refund fees a small minority — so they are a cost of ACCEPTING
+  // DEPOSITS and count as payment-side fees in the analysis views (see
+  // GatewayFeeBuckets). Captured by the account-fee sweep.
   AccountFee = 3,
+}
+
+// Which side of the money flow a fee row belongs to in the analysis views.
+// Payment-side fees are costs of accepting deposits and feed the blended
+// gateway rate (gwRate = paymentFees / deposits); payout-side fees are costs
+// of moving money out (paid per transfer / card refund).
+public static class GatewayFeeBuckets
+{
+  // paymentFees = Payment + AccountFee (account-level billings are dominated
+  // by per-attempt gateway/3DS fees — deposit acceptance costs)
+  public static bool IsPaymentSide(GatewayFeeSourceType type) =>
+    type is GatewayFeeSourceType.Payment or GatewayFeeSourceType.AccountFee;
+
+  // payoutFees = Transfer + Refund ONLY
+  public static bool IsPayoutSide(GatewayFeeSourceType type) =>
+    type is GatewayFeeSourceType.Transfer or GatewayFeeSourceType.Refund;
 }
 
 // pure business data of one gateway financial transaction
@@ -326,10 +344,13 @@ public class GatewayFeeSyncRunner(
 //
 // The per-source sync above only finds fees reported against movements we
 // know (intents, transfers, refunds). Airwallex also bills account-level
-// fees — e.g. the S$0.30 card-refund fee arrives not on the refund's own
-// financial transaction but as an aggregate FEE-type transaction with no
-// owning source we track. This sweep lists FEE-type financial transactions
-// over a created-at window and upserts them as SourceType = AccountFee.
+// fees as aggregate FEE-type transactions with no owning source we track —
+// dominated by per-payment-attempt fees (gateway + 3DS on every checkout
+// attempt, including failed ones), plus smaller items like the S$0.30
+// card-refund fee (which never lands on the refund's own financial
+// transaction; fee = 0 there). This sweep lists FEE-type financial
+// transactions over a created-at window and upserts them as
+// SourceType = AccountFee.
 
 // one account-level FEE-type financial transaction as the gateway reports it
 public record GatewayAccountFeeLine

--- a/Domain/Payment/GatewayFee.cs
+++ b/Domain/Payment/GatewayFee.cs
@@ -18,6 +18,14 @@ public enum GatewayFeeSourceType : byte
 
   // a card-refund fragment (WithdrawalRefundData.AirwallexRefundId)
   Refund = 2,
+
+  // an account-level FEE financial transaction with no owning money movement
+  // in our DB — e.g. Airwallex bills card-refund fees (S$0.30/refund) not on
+  // the refund's own financial transaction (fee = 0 there) but as aggregate
+  // FEE-type rows against an internal source (SourceId = the transaction's
+  // reported source_id). Captured by the account-fee sweep; counts as a
+  // payout-side fee in the analysis views.
+  AccountFee = 3,
 }
 
 // pure business data of one gateway financial transaction
@@ -108,6 +116,10 @@ public interface IGatewayFeeRepository
   // idempotent by FinancialTransactionId: existing rows are refreshed,
   // unseen rows inserted (see GatewayFeePlanner). Returns rows written.
   Task<Result<int>> Upsert(IEnumerable<GatewayFeeRecord> records);
+
+  // latest TransactedAt among stored AccountFee rows — the account-fee
+  // sweep's incremental watermark; null = never swept (sweep full history)
+  Task<Result<DateTime?>> LatestAccountFeeTransactedAt();
 }
 
 // fee lines for one pending source, straight from the gateway; empty = the
@@ -307,5 +319,126 @@ public class GatewayFeeSyncRunner(
       Synced = synced,
       Missing = missing.Count,
     };
+  }
+}
+
+// ---- account-level fee sweep ----
+//
+// The per-source sync above only finds fees reported against movements we
+// know (intents, transfers, refunds). Airwallex also bills account-level
+// fees — e.g. the S$0.30 card-refund fee arrives not on the refund's own
+// financial transaction but as an aggregate FEE-type transaction with no
+// owning source we track. This sweep lists FEE-type financial transactions
+// over a created-at window and upserts them as SourceType = AccountFee.
+
+// one account-level FEE-type financial transaction as the gateway reports it
+public record GatewayAccountFeeLine
+{
+  // the gateway's own source_id for the fee (an internal billing object,
+  // not a movement we track); empty when the gateway reports none
+  public required string SourceId { get; init; }
+
+  public required string FinancialTransactionId { get; init; }
+
+  public required decimal Amount { get; init; }
+
+  public required decimal Net { get; init; }
+
+  public required string Currency { get; init; }
+
+  public required DateTime TransactedAt { get; init; }
+}
+
+// FEE-type financial transactions created in [fromUtc, toUtc), straight from
+// the gateway's ledger
+public interface IGatewayAccountFeeSource
+{
+  Task<Result<IEnumerable<GatewayAccountFeeLine>>> InRange(DateTime fromUtc, DateTime toUtc);
+}
+
+// Pure window/mapping rules, shared by the sweep service and the unit tests.
+public static class GatewayAccountFeePlanner
+{
+  // re-read this much before the watermark every sweep: financial
+  // transactions can post with delay, and the idempotent upsert makes the
+  // overlap a refresh, never a duplicate
+  public static readonly TimeSpan Overlap = TimeSpan.FromDays(3);
+
+  // first-run "full history" floor — safely before the Airwallex account
+  // existed, so the first sweep captures everything ever billed
+  public static readonly DateTime FullHistoryStartUtc = new(
+    2020,
+    1,
+    1,
+    0,
+    0,
+    0,
+    DateTimeKind.Utc
+  );
+
+  public static DateTime WindowStart(DateTime? watermarkUtc) =>
+    watermarkUtc is { } w ? w - Overlap : FullHistoryStartUtc;
+
+  // account fees post as negative amounts (money leaving the account); the
+  // stored Fee is the positive fee take, Amount/Net stay as reported
+  public static GatewayFeeRecord ToRecord(GatewayAccountFeeLine line) =>
+    new()
+    {
+      SourceId = line.SourceId,
+      SourceType = GatewayFeeSourceType.AccountFee,
+      FinancialTransactionId = line.FinancialTransactionId,
+      Amount = line.Amount,
+      Fee = Math.Abs(line.Amount),
+      Net = line.Net,
+      Currency = line.Currency,
+      TransactedAt = line.TransactedAt,
+    };
+}
+
+public record GatewayAccountFeeSweepReport
+{
+  public required DateTime FromUtc { get; init; }
+
+  public required DateTime ToUtc { get; init; }
+
+  // rows written (inserted or refreshed) this sweep
+  public required int Wrote { get; init; }
+}
+
+// Sweep driver: full history on the first run (no AccountFee rows yet), then
+// incremental from the stored watermark minus an overlap window for late
+// postings — the idempotent upsert dedupes whatever the overlap re-reads.
+public class GatewayAccountFeeSweep(
+  IGatewayFeeRepository repo,
+  IGatewayAccountFeeSource gateway,
+  ILogger<GatewayAccountFeeSweep> logger
+)
+{
+  public async Task<Result<GatewayAccountFeeSweepReport>> Sweep(DateTime nowUtc)
+  {
+    return await repo
+      .LatestAccountFeeTransactedAt()
+      .ThenAwait(watermark =>
+      {
+        var from = GatewayAccountFeePlanner.WindowStart(watermark);
+        logger.LogInformation(
+          "Sweeping account-level gateway fees in [{From}, {To}) (watermark: {Watermark})",
+          from,
+          nowUtc,
+          watermark
+        );
+        return gateway
+          .InRange(from, nowUtc)
+          .ThenAwait(lines => repo.Upsert(lines.Select(GatewayAccountFeePlanner.ToRecord)))
+          .Then(
+            wrote => new GatewayAccountFeeSweepReport
+            {
+              FromUtc = from,
+              ToUtc = nowUtc,
+              Wrote = wrote,
+            },
+            Errors.MapNone
+          );
+      });
   }
 }

--- a/Domain/RangeClamp.cs
+++ b/Domain/RangeClamp.cs
@@ -1,0 +1,67 @@
+using Domain.Booking;
+using Domain.User;
+
+namespace Domain;
+
+// Owner-only history gate for the analysis/P&L read models: callers without
+// the 'owner' role may only see data from June 2026 (SGT) onward. The gate is
+// a server-side CLAMP, never an error — the effective After becomes
+// max(requested After, NonOwnerFloor); Before is left alone, so a range that
+// ends before the floor turns into an empty range (After > Before) and every
+// repository/calculator naturally returns nothing for it.
+public static class RangeClamp
+{
+  // first SGT calendar date non-owners may see
+  public static readonly DateOnly NonOwnerFloor = new(2026, 6, 1);
+
+  public static (DateOnly? After, DateOnly? Before) Clamp(
+    DateOnly? after,
+    DateOnly? before,
+    bool fullHistory
+  ) =>
+    fullHistory
+      ? (after, before)
+      : (after is null || after < NonOwnerFloor ? NonOwnerFloor : after, before);
+
+  public static BookingAnalysisQuery ClampHistory(this BookingAnalysisQuery q, bool fullHistory)
+  {
+    var (after, before) = Clamp(q.After, q.Before, fullHistory);
+    return q with { After = after, Before = before };
+  }
+
+  public static TravelAnalysisQuery ClampHistory(this TravelAnalysisQuery q, bool fullHistory)
+  {
+    var (after, before) = Clamp(q.After, q.Before, fullHistory);
+    return q with { After = after, Before = before };
+  }
+
+  public static ProfitAnalysisQuery ClampHistory(this ProfitAnalysisQuery q, bool fullHistory)
+  {
+    var (after, before) = Clamp(q.After, q.Before, fullHistory);
+    return q with { After = after, Before = before };
+  }
+
+  public static PnlAnalysisQuery ClampHistory(this PnlAnalysisQuery q, bool fullHistory)
+  {
+    var (after, before) = Clamp(q.After, q.Before, fullHistory);
+    return q with { After = after, Before = before };
+  }
+
+  public static PnlTerminalQuery ClampHistory(this PnlTerminalQuery q, bool fullHistory)
+  {
+    var (after, before) = Clamp(q.After, q.Before, fullHistory);
+    return q with { After = after, Before = before };
+  }
+
+  public static BookingBoostQuery ClampHistory(this BookingBoostQuery q, bool fullHistory)
+  {
+    var (after, before) = Clamp(q.After, q.Before, fullHistory);
+    return q with { After = after, Before = before };
+  }
+
+  public static PartnerPnlQuery ClampHistory(this PartnerPnlQuery q, bool fullHistory)
+  {
+    var (after, before) = Clamp(q.After, q.Before, fullHistory);
+    return q with { After = after, Before = before };
+  }
+}

--- a/Domain/User/PartnerEconomics.cs
+++ b/Domain/User/PartnerEconomics.cs
@@ -31,6 +31,12 @@ public record PartnerPnlDailySum
 
   public required int Bookings { get; init; }
 
+  // completed bookings with a consumed priority boost (Priority && a positive
+  // PriorityFee — the same guard the analysis page uses) and their fee sum
+  public required int BoostCount { get; init; }
+
+  public required decimal BoostAmount { get; init; }
+
   public required decimal Collected { get; init; }
 
   public required decimal KtmbCost { get; init; }
@@ -59,6 +65,12 @@ public record PartnerPnlRow
   public required decimal WithdrawalGross { get; init; }
 
   public required decimal WithdrawalFeeIncome { get; init; }
+
+  // completed bookings that month with a consumed priority boost, and the
+  // priority fees they kept — Bookings stays the full ticket count
+  public required int BoostCount { get; init; }
+
+  public required decimal BoostAmount { get; init; }
 }
 
 public static class PartnerPnlCalculator
@@ -81,6 +93,8 @@ public static class PartnerPnlCalculator
           Deposits = g.Sum(d => d.Deposits),
           WithdrawalGross = g.Sum(d => d.WithdrawalGross),
           WithdrawalFeeIncome = g.Sum(d => d.WithdrawalFeeIncome),
+          BoostCount = g.Sum(d => d.BoostCount),
+          BoostAmount = g.Sum(d => d.BoostAmount),
         })
         .Where(r =>
           r.Bookings != 0
@@ -89,6 +103,8 @@ public static class PartnerPnlCalculator
           || r.Deposits != 0m
           || r.WithdrawalGross != 0m
           || r.WithdrawalFeeIncome != 0m
+          || r.BoostCount != 0
+          || r.BoostAmount != 0m
         )
         .OrderBy(r => r.Month[3..])
         .ThenBy(r => r.Month[..2]),

--- a/UnitTest/Bookings/RangeClampTests.cs
+++ b/UnitTest/Bookings/RangeClampTests.cs
@@ -1,0 +1,88 @@
+using Domain;
+using FluentAssertions;
+
+namespace UnitTest.Bookings;
+
+// The owner-only history gate: non-owners are clamped to NonOwnerFloor
+// onward (a clamp, never an error), owners pass through untouched. A range
+// that ends before the floor becomes After > Before, which every repository
+// and calculator treats as empty.
+public class RangeClampTests
+{
+  private static readonly DateOnly Floor = RangeClamp.NonOwnerFloor;
+
+  [Fact]
+  public void The_floor_is_june_2026()
+  {
+    Floor.Should().Be(new DateOnly(2026, 6, 1));
+  }
+
+  [Fact]
+  public void Owners_pass_through_untouched()
+  {
+    var (after, before) = RangeClamp.Clamp(new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31), true);
+
+    after.Should().Be(new DateOnly(2024, 1, 1));
+    before.Should().Be(new DateOnly(2024, 12, 31));
+  }
+
+  [Fact]
+  public void Owners_keep_unbounded_ranges()
+  {
+    var (after, before) = RangeClamp.Clamp(null, null, true);
+
+    after.Should().BeNull();
+    before.Should().BeNull();
+  }
+
+  [Fact]
+  public void Non_owner_unbounded_after_becomes_the_floor()
+  {
+    var (after, before) = RangeClamp.Clamp(null, null, false);
+
+    after.Should().Be(Floor);
+    before.Should().BeNull();
+  }
+
+  [Fact]
+  public void Non_owner_after_before_the_floor_is_raised_to_it()
+  {
+    var (after, _) = RangeClamp.Clamp(new DateOnly(2025, 1, 1), null, false);
+
+    after.Should().Be(Floor);
+  }
+
+  [Fact]
+  public void Non_owner_after_on_or_past_the_floor_is_kept()
+  {
+    var (atFloor, _) = RangeClamp.Clamp(Floor, null, false);
+    var (past, _) = RangeClamp.Clamp(new DateOnly(2026, 7, 2), null, false);
+
+    atFloor.Should().Be(Floor);
+    past.Should().Be(new DateOnly(2026, 7, 2));
+  }
+
+  [Fact]
+  public void Non_owner_range_ending_before_the_floor_becomes_empty_not_an_error()
+  {
+    var (after, before) = RangeClamp.Clamp(
+      new DateOnly(2025, 1, 1),
+      new DateOnly(2025, 12, 31),
+      false
+    );
+
+    // Before stays put and After overtakes it — the empty range the repos
+    // and calculators naturally answer with no rows
+    after.Should().Be(Floor);
+    before.Should().Be(new DateOnly(2025, 12, 31));
+    (after > before).Should().BeTrue();
+  }
+
+  [Fact]
+  public void Non_owner_before_is_never_moved()
+  {
+    var (_, before) = RangeClamp.Clamp(null, new DateOnly(2026, 8, 15), false);
+
+    before.Should().Be(new DateOnly(2026, 8, 15));
+  }
+}

--- a/UnitTest/Payments/AirwallexAccountFeeSourceTests.cs
+++ b/UnitTest/Payments/AirwallexAccountFeeSourceTests.cs
@@ -9,10 +9,11 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace UnitTest.Payments;
 
 // The account-level fee listing: FEE-type financial transactions over a
-// created-at window (Airwallex bills e.g. card-refund fees as aggregate FEE
-// rows owned by no movement we track). The adapter must ask the ledger with
-// transaction_type + from/to_created_at, follow page_num until has_more is
-// false, and keep only FEE rows even if the gateway answers leniently.
+// created-at window (Airwallex bills per-attempt gateway/3DS fees and
+// per-refund fees as aggregate FEE rows owned by no movement we track). The
+// adapter must ask the ledger with transaction_type + from/to_created_at,
+// follow page_num until has_more is false, and keep only FEE rows even if
+// the gateway answers leniently.
 public class AirwallexAccountFeeSourceTests
 {
   private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> answer)

--- a/UnitTest/Payments/AirwallexAccountFeeSourceTests.cs
+++ b/UnitTest/Payments/AirwallexAccountFeeSourceTests.cs
@@ -1,0 +1,164 @@
+using System.Net;
+using System.Text;
+using App.Modules.Payments.Airwallex;
+using CSharp_Result;
+using Domain.Payment;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace UnitTest.Payments;
+
+// The account-level fee listing: FEE-type financial transactions over a
+// created-at window (Airwallex bills e.g. card-refund fees as aggregate FEE
+// rows owned by no movement we track). The adapter must ask the ledger with
+// transaction_type + from/to_created_at, follow page_num until has_more is
+// false, and keep only FEE rows even if the gateway answers leniently.
+public class AirwallexAccountFeeSourceTests
+{
+  private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> answer)
+    : HttpMessageHandler
+  {
+    public List<string> Requests { get; } = [];
+
+    protected override Task<HttpResponseMessage> SendAsync(
+      HttpRequestMessage request,
+      CancellationToken cancellationToken
+    )
+    {
+      this.Requests.Add(request.RequestUri!.PathAndQuery);
+      return Task.FromResult(answer(request));
+    }
+  }
+
+  private sealed class StubFactory(HttpMessageHandler handler) : IHttpClientFactory
+  {
+    public HttpClient CreateClient(string name) =>
+      new(handler, disposeHandler: false) { BaseAddress = new Uri("https://gateway.test/") };
+  }
+
+  private sealed class StubAuthenticator : IGatewayAuthenticator
+  {
+    public Task<Result<string>> GetToken() => Task.FromResult("token".ToResult());
+  }
+
+  private static HttpResponseMessage Json(string body, HttpStatusCode status = HttpStatusCode.OK) =>
+    new(status) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+  private static AirwallexAccountFeeSource Source(StubHandler handler) =>
+    new(
+      new AirWallexClient(
+        new StubFactory(handler),
+        new StubAuthenticator(),
+        NullLogger<AirWallexClient>.Instance
+      )
+    );
+
+  private static readonly DateTime From = new(2026, 7, 10, 0, 0, 0, DateTimeKind.Utc);
+  private static readonly DateTime To = new(2026, 7, 15, 1, 0, 0, DateTimeKind.Utc);
+
+  [Fact]
+  public async Task The_ledger_is_asked_for_fee_rows_in_the_window()
+  {
+    var handler = new StubHandler(_ =>
+      Json(
+        """
+        {"has_more":false,"items":[{"id":"ft_1","source_id":"fbl_1",
+        "transaction_type":"FEE","amount":-61,"fee":0,"net":-61,
+        "currency":"SGD","created_at":"2026-07-14T00:00:00Z"}]}
+        """
+      )
+    );
+
+    var r = await Source(handler).InRange(From, To);
+
+    var lines = r.SuccessOrDefault().ToArray();
+    lines.Should().ContainSingle();
+    lines[0].FinancialTransactionId.Should().Be("ft_1");
+    lines[0].SourceId.Should().Be("fbl_1");
+    lines[0].Amount.Should().Be(-61m);
+    lines[0].TransactedAt.Kind.Should().Be(DateTimeKind.Utc);
+    handler.Requests.Should().Equal(
+      "/api/v1/financial_transactions?transaction_type=FEE"
+        + "&from_created_at=2026-07-10T00%3A00%3A00Z&to_created_at=2026-07-15T01%3A00%3A00Z"
+        + "&page_num=0&page_size=100"
+    );
+  }
+
+  [Fact]
+  public async Task Paging_follows_until_has_more_is_false()
+  {
+    var handler = new StubHandler(req =>
+      req.RequestUri!.Query.Contains("page_num=0")
+        ? Json(
+          """
+          {"has_more":true,"items":[{"id":"ft_1","source_id":"fbl_1",
+          "transaction_type":"FEE","amount":-1,"fee":0,"net":-1,
+          "currency":"SGD","created_at":"2026-07-13T00:00:00Z"}]}
+          """
+        )
+        : Json(
+          """
+          {"has_more":false,"items":[{"id":"ft_2","source_id":"fbl_2",
+          "transaction_type":"FEE","amount":-2,"fee":0,"net":-2,
+          "currency":"SGD","created_at":"2026-07-14T00:00:00Z"}]}
+          """
+        )
+    );
+
+    var r = await Source(handler).InRange(From, To);
+
+    r.SuccessOrDefault().Select(x => x.FinancialTransactionId).Should().Equal("ft_1", "ft_2");
+    handler.Requests.Should().HaveCount(2);
+  }
+
+  [Fact]
+  public async Task Non_fee_rows_are_dropped_even_if_the_gateway_answers_leniently()
+  {
+    var handler = new StubHandler(_ =>
+      Json(
+        """
+        {"has_more":false,"items":[
+        {"id":"ft_fee","source_id":"fbl_1","transaction_type":"fee",
+        "amount":-1,"fee":0,"net":-1,"currency":"SGD","created_at":"2026-07-13T00:00:00Z"},
+        {"id":"ft_payout","source_id":"po_1","transaction_type":"PAYOUT",
+        "amount":-50,"fee":0.2,"net":-50.2,"currency":"SGD","created_at":"2026-07-13T00:00:00Z"}
+        ]}
+        """
+      )
+    );
+
+    var r = await Source(handler).InRange(From, To);
+
+    // the FEE match is case-insensitive; everything else is dropped
+    r.SuccessOrDefault().Should().ContainSingle(x => x.FinancialTransactionId == "ft_fee");
+  }
+
+  [Fact]
+  public async Task A_missing_source_id_stores_as_empty_never_null()
+  {
+    var handler = new StubHandler(_ =>
+      Json(
+        """
+        {"has_more":false,"items":[{"id":"ft_1","transaction_type":"FEE",
+        "amount":-1,"fee":0,"net":-1,"currency":"SGD","created_at":"2026-07-13T00:00:00Z"}]}
+        """
+      )
+    );
+
+    var r = await Source(handler).InRange(From, To);
+
+    r.SuccessOrDefault().Single().SourceId.Should().Be(string.Empty);
+  }
+
+  [Fact]
+  public async Task A_failed_listing_is_a_failure_not_an_empty_answer()
+  {
+    var handler = new StubHandler(_ =>
+      Json("""{"code":"boom"}""", HttpStatusCode.InternalServerError)
+    );
+
+    var r = await Source(handler).InRange(From, To);
+
+    r.IsFailure().Should().BeTrue();
+  }
+}

--- a/UnitTest/Payments/GatewayAccountFeeSweepTests.cs
+++ b/UnitTest/Payments/GatewayAccountFeeSweepTests.cs
@@ -1,0 +1,159 @@
+using CSharp_Result;
+using Domain.Payment;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace UnitTest.Payments;
+
+// The account-level fee sweep: full history on the first run (no watermark),
+// incremental from the watermark minus the overlap window after, and each
+// FEE-type line stored as SourceType = AccountFee with Fee = |amount| while
+// Amount/Net stay as the gateway reported them.
+public class GatewayAccountFeeSweepTests
+{
+  private static GatewayAccountFeeLine Line(
+    string ftId,
+    decimal amount = -61m,
+    string sourceId = "fbl_1"
+  ) =>
+    new()
+    {
+      SourceId = sourceId,
+      FinancialTransactionId = ftId,
+      Amount = amount,
+      Net = amount,
+      Currency = "SGD",
+      TransactedAt = new DateTime(2026, 7, 14, 0, 0, 0, DateTimeKind.Utc),
+    };
+
+  // ---- GatewayAccountFeePlanner (pure window + mapping rules) ----
+
+  [Fact]
+  public void First_run_sweeps_full_history()
+  {
+    GatewayAccountFeePlanner.WindowStart(null)
+      .Should()
+      .Be(GatewayAccountFeePlanner.FullHistoryStartUtc);
+  }
+
+  [Fact]
+  public void Later_runs_sweep_from_the_watermark_minus_the_overlap()
+  {
+    var watermark = new DateTime(2026, 7, 14, 12, 0, 0, DateTimeKind.Utc);
+
+    GatewayAccountFeePlanner.WindowStart(watermark)
+      .Should()
+      .Be(watermark - GatewayAccountFeePlanner.Overlap);
+  }
+
+  [Fact]
+  public void Lines_store_as_account_fees_with_the_absolute_amount_as_the_fee()
+  {
+    var record = GatewayAccountFeePlanner.ToRecord(Line("ft_1", amount: -61m));
+
+    record.SourceType.Should().Be(GatewayFeeSourceType.AccountFee);
+    record.SourceId.Should().Be("fbl_1");
+    record.FinancialTransactionId.Should().Be("ft_1");
+    record.Fee.Should().Be(61m, "the fee take is stored positive");
+    record.Amount.Should().Be(-61m, "amount stays as the gateway reported it");
+    record.Net.Should().Be(-61m, "net stays as the gateway reported it");
+  }
+
+  // ---- GatewayAccountFeeSweep (driver) ----
+
+  private sealed class FakeRepo : IGatewayFeeRepository
+  {
+    public DateTime? Watermark { get; init; }
+    public List<GatewayFeeRecord> Upserted { get; } = [];
+
+    public Task<Result<IEnumerable<PendingFeeSource>>> ListPendingSources(
+      DateTime after,
+      DateTime before,
+      IReadOnlyCollection<string> exclude,
+      int max
+    ) => Task.FromResult(Array.Empty<PendingFeeSource>().AsEnumerable().ToResult());
+
+    public Task<Result<int>> Upsert(IEnumerable<GatewayFeeRecord> records)
+    {
+      var r = records.ToArray();
+      this.Upserted.AddRange(r);
+      return Task.FromResult((Result<int>)r.Length);
+    }
+
+    public Task<Result<DateTime?>> LatestAccountFeeTransactedAt() =>
+      Task.FromResult((Result<DateTime?>)this.Watermark);
+  }
+
+  private sealed class FakeGateway(
+    Func<DateTime, DateTime, Result<IEnumerable<GatewayAccountFeeLine>>> answer
+  ) : IGatewayAccountFeeSource
+  {
+    public List<(DateTime From, DateTime To)> Calls { get; } = [];
+
+    public Task<Result<IEnumerable<GatewayAccountFeeLine>>> InRange(
+      DateTime fromUtc,
+      DateTime toUtc
+    )
+    {
+      this.Calls.Add((fromUtc, toUtc));
+      return Task.FromResult(answer(fromUtc, toUtc));
+    }
+  }
+
+  private static GatewayAccountFeeSweep Sweep(FakeRepo repo, FakeGateway gateway) =>
+    new(repo, gateway, NullLogger<GatewayAccountFeeSweep>.Instance);
+
+  [Fact]
+  public async Task First_sweep_covers_full_history_and_writes_every_line()
+  {
+    var repo = new FakeRepo();
+    var gateway = new FakeGateway((_, _) =>
+      new[] { Line("ft_1"), Line("ft_2", amount: -0.3m, sourceId: "fbl_2") }
+        .AsEnumerable()
+        .ToResult()
+    );
+    var now = new DateTime(2026, 7, 15, 1, 0, 0, DateTimeKind.Utc);
+
+    var r = await Sweep(repo, gateway).Sweep(now);
+
+    r.IsSuccess().Should().BeTrue();
+    var report = r.SuccessOrDefault();
+    report.FromUtc.Should().Be(GatewayAccountFeePlanner.FullHistoryStartUtc);
+    report.ToUtc.Should().Be(now);
+    report.Wrote.Should().Be(2);
+    repo.Upserted.Should().HaveCount(2);
+    repo.Upserted.Should().OnlyContain(x => x.SourceType == GatewayFeeSourceType.AccountFee);
+  }
+
+  [Fact]
+  public async Task Incremental_sweep_asks_from_the_watermark_minus_the_overlap()
+  {
+    var watermark = new DateTime(2026, 7, 10, 0, 0, 0, DateTimeKind.Utc);
+    var repo = new FakeRepo { Watermark = watermark };
+    var gateway = new FakeGateway((_, _) =>
+      Array.Empty<GatewayAccountFeeLine>().AsEnumerable().ToResult()
+    );
+    var now = new DateTime(2026, 7, 15, 1, 0, 0, DateTimeKind.Utc);
+
+    var r = await Sweep(repo, gateway).Sweep(now);
+
+    r.IsSuccess().Should().BeTrue();
+    gateway.Calls.Should().ContainSingle();
+    gateway.Calls[0].From.Should().Be(watermark - GatewayAccountFeePlanner.Overlap);
+    gateway.Calls[0].To.Should().Be(now);
+    r.SuccessOrDefault().Wrote.Should().Be(0, "an empty window is a normal answer");
+  }
+
+  [Fact]
+  public async Task A_failed_gateway_listing_fails_the_sweep_without_writing()
+  {
+    var repo = new FakeRepo();
+    var gateway = new FakeGateway((_, _) => new HttpRequestException("boom"));
+
+    var r = await Sweep(repo, gateway)
+      .Sweep(new DateTime(2026, 7, 15, 1, 0, 0, DateTimeKind.Utc));
+
+    r.IsSuccess().Should().BeFalse();
+    repo.Upserted.Should().BeEmpty();
+  }
+}

--- a/UnitTest/Payments/GatewayFeeBucketsTests.cs
+++ b/UnitTest/Payments/GatewayFeeBucketsTests.cs
@@ -1,0 +1,41 @@
+using Domain.Payment;
+using FluentAssertions;
+
+namespace UnitTest.Payments;
+
+// Pins the payments-vs-payouts fee attribution the analysis views bucket by:
+// paymentFees = Payment + AccountFee (account-level billings are dominated by
+// per-attempt gateway/3DS fees — costs of ACCEPTING deposits, absorbed by the
+// blended gwRate), payoutFees = Transfer + Refund ONLY. Every source type
+// must land in exactly one bucket.
+public class GatewayFeeBucketsTests
+{
+  [Theory]
+  [InlineData(GatewayFeeSourceType.Payment, true)]
+  [InlineData(GatewayFeeSourceType.AccountFee, true)]
+  [InlineData(GatewayFeeSourceType.Transfer, false)]
+  [InlineData(GatewayFeeSourceType.Refund, false)]
+  public void Payment_side_is_payment_plus_account_fee(GatewayFeeSourceType type, bool expected)
+  {
+    GatewayFeeBuckets.IsPaymentSide(type).Should().Be(expected);
+  }
+
+  [Theory]
+  [InlineData(GatewayFeeSourceType.Payment, false)]
+  [InlineData(GatewayFeeSourceType.AccountFee, false)]
+  [InlineData(GatewayFeeSourceType.Transfer, true)]
+  [InlineData(GatewayFeeSourceType.Refund, true)]
+  public void Payout_side_is_transfer_plus_refund_only(GatewayFeeSourceType type, bool expected)
+  {
+    GatewayFeeBuckets.IsPayoutSide(type).Should().Be(expected);
+  }
+
+  [Fact]
+  public void Every_source_type_lands_in_exactly_one_bucket()
+  {
+    foreach (var type in Enum.GetValues<GatewayFeeSourceType>())
+      (GatewayFeeBuckets.IsPaymentSide(type) ^ GatewayFeeBuckets.IsPayoutSide(type))
+        .Should()
+        .BeTrue($"{type} must be exactly one of payment-side / payout-side");
+  }
+}

--- a/UnitTest/Payments/GatewayFeeSyncTests.cs
+++ b/UnitTest/Payments/GatewayFeeSyncTests.cs
@@ -103,6 +103,14 @@ public class GatewayFeeSyncTests
       this.Upserted.AddRange(r);
       return Task.FromResult((Result<int>)r.Length);
     }
+
+    public Task<Result<DateTime?>> LatestAccountFeeTransactedAt() =>
+      Task.FromResult(
+        (Result<DateTime?>)
+          this.Upserted.Where(x => x.SourceType == GatewayFeeSourceType.AccountFee)
+            .Select(x => (DateTime?)x.TransactedAt)
+            .Max()
+      );
   }
 
   private sealed class FakeGateway(Func<string, Result<IEnumerable<GatewayFeeLine>>> answer)

--- a/UnitTest/Users/PartnerEconomicsWireContractTests.cs
+++ b/UnitTest/Users/PartnerEconomicsWireContractTests.cs
@@ -40,6 +40,8 @@ public class PartnerEconomicsWireContractTests
         Deposits = 200m,
         WithdrawalGross = 90m,
         WithdrawalFeeIncome = 4m,
+        BoostCount = 2,
+        BoostAmount = 9.9m,
       },
     };
 
@@ -49,7 +51,7 @@ public class PartnerEconomicsWireContractTests
       .Be(
         "[{\"month\":\"08-2026\",\"bookings\":3,\"collected\":135.5,"
           + "\"ktmbCost\":61.2,\"deposits\":200,\"withdrawalGross\":90,"
-          + "\"withdrawalFeeIncome\":4}]"
+          + "\"withdrawalFeeIncome\":4,\"boostCount\":2,\"boostAmount\":9.9}]"
       );
   }
 

--- a/UnitTest/Users/PartnerPnlCalculatorTests.cs
+++ b/UnitTest/Users/PartnerPnlCalculatorTests.cs
@@ -14,7 +14,9 @@ public class PartnerPnlCalculatorTests
     decimal ktmbCost = 0m,
     decimal deposits = 0m,
     decimal withdrawalGross = 0m,
-    decimal withdrawalFeeIncome = 0m
+    decimal withdrawalFeeIncome = 0m,
+    int boostCount = 0,
+    decimal boostAmount = 0m
   ) =>
     new()
     {
@@ -25,6 +27,8 @@ public class PartnerPnlCalculatorTests
       Deposits = deposits,
       WithdrawalGross = withdrawalGross,
       WithdrawalFeeIncome = withdrawalFeeIncome,
+      BoostCount = boostCount,
+      BoostAmount = boostAmount,
     };
 
   [Fact]
@@ -38,7 +42,14 @@ public class PartnerPnlCalculatorTests
           withdrawalGross: 90m,
           withdrawalFeeIncome: 4m
         ),
-        Day(new DateOnly(2026, 8, 31), bookings: 3, collected: 135m, ktmbCost: 61.2m),
+        Day(
+          new DateOnly(2026, 8, 31),
+          bookings: 3,
+          collected: 135m,
+          ktmbCost: 61.2m,
+          boostCount: 2,
+          boostAmount: 9.9m
+        ),
       ],
       null,
       null
@@ -57,6 +68,8 @@ public class PartnerPnlCalculatorTests
           Deposits = 200m,
           WithdrawalGross = 90m,
           WithdrawalFeeIncome = 4m,
+          BoostCount = 2,
+          BoostAmount = 9.9m,
         }
       );
   }


### PR DESCRIPTION
Three related backend P&L refinements, one PR.

## 1. Partner boost/ticket counts on `GET /User/{id}/pnl`

Additive wire change (frontend is being built against it in parallel): each monthly row gains

- `boostCount` (int) — completed bookings that month with a consumed priority boost, i.e. the same guard the analysis uses: `Priority && PriorityFee > 0`
- `boostAmount` (decimal) — sum of those bookings' `PriorityFee`

`bookings` stays the full ticket count. Same attribution as the existing row (wallet-scoped completed bookings, SGT `CompletedAt` month). Wire-pin test updated; fields are appended so existing consumers are untouched.

## 2. Airwallex account-level fee capture

Verified live: Airwallex bills account-level fees **not** on the owning movement's financial transaction but as aggregate FEE-type financial transactions with no owning source we track (observed: `source_id 'fbl_5PkDZlfKNgOYeT8PpZOj4g'`, amount −61.00 SGD on 2026-07-14). A full production sweep (747 rows, −S$2,575.91 since 2024-03) showed these batches are **dominated by per-payment-attempt fees** (gateway + 3DS on every checkout attempt, including failed ones), with per-refund fees (S$0.30/refund) a small minority — days with 8–13 refunds bill the same S$40–60 as zero-refund days.

Design:

- new `GatewayFeeSourceType.AccountFee = 3`
- the hourly `GatewayFeeSyncWorker` gains a **second sweep** after the per-source drain: `GET /api/v1/financial_transactions?transaction_type=FEE&from_created_at=...&to_created_at=...` (same endpoint/paging the per-source listing already uses), upserted keyed by `FinancialTransactionId` with `SourceType = AccountFee`, `SourceId` = the transaction's reported `source_id`, `Fee = ABS(amount)`, `Amount`/`Net` as reported
- **full history on first run** (no AccountFee rows → sweep from 2020-01-01), then **incremental**: watermark = max stored AccountFee `TransactedAt`, re-read with a 3-day overlap for late postings; the existing idempotent upsert dedupes the overlap

**Attribution** (`GatewayFeeBuckets`, since account-level fees are a cost of ACCEPTING DEPOSITS, not a payout cost):

- `GET /Booking/pnl/terminal`: **`paymentFees` = Payment + AccountFee** — so `gwRate = (payment + account fees) / deposits` absorbs them and every terminal event carries its share pro-rata; **`payoutFees` = Transfer + Refund ONLY**
- `GET /Booking/analysis`: the payments-vs-payouts fee bucketing (range summary + monthly rollup) mirrors the same split
- `GET /Booking/analysis/pnl`: the monthly `gatewayFees` total stays a single lump summing every source type (cash view)
- No wire-shape changes anywhere.

## 3. Owner-only history

On all `GET /Booking/analysis/*` endpoints (analysis, travel, profit, pnl, boosts), `GET /Booking/pnl/terminal` and `GET /User/{id}/pnl`: callers **without the `owner` role** only see data from **June 2026 (SGT)** onward.

- Server-side **clamp**, not an error: effective `After = max(requested After, 01-06-2026)`; `Before` is never moved, so a range ending before the floor becomes `After > Before` and every repository/calculator naturally returns empty
- Pure helper `Domain.RangeClamp` (unit-tested), applied in the controllers after validation
- **Role plumbing (investigated):** authorization roles come from the Descope JWT — `AuthHelper.FieldToScope` maps the `roles` field to `http://schemas.microsoft.com/ws/2008/06/identity/claims/role` claims filtered by the configured issuer. `OnlyAdmin`/`GuardOrAnyAsync` match those claim values (config-driven policies in `App/Config/settings*.yaml`). No `owner` role existed before; **an account needs the role claim value `owner` (matched case-insensitively) in its Descope JWT** for full history. `UserData.ExtraRoles` is admin-managed pricing targeting and is deliberately NOT consulted for this gate.

## Tests

- `RangeClampTests` — clamp contract (owner passthrough, floor raise, empty-range behaviour)
- `GatewayFeeBucketsTests` — pins the payments-vs-payouts attribution (Payment + AccountFee vs Transfer + Refund, every type in exactly one bucket)
- `GatewayAccountFeeSweepTests` — planner window rules + sweep driver (full history/incremental/failure)
- `AirwallexAccountFeeSourceTests` — HTTP adapter: window params, paging, lenient-answer filtering
- updated `PartnerEconomicsWireContractTests` (wire pin) and `PartnerPnlCalculatorTests`

`dotnet test` locally: 754 passed, 1 failed — the known `Terminate_keeps_the_priority_fee` wall-clock baseline failure that also fails on clean main locally and passes in CI.
