### PR TITLE
feat: PDPA account wipe — erase PII, retain financial records

### DIFF
--- a/App/Error/V1/InvalidUserWipeOperation.cs
+++ b/App/Error/V1/InvalidUserWipeOperation.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace App.Error.V1;
+
+[Description(
+  "The PDPA account wipe attempted is not valid: the wallet still holds money, a withdrawal is still in flight, or the user is already wiped"
+)]
+public class InvalidUserWipeOperation : IDomainProblem
+{
+  public InvalidUserWipeOperation() { }
+
+  public InvalidUserWipeOperation(string detail, string userId, string reason)
+  {
+    this.Detail = detail;
+    this.UserId = userId;
+    this.Reason = reason;
+  }
+
+  [JsonIgnore]
+  public string Id { get; } = "invalid_user_wipe_operation";
+
+  [JsonIgnore]
+  public string Title { get; } = "Invalid User Wipe Operation";
+
+  [JsonIgnore]
+  public string Version { get; } = "v1";
+
+  public string Detail { get; } = string.Empty;
+
+  [Description("The user targeted by the wipe")]
+  public string UserId { get; } = string.Empty;
+
+  [Description(
+    "Why the wipe was refused: wallet_not_empty, withdrawal_in_flight or already_wiped"
+  )]
+  public string Reason { get; } = string.Empty;
+}

--- a/App/Migrations/20260715040725_AddUserWipeAudit.Designer.cs
+++ b/App/Migrations/20260715040725_AddUserWipeAudit.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using App.StartUp.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace App.Migrations
 {
     [DbContext(typeof(MainDbContext))]
-    partial class MainDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260715040725_AddUserWipeAudit")]
+    partial class AddUserWipeAudit
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/App/Migrations/20260715040725_AddUserWipeAudit.cs
+++ b/App/Migrations/20260715040725_AddUserWipeAudit.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace App.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserWipeAudit : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "WipedAt",
+                table: "Users",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "WipedById",
+                table: "Users",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "WipedAt",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "WipedById",
+                table: "Users");
+        }
+    }
+}

--- a/App/Modules/Bookings/Data/BookingRepository.cs
+++ b/App/Modules/Bookings/Data/BookingRepository.cs
@@ -738,6 +738,54 @@ public class BookingRepository(
     }
   }
 
+  public async Task<Result<string[]>> ListTicketKeys(string userId)
+  {
+    try
+    {
+      logger.LogInformation("Listing ticket blob keys under User '{UserId}' (PDPA wipe)", userId);
+      var keys = await db
+        .Bookings.Where(x => x.UserId == userId && x.Ticket != null)
+        .Select(x => x.Ticket!)
+        .ToArrayAsync();
+      return keys;
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to list ticket keys under User '{UserId}'", userId);
+      return e;
+    }
+  }
+
+  public async Task<Result<int>> WipePersonalData(string userId)
+  {
+    try
+    {
+      logger.LogInformation("Wiping personal data on Bookings under User '{UserId}'", userId);
+      var rows = await db.Bookings.Where(x => x.UserId == userId).ToArrayAsync();
+      foreach (var b in rows)
+      {
+        // blank the embedded passenger snapshot; the booking row itself
+        // (BookingNo, TicketNo, amounts, KTMB costs/refunds) is a financial
+        // record and stays
+        b.Passenger.FullName = "";
+        b.Passenger.Gender = 0;
+        b.Passenger.PassportExpiry = default;
+        b.Passenger.PassportNumber = "";
+        // the blob object is removed by the wipe flow; drop the reference
+        b.Ticket = null;
+      }
+
+      await db.SaveChangesAsync();
+      await cdc.Add("wipe");
+      return rows.Length;
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to wipe personal data on Bookings under User '{UserId}'", userId);
+      return e;
+    }
+  }
+
   public async Task<Result<IEnumerable<BookingCount>>> Count(
     DateOnly date,
     TimeOnly time,

--- a/App/Modules/Bookings/Data/BookingStorage.cs
+++ b/App/Modules/Bookings/Data/BookingStorage.cs
@@ -22,4 +22,9 @@ public class BookingStorage(IFileRepository file) : IBookingStorage
   {
     return file.Exists(BlockStorages.Main, key);
   }
+
+  public Task<Result<Unit>> Remove(string key)
+  {
+    return file.Remove(BlockStorages.Main, key);
+  }
 }

--- a/App/Modules/Common/BaseController.cs
+++ b/App/Modules/Common/BaseController.cs
@@ -67,6 +67,10 @@ public class AtomiControllerBase(IAuthHelper h) : ControllerBase
         HttpStatusCode.BadRequest,
         new InvalidWithdrawalOperation(iwoe.Message, iwoe.WithdrawStatus, iwoe.Operation)
       ),
+      InvalidUserWipeOperationException iuwe => this.Error(
+        HttpStatusCode.Conflict,
+        new InvalidUserWipeOperation(iuwe.Message, iuwe.UserId, iuwe.Reason)
+      ),
       InsufficientRefundablePoolException irpe => this.Error(
         HttpStatusCode.Conflict,
         new InsufficientRefundablePool(irpe.Message, irpe.Required, irpe.Available)

--- a/App/Modules/Common/FileRepository.cs
+++ b/App/Modules/Common/FileRepository.cs
@@ -19,6 +19,10 @@ public interface IFileRepository
   // true when the object behind the key exists in the store, false when it is
   // missing (a dangling reference); other storage failures surface as errors
   Task<Result<bool>> Exists(string store, string key);
+
+  // permanently removes the object behind the key (PDPA erasure); idempotent
+  // — a missing object or bucket is a success, other failures are errors
+  Task<Result<Unit>> Remove(string store, string key);
 }
 
 public class FileRepository(IBlockStorageFactory factory, ContentInspector inspector)
@@ -138,6 +142,32 @@ public class FileRepository(IBlockStorageFactory factory, ContentInspector inspe
   // Only a definitive "object is not there" maps to false; any other failure
   // (auth, network, bucket) is an error, so an outage can never masquerade
   // as a missing ticket.
+  public async Task<Result<Unit>> Remove(string store, string key)
+  {
+    var s = this.Store(store);
+    try
+    {
+      await s
+        .WriteClient.RemoveObjectAsync(
+          new RemoveObjectArgs().WithBucket(s.Bucket).WithObject(key)
+        )
+        .ConfigureAwait(false);
+      return new Unit();
+    }
+    catch (ObjectNotFoundException)
+    {
+      return new Unit();
+    }
+    catch (BucketNotFoundException)
+    {
+      return new Unit();
+    }
+    catch (Exception e)
+    {
+      return e;
+    }
+  }
+
   public async Task<Result<bool>> Exists(string store, string key)
   {
     var s = this.Store(store);

--- a/App/Modules/DomainServices.cs
+++ b/App/Modules/DomainServices.cs
@@ -42,6 +42,8 @@ public static class DomainServices
     // USER
     s.AddScoped<IUserService, UserService>().AutoTrace<IUserService>();
 
+    s.AddScoped<IUserWipeService, UserWipeService>().AutoTrace<IUserWipeService>();
+
     s.AddScoped<IUserRepository, UserRepository>().AutoTrace<IUserRepository>();
 
     s.AddScoped<IPartnerEconomicsRepository, PartnerEconomicsRepository>()

--- a/App/Modules/Passengers/Data/PassengerRepository.cs
+++ b/App/Modules/Passengers/Data/PassengerRepository.cs
@@ -174,4 +174,21 @@ public class PassengerRepository(MainDbContext db, ILogger<PassengerRepository> 
       return e;
     }
   }
+
+  public async Task<Result<int>> DeleteByUser(string userId)
+  {
+    try
+    {
+      logger.LogInformation("Deleting all Passengers under User '{UserId}' (PDPA wipe)", userId);
+      var rows = await db.Passengers.Where(x => x.UserId == userId).ToArrayAsync();
+      db.Passengers.RemoveRange(rows);
+      await db.SaveChangesAsync();
+      return rows.Length;
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to delete Passengers under User '{UserId}'", userId);
+      return e;
+    }
+  }
 }

--- a/App/Modules/Users/API/V1/UserController.cs
+++ b/App/Modules/Users/API/V1/UserController.cs
@@ -20,6 +20,7 @@ namespace App.Modules.Users.API.V1;
 [Route("api/v{version:apiVersion}/[controller]")]
 public class UserController(
   IUserService service,
+  IUserWipeService wipeService,
   IPartnerEconomicsRepository partnerEconomicsRepo,
   CreateUserReqValidator createUserReqValidator,
   UpdateUserReqValidator updateUserReqValidator,
@@ -224,6 +225,29 @@ public class UserController(
     return this.ReturnNullableResult(
       x,
       new EntityNotFound("User or extra role not found", typeof(UserPrincipal), id)
+    );
+  }
+
+  // PDPA right-to-erasure: anonymizes the user in place (PII gone, the row
+  // and its financial records — wallet, transactions, payments, withdrawals,
+  // booking revenue fields — stay for the IRAS 5-year retention). 409 when
+  // the wallet still holds money, a payout is in flight, or already wiped.
+  // The surgical alternative to DELETE /User/{id} below, which removes the
+  // row entirely.
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpPost("{id}/wipe")]
+  public async Task<ActionResult<UserWipeRes>> Wipe(string id)
+  {
+    var admin = this.Sub();
+    if (admin == null)
+    {
+      Result<UserWipeRes> r = new Unauthenticated("You are not authenticated").ToException();
+      return this.ReturnResult(r);
+    }
+
+    var wiped = await wipeService.Wipe(id, admin).Then(x => x?.ToRes(), Errors.MapAll);
+    return this.ReturnNullableResult(
+      wiped,
+      new EntityNotFound("User Not Found", typeof(UserPrincipal), id)
     );
   }
 

--- a/App/Modules/Users/API/V1/UserMapper.cs
+++ b/App/Modules/Users/API/V1/UserMapper.cs
@@ -18,6 +18,8 @@ public static class UserMapper
   public static PartnerUserRes ToRes(this PartnerUser user) =>
     new(user.Id, user.Username, user.Email);
 
+  public static UserWipeRes ToRes(this UserWipe wipe) => new(wipe.Id, wipe.WipedAt);
+
   public static PartnerPnlRowRes ToRes(this PartnerPnlRow row) =>
     new(
       row.Month,

--- a/App/Modules/Users/API/V1/UserModel.cs
+++ b/App/Modules/Users/API/V1/UserModel.cs
@@ -15,6 +15,10 @@ public record PartnerPnlQueryReq(string? After, string? Before);
 // RESP
 public record UserExistRes(bool Exists);
 
+// PDPA account wipe receipt — the PINNED wire contract argon builds against:
+// { "id": ..., "wipedAt": ISO timestamp }
+public record UserWipeRes(string Id, DateTime WipedAt);
+
 public record PartnerUserRes(string Id, string Username, string Email);
 
 // Bookings is the full ticket count; BoostCount/BoostAmount cover the subset

--- a/App/Modules/Users/Data/PartnerEconomicsRepository.cs
+++ b/App/Modules/Users/Data/PartnerEconomicsRepository.cs
@@ -65,6 +65,9 @@ public class PartnerEconomicsRepository(
             FROM unnest(u."ExtraRoles") AS r(role)
             WHERE lower(r.role) = 'partner'
           )
+          -- PDPA-wiped users clear ExtraRoles anyway; this keeps an
+          -- anonymized row out of the listing even if roles are re-granted
+          AND u."WipedAt" IS NULL
           ORDER BY u."Username", u."Id"
           """
         )

--- a/App/Modules/Users/Data/UserData.cs
+++ b/App/Modules/Users/Data/UserData.cs
@@ -30,6 +30,15 @@ public class UserData
   // Update mapper deliberately never touches this column)
   public string[] ExtraRoles { get; set; } = [];
 
+  // PDPA erasure audit: when the account wipe anonymized this row (null =
+  // never wiped). A set stamp refuses re-wipe and blocks the token-sync
+  // Update path from repopulating identity fields.
+  public DateTime? WipedAt { get; set; }
+
+  // the acting admin's sub that performed the wipe
+  [MaxLength(128)]
+  public string? WipedById { get; set; }
+
   // Reference
   public WalletData? Wallet { get; set; }
 }

--- a/App/Modules/Users/Data/UserMapper.cs
+++ b/App/Modules/Users/Data/UserMapper.cs
@@ -16,7 +16,13 @@ public static class UserMapper
     };
 
   public static UserPrincipal ToPrincipal(this UserData data) =>
-    new() { Id = data.Id, Record = data.ToRecord() };
+    new()
+    {
+      Id = data.Id,
+      Record = data.ToRecord(),
+      WipedAt = data.WipedAt,
+      WipedById = data.WipedById,
+    };
 
   public static User ToDomain(this UserData data) =>
     new()

--- a/App/Modules/Users/Data/UserRepository.cs
+++ b/App/Modules/Users/Data/UserRepository.cs
@@ -151,6 +151,13 @@ public class UserRepository(MainDbContext db, ILogger<UserRepository> logger) : 
       if (v1 == null)
         return (UserPrincipal?)null;
 
+      // a wiped row is anonymized-in-place; this Update is the frontend
+      // token-sync path, and letting it through would repopulate Username/
+      // Email/Roles from a still-live Descope session — resurrecting the
+      // very identity the PDPA wipe erased. Treat as not-found instead.
+      if (v1.WipedAt != null)
+        return (UserPrincipal?)null;
+
       var v3 = v1.Update(v2);
 
       // v1 is already tracked — change tracking writes ONLY the columns the
@@ -225,6 +232,42 @@ public class UserRepository(MainDbContext db, ILogger<UserRepository> logger) : 
     {
       logger.LogError(e, "Failed to remove extra role '{Role}' from User '{Id}'", role, id);
       return e;
+    }
+  }
+
+  // anonymize in place: the row and id survive for financial FK linkage
+  // (wallet, transactions, bookings), the identity does not. Pure so the
+  // anonymization shape is pinned by unit tests.
+  public static UserData ApplyWipe(UserData data, string wipedById, DateTime wipedAt)
+  {
+    data.Username = UserWipeService.AnonymizedUsername(data.Id);
+    data.Email = "";
+    data.EmailVerified = false;
+    data.Roles = null;
+    data.ExtraRoles = [];
+    data.WipedAt = wipedAt;
+    data.WipedById = wipedById;
+    return data;
+  }
+
+  public async Task<Result<UserPrincipal?>> Wipe(string id, string wipedById)
+  {
+    try
+    {
+      logger.LogInformation("Wiping User '{Id}', acting admin '{WipedById}'", id, wipedById);
+      var data = await db.Users.Where(x => x.Id == id).FirstOrDefaultAsync();
+      if (data == null)
+        return (UserPrincipal?)null;
+
+      ApplyWipe(data, wipedById, DateTime.UtcNow);
+      await db.SaveChangesAsync();
+
+      return data.ToPrincipal();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed wiping User '{Id}'", id);
+      throw;
     }
   }
 

--- a/Domain/Booking/Repository.cs
+++ b/Domain/Booking/Repository.cs
@@ -78,6 +78,19 @@ public interface IBookingRepository
 
   Task<Result<Unit?>> Delete(string? userId, Guid id);
 
+  // PDPA account wipe: the ticket blob keys referenced by this user's
+  // bookings (tickets are PDFs carrying passenger name/passport) — collected
+  // before the scrub so the objects can be removed from blob storage
+  Task<Result<string[]>> ListTicketKeys(string userId);
+
+  // PDPA account wipe: scrubs passenger-identifying content from ALL of this
+  // user's bookings — blanks the embedded passenger snapshot (FullName,
+  // PassportNumber, PassportExpiry, Gender) and nulls the Ticket blob
+  // reference — while keeping the rows themselves (BookingNo, TicketNo,
+  // amounts, KTMB costs/refunds are revenue records). Returns the number of
+  // bookings scrubbed.
+  Task<Result<int>> WipePersonalData(string userId);
+
   Task<Result<IEnumerable<BookingCount>>> Count(
     DateOnly date,
     TimeOnly time,

--- a/Domain/Booking/Storage.cs
+++ b/Domain/Booking/Storage.cs
@@ -11,4 +11,8 @@ public interface IBookingStorage
   // whether the stored object behind this key actually exists — used by the
   // ticket-health probe to surface dangling references without serving them
   Task<Result<bool>> Exists(string key);
+
+  // permanently removes the stored object (PDPA wipe of ticket PDFs);
+  // idempotent — a missing object is a success, not an error
+  Task<Result<Unit>> Remove(string key);
 }

--- a/Domain/Exceptions/InvalidUserWipeOperationException.cs
+++ b/Domain/Exceptions/InvalidUserWipeOperationException.cs
@@ -1,0 +1,13 @@
+namespace Domain.Exceptions;
+
+// the PDPA account wipe was refused: the wallet still holds money, a payout
+// is still in flight, or the user is already wiped — maps to 409 at the edge
+public class InvalidUserWipeOperationException(string? message, string userId, string reason)
+  : Exception(message)
+{
+  public string UserId { get; init; } = userId;
+
+  // machine-readable refusal: "wallet_not_empty", "withdrawal_in_flight" or
+  // "already_wiped"
+  public string Reason { get; init; } = reason;
+}

--- a/Domain/Passenger/Repository.cs
+++ b/Domain/Passenger/Repository.cs
@@ -13,4 +13,9 @@ public interface IPassengerRepository
   Task<Result<PassengerPrincipal?>> Update(string? userId, Guid id, PassengerRecord record);
 
   Task<Result<Unit?>> Delete(string? userId, Guid id);
+
+  // PDPA account wipe: hard-delete every saved passenger of this user
+  // (FullName, PassportNumber, PassportExpiry, Gender — the PII core);
+  // returns how many rows were removed (0 when the user had none)
+  Task<Result<int>> DeleteByUser(string userId);
 }

--- a/Domain/User/Model.cs
+++ b/Domain/User/Model.cs
@@ -26,6 +26,21 @@ public record UserPrincipal
 {
   public required string Id { get; init; }
   public required UserRecord Record { get; init; }
+
+  // PDPA erasure audit stamp: set exactly once by the account wipe; a
+  // non-null WipedAt marks the row as anonymized (PII gone, id retained for
+  // financial linkage) and blocks re-wipe and token-sync resurrection
+  public DateTime? WipedAt { get; init; }
+
+  // the acting admin's sub that performed the wipe
+  public string? WipedById { get; init; }
+}
+
+// result of a PDPA account wipe (the pinned wire contract carries these two)
+public record UserWipe
+{
+  public required string Id { get; init; }
+  public required DateTime WipedAt { get; init; }
 }
 
 public record UserRecord

--- a/Domain/User/Repository.cs
+++ b/Domain/User/Repository.cs
@@ -23,4 +23,10 @@ public interface IUserRepository
   Task<Result<UserPrincipal?>> RemoveExtraRole(string id, string role);
 
   Task<Result<Unit?>> Delete(string id);
+
+  // PDPA anonymize-in-place: blanks the PII columns (Username → deterministic
+  // placeholder, Email → '', EmailVerified → false, Roles/ExtraRoles →
+  // cleared) and stamps WipedAt/WipedById; the row and id survive for
+  // financial FK linkage. null when no such user exists.
+  Task<Result<UserPrincipal?>> Wipe(string id, string wipedById);
 }

--- a/Domain/User/WipeService.cs
+++ b/Domain/User/WipeService.cs
@@ -1,0 +1,145 @@
+using CSharp_Result;
+using Domain.Booking;
+using Domain.Exceptions;
+using Domain.Passenger;
+using Domain.Withdrawal;
+
+namespace Domain.User;
+
+// PDPA right-to-erasure: deletes/anonymizes the user's personal data while
+// retaining the financial records (bookings' revenue fields, wallets,
+// transactions, payments, withdrawals) for the 5-year accounting retention.
+// The surgical alternative to DELETE /User/{id}, which removes the row (and
+// cascades) entirely.
+public interface IUserWipeService
+{
+  // null = no such user (404); InvalidUserWipeOperationException (409) when
+  // the wallet still holds money, a payout is in flight, or already wiped
+  Task<Result<UserWipe?>> Wipe(string userId, string wipedById);
+}
+
+public class UserWipeService(
+  IUserRepository userRepo,
+  IPassengerRepository passengerRepo,
+  IBookingRepository bookingRepo,
+  IBookingStorage bookingStorage,
+  IWithdrawalRepository withdrawalRepo,
+  ITransactionManager transaction
+) : IUserWipeService
+{
+  // payout states that still move money — the user must be fully paid out
+  // (Completed / Rejected / Cancel) before erasure
+  private static readonly WithdrawStatus[] InFlightStatuses =
+  [
+    WithdrawStatus.Pending,
+    WithdrawStatus.Processing,
+    WithdrawStatus.RequireManualIntervention,
+  ];
+
+  // the pinned anonymization shape: 'deleted-' + first 8 chars of the user
+  // id — deterministic, so re-runs and audits can recognize a wiped row
+  public static string AnonymizedUsername(string id) =>
+    "deleted-" + id[..Math.Min(8, id.Length)];
+
+  public Task<Result<UserWipe?>> Wipe(string userId, string wipedById)
+  {
+    return userRepo
+      .GetById(userId)
+      .ThenAwait(user =>
+        user == null
+          ? Task.FromResult((Result<UserWipe?>)(UserWipe?)null)
+          : this.WipeExisting(user, wipedById)
+      );
+  }
+
+  private async Task<Result<UserWipe?>> WipeExisting(User user, string wipedById)
+  {
+    var userId = user.Principal.Id;
+
+    // refuse re-wipe: the stamp marks the row as already anonymized
+    if (user.Principal.WipedAt != null)
+      return new InvalidUserWipeOperationException(
+        $"User '{userId}' has already been wiped",
+        userId,
+        "already_wiped"
+      );
+
+    // every cent must be paid out first — erasing while money is held would
+    // orphan funds we can no longer attribute or return
+    var w = user.Wallet.Record;
+    if (w.Usable > 0 || w.WithdrawReserve > 0 || w.BookingReserve > 0)
+      return new InvalidUserWipeOperationException(
+        $"User '{userId}' still holds money in the wallet; pay the user out fully before wiping",
+        userId,
+        "wallet_not_empty"
+      );
+
+    var inFlight = await this.GuardNoInFlightWithdrawals(userId);
+    if (inFlight.IsFailure())
+      return inFlight.FailureOrDefault();
+
+    // blob objects go FIRST: MinIO cannot join the DB transaction, and this
+    // order is retryable in both directions — if a removal fails the DB is
+    // untouched and the wipe can be re-run; if the DB transaction fails the
+    // dangling Ticket references are re-collected and re-removed (Remove is
+    // idempotent) on the next attempt. The reverse order could commit the
+    // wipe stamp and then fail, leaving PII ticket PDFs in storage with no
+    // retry path (re-wipe is refused).
+    var removed = await bookingRepo
+      .ListTicketKeys(userId)
+      .ThenAwait(keys => this.RemoveTickets(keys));
+    if (removed.IsFailure())
+      return removed.FailureOrDefault();
+
+    return await transaction
+      .Start(() =>
+        passengerRepo
+          .DeleteByUser(userId)
+          .ThenAwait(_ => bookingRepo.WipePersonalData(userId))
+          .ThenAwait(_ => userRepo.Wipe(userId, wipedById))
+          // the row was read above; vanishing mid-transaction is a hard fault
+          .NullToError(userId)
+      )
+      .Then(
+        p => (UserWipe?)new UserWipe { Id = p.Id, WipedAt = p.WipedAt!.Value },
+        Errors.MapAll
+      );
+  }
+
+  private async Task<Result<Unit>> GuardNoInFlightWithdrawals(string userId)
+  {
+    foreach (var status in InFlightStatuses)
+    {
+      var r = await withdrawalRepo.Search(
+        new WithdrawalSearch
+        {
+          UserId = userId,
+          Status = status,
+          Limit = 1,
+        }
+      );
+      if (r.IsFailure())
+        return r.FailureOrDefault();
+      if (r.Get().Any())
+        return new InvalidUserWipeOperationException(
+          $"User '{userId}' has a withdrawal in state '{status}'; it must settle before wiping",
+          userId,
+          "withdrawal_in_flight"
+        );
+    }
+
+    return new Unit();
+  }
+
+  private async Task<Result<Unit>> RemoveTickets(string[] keys)
+  {
+    foreach (var key in keys)
+    {
+      var r = await bookingStorage.Remove(key);
+      if (r.IsFailure())
+        return r.FailureOrDefault();
+    }
+
+    return new Unit();
+  }
+}

--- a/UnitTest/Bookings/BookingServiceAttachTicketTests.cs
+++ b/UnitTest/Bookings/BookingServiceAttachTicketTests.cs
@@ -215,6 +215,8 @@ public class BookingServiceAttachTicketTests
 
   private sealed class FakeStorage : IBookingStorage
   {
+    public Task<Result<Unit>> Remove(string key) => Task.FromResult((Result<Unit>)new Unit());
+
     public Task<Result<string>> Save(Stream stream) => Task.FromResult((Result<string>)"file-id");
     public Task<Result<string>> Get(string key) => Task.FromResult((Result<string>)"file-url");
     public Task<Result<bool>> Exists(string key) => Task.FromResult((Result<bool>)true);
@@ -227,6 +229,12 @@ public class BookingServiceAttachTicketTests
 
   private sealed class FakeBookingRepository(Booking? booking) : IBookingRepository
   {
+    public Task<Result<string[]>> ListTicketKeys(string userId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<int>> WipePersonalData(string userId) =>
+      throw new NotImplementedException();
+
     public int UpdateCalls { get; private set; }
     public BookingStatus? LastStatusWritten { get; private set; }
     public BookingComplete? LastCompleteWritten { get; private set; }

--- a/UnitTest/Bookings/BookingServiceBuyingGuardTests.cs
+++ b/UnitTest/Bookings/BookingServiceBuyingGuardTests.cs
@@ -173,6 +173,12 @@ public class BookingServiceBuyingGuardTests
 
   private sealed class FakeBookingRepository(Booking? booking) : IBookingRepository
   {
+    public Task<Result<string[]>> ListTicketKeys(string userId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<int>> WipePersonalData(string userId) =>
+      throw new NotImplementedException();
+
     public int UpdateCalls { get; private set; }
     public BookingStatus? LastStatusWritten { get; private set; }
 

--- a/UnitTest/Bookings/BookingServiceCompleteNoCollectTests.cs
+++ b/UnitTest/Bookings/BookingServiceCompleteNoCollectTests.cs
@@ -144,6 +144,8 @@ public class BookingServiceCompleteNoCollectTests
 
   private sealed class FakeStorage : IBookingStorage
   {
+    public Task<Result<Unit>> Remove(string key) => Task.FromResult((Result<Unit>)new Unit());
+
     public Task<Result<string>> Save(Stream stream) => Task.FromResult((Result<string>)"file-id");
     public Task<Result<string>> Get(string key) => Task.FromResult((Result<string>)"file-url");
     public Task<Result<bool>> Exists(string key) => Task.FromResult((Result<bool>)true);
@@ -166,6 +168,12 @@ public class BookingServiceCompleteNoCollectTests
 
   private sealed class FakeBookingRepository(Booking? booking) : IBookingRepository
   {
+    public Task<Result<string[]>> ListTicketKeys(string userId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<int>> WipePersonalData(string userId) =>
+      throw new NotImplementedException();
+
     public int UpdateCalls { get; private set; }
     public BookingStatus? LastStatusWritten { get; private set; }
     public BookingComplete? LastCompleteWritten { get; private set; }

--- a/UnitTest/Bookings/BookingServiceKtmbActualCostTests.cs
+++ b/UnitTest/Bookings/BookingServiceKtmbActualCostTests.cs
@@ -401,6 +401,8 @@ public class BookingServiceKtmbActualCostTests
 
   private sealed class FakeStorage : IBookingStorage
   {
+    public Task<Result<Unit>> Remove(string key) => Task.FromResult((Result<Unit>)new Unit());
+
     public Task<Result<string>> Save(Stream stream) => Task.FromResult((Result<string>)"file-id");
 
     public Task<Result<string>> Get(string key) => Task.FromResult((Result<string>)"file-url");
@@ -436,6 +438,12 @@ public class BookingServiceKtmbActualCostTests
 
   private sealed class FakeBookingRepository(Booking? booking) : IBookingRepository
   {
+    public Task<Result<string[]>> ListTicketKeys(string userId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<int>> WipePersonalData(string userId) =>
+      throw new NotImplementedException();
+
     private BookingComplete? completeOverride;
 
     private BookingStatus? statusOverride;

--- a/UnitTest/Bookings/BookingServicePrioritizeTests.cs
+++ b/UnitTest/Bookings/BookingServicePrioritizeTests.cs
@@ -825,6 +825,9 @@ public class BookingServicePrioritizeTests
 
   private sealed class FakeUserRepository(UserRecord? user) : IUserRepository
   {
+    public Task<Result<UserPrincipal?>> Wipe(string id, string wipedById) =>
+      throw new NotImplementedException();
+
     public Task<Result<User?>> GetById(string id) =>
       Task.FromResult(
         (Result<User?>)(
@@ -898,6 +901,12 @@ public class BookingServicePrioritizeTests
 
   private sealed class FakeBookingRepository(Booking? booking) : IBookingRepository
   {
+    public Task<Result<string[]>> ListTicketKeys(string userId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<int>> WipePersonalData(string userId) =>
+      throw new NotImplementedException();
+
     private BookStatus? statusOverride;
     private bool priorityOverride;
     private decimal? feeOverride;

--- a/UnitTest/Bookings/BookingServiceRecoverRevertTests.cs
+++ b/UnitTest/Bookings/BookingServiceRecoverRevertTests.cs
@@ -220,6 +220,12 @@ public class BookingServiceRecoverRevertTests
   // recoverer failing the recycled attempt again.
   private sealed class FakeBookingRepository(Booking? booking) : IBookingRepository
   {
+    public Task<Result<string[]>> ListTicketKeys(string userId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<int>> WipePersonalData(string userId) =>
+      throw new NotImplementedException();
+
     public int UpdateCalls { get; private set; }
     public int IncrementCalls { get; private set; }
     public int Retries { get; private set; } = booking?.Principal.RecoveryRetries ?? 0;

--- a/UnitTest/Bookings/BookingServiceRevertGuardTests.cs
+++ b/UnitTest/Bookings/BookingServiceRevertGuardTests.cs
@@ -306,6 +306,12 @@ public class BookingServiceRevertGuardTests
 
   private sealed class FakeBookingRepository(Booking? booking) : IBookingRepository
   {
+    public Task<Result<string[]>> ListTicketKeys(string userId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<int>> WipePersonalData(string userId) =>
+      throw new NotImplementedException();
+
     public int UpdateCalls { get; private set; }
     public BookingStatus? LastStatusWritten { get; private set; }
 

--- a/UnitTest/Bookings/BookingServiceTerminateTests.cs
+++ b/UnitTest/Bookings/BookingServiceTerminateTests.cs
@@ -301,6 +301,12 @@ public class BookingServiceTerminateTests
 
   private sealed class FakeBookingRepository(Booking booking) : IBookingRepository
   {
+    public Task<Result<string[]>> ListTicketKeys(string userId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<int>> WipePersonalData(string userId) =>
+      throw new NotImplementedException();
+
     private BookStatus? statusOverride;
 
     private Booking Current()

--- a/UnitTest/Bookings/BookingServiceTicketHealthTests.cs
+++ b/UnitTest/Bookings/BookingServiceTicketHealthTests.cs
@@ -151,6 +151,8 @@ public class BookingServiceTicketHealthTests
 
   private sealed class FakeStorage(bool exists) : IBookingStorage
   {
+    public Task<Result<Unit>> Remove(string key) => Task.FromResult((Result<Unit>)new Unit());
+
     public List<string> ProbedKeys { get; } = [];
 
     public Task<Result<string>> Save(Stream stream) => throw new NotImplementedException();
@@ -166,6 +168,12 @@ public class BookingServiceTicketHealthTests
 
   private sealed class FakeBookingRepository(Booking? booking) : IBookingRepository
   {
+    public Task<Result<string[]>> ListTicketKeys(string userId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<int>> WipePersonalData(string userId) =>
+      throw new NotImplementedException();
+
     public Task<Result<Booking?>> Get(string? userId, Guid id) =>
       Task.FromResult((Result<Booking?>)booking);
 

--- a/UnitTest/Users/UserWipeAnonymizationTests.cs
+++ b/UnitTest/Users/UserWipeAnonymizationTests.cs
@@ -1,0 +1,46 @@
+using App.Modules.Users.Data;
+
+namespace UnitTest.Users;
+
+// The row-level anonymization shape: what a PDPA wipe blanks and what it
+// deliberately keeps on the Users row (the id survives for financial FK
+// linkage; everything identifying goes).
+public class UserWipeAnonymizationTests
+{
+  private static readonly DateTime WipeStamp = new(2026, 7, 15, 8, 0, 0, DateTimeKind.Utc);
+
+  private static UserData Original() =>
+    new()
+    {
+      Id = "user-1234567890",
+      Username = "bunny",
+      Email = "bunny@example.com",
+      EmailVerified = true,
+      Roles = ["role_a"],
+      ExtraRoles = ["partner"],
+    };
+
+  [Fact]
+  public void ApplyWipe_blanks_every_identifying_field()
+  {
+    var data = UserRepository.ApplyWipe(Original(), "admin-1", WipeStamp);
+
+    data.Username.Should().Be("deleted-user-123");
+    data.Email.Should().Be("");
+    data.EmailVerified.Should().Be(false);
+    // Roles mirror the (now dead) Descope JWT; ExtraRoles drive the partner
+    // listing and pricing — both cleared so nothing targets a ghost
+    data.Roles.Should().BeNull();
+    data.ExtraRoles.Should().BeEmpty();
+  }
+
+  [Fact]
+  public void ApplyWipe_keeps_the_id_and_stamps_the_audit_fields()
+  {
+    var data = UserRepository.ApplyWipe(Original(), "admin-1", WipeStamp);
+
+    data.Id.Should().Be("user-1234567890");
+    data.WipedAt.Should().Be(WipeStamp);
+    data.WipedById.Should().Be("admin-1");
+  }
+}

--- a/UnitTest/Users/UserWipeServiceTests.cs
+++ b/UnitTest/Users/UserWipeServiceTests.cs
@@ -1,0 +1,512 @@
+using CSharp_Result;
+using Domain;
+using Domain.Booking;
+using Domain.Exceptions;
+using Domain.Passenger;
+using Domain.Timings;
+using Domain.User;
+using Domain.Wallet;
+using Domain.Withdrawal;
+
+namespace UnitTest.Users;
+
+// PDPA account wipe guards + erasure/retention split on UserWipeService.
+// The invariants: nothing is mutated until every guard passes, ticket blobs
+// are removed BEFORE the DB scrub (retryable in both directions), and the
+// financial repos (wallet, withdrawal, transaction) are never written —
+// every fake below throws on any call the wipe must not make.
+public class UserWipeServiceTests
+{
+  private const string UserId = "user-1234567890";
+  private const string AdminId = "admin-1";
+
+  private static readonly DateTime WipeStamp = new(2026, 7, 15, 8, 0, 0, DateTimeKind.Utc);
+
+  private static User UserWith(
+    decimal usable = 0m,
+    decimal withdrawReserve = 0m,
+    decimal bookingReserve = 0m,
+    DateTime? wipedAt = null
+  ) =>
+    new()
+    {
+      Principal = new UserPrincipal
+      {
+        Id = UserId,
+        Record = new UserRecord { Username = "bunny", Email = "bunny@example.com" },
+        WipedAt = wipedAt,
+      },
+      Wallet = new WalletPrincipal
+      {
+        Id = Guid.NewGuid(),
+        UserId = UserId,
+        Record = new WalletRecord
+        {
+          Usable = usable,
+          WithdrawReserve = withdrawReserve,
+          BookingReserve = bookingReserve,
+        },
+      },
+    };
+
+  private static (
+    UserWipeService Service,
+    FakeUserRepository Users,
+    FakePassengerRepository Passengers,
+    FakeBookingRepository Bookings,
+    FakeBookingStorage Storage,
+    FakeWithdrawalRepository Withdrawals,
+    List<string> Calls
+  ) Make(
+    User? user,
+    string[]? ticketKeys = null,
+    WithdrawStatus[]? inFlight = null,
+    bool storageFails = false
+  )
+  {
+    var calls = new List<string>();
+    var users = new FakeUserRepository(user, calls);
+    var passengers = new FakePassengerRepository(calls);
+    var bookings = new FakeBookingRepository(ticketKeys ?? [], calls);
+    var storage = new FakeBookingStorage(storageFails, calls);
+    var withdrawals = new FakeWithdrawalRepository(inFlight ?? [], calls);
+    var service = new UserWipeService(
+      users,
+      passengers,
+      bookings,
+      storage,
+      withdrawals,
+      new PassThroughTransactionManager()
+    );
+    return (service, users, passengers, bookings, storage, withdrawals, calls);
+  }
+
+  // ---- guard refusals -----------------------------------------------------
+
+  [Fact]
+  public async Task Wipe_of_unknown_user_returns_null_and_touches_nothing()
+  {
+    var (service, _, passengers, bookings, storage, _, _) = Make(user: null);
+
+    var result = await service.Wipe(UserId, AdminId);
+
+    result.IsSuccess().Should().BeTrue();
+    result.Get().Should().BeNull();
+    passengers.DeletedUsers.Should().BeEmpty();
+    bookings.WipedUsers.Should().BeEmpty();
+    storage.RemovedKeys.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task Wipe_refuses_an_already_wiped_user()
+  {
+    var (service, users, passengers, bookings, storage, _, _) = Make(
+      UserWith(wipedAt: WipeStamp)
+    );
+
+    var result = await service.Wipe(UserId, AdminId);
+
+    var e = result
+      .FailureOrDefault()
+      .Should()
+      .BeOfType<InvalidUserWipeOperationException>()
+      .Subject;
+    e.Reason.Should().Be("already_wiped");
+    e.UserId.Should().Be(UserId);
+    users.WipeCalls.Should().BeEmpty();
+    passengers.DeletedUsers.Should().BeEmpty();
+    bookings.WipedUsers.Should().BeEmpty();
+    storage.RemovedKeys.Should().BeEmpty();
+  }
+
+  [Theory]
+  [InlineData(10.5, 0, 0)]
+  [InlineData(0, 25, 0)]
+  [InlineData(0, 0, 31)]
+  [InlineData(0.00000001, 0, 0)]
+  public async Task Wipe_refuses_while_the_wallet_still_holds_money(
+    decimal usable,
+    decimal withdrawReserve,
+    decimal bookingReserve
+  )
+  {
+    var (service, users, passengers, bookings, storage, _, _) = Make(
+      UserWith(usable, withdrawReserve, bookingReserve)
+    );
+
+    var result = await service.Wipe(UserId, AdminId);
+
+    var e = result
+      .FailureOrDefault()
+      .Should()
+      .BeOfType<InvalidUserWipeOperationException>()
+      .Subject;
+    e.Reason.Should().Be("wallet_not_empty");
+    users.WipeCalls.Should().BeEmpty();
+    passengers.DeletedUsers.Should().BeEmpty();
+    bookings.WipedUsers.Should().BeEmpty();
+    storage.RemovedKeys.Should().BeEmpty();
+  }
+
+  [Theory]
+  [InlineData(WithdrawStatus.Pending)]
+  [InlineData(WithdrawStatus.Processing)]
+  [InlineData(WithdrawStatus.RequireManualIntervention)]
+  public async Task Wipe_refuses_while_a_withdrawal_is_in_flight(WithdrawStatus status)
+  {
+    var (service, users, passengers, bookings, storage, _, _) = Make(
+      UserWith(),
+      inFlight: [status]
+    );
+
+    var result = await service.Wipe(UserId, AdminId);
+
+    var e = result
+      .FailureOrDefault()
+      .Should()
+      .BeOfType<InvalidUserWipeOperationException>()
+      .Subject;
+    e.Reason.Should().Be("withdrawal_in_flight");
+    users.WipeCalls.Should().BeEmpty();
+    passengers.DeletedUsers.Should().BeEmpty();
+    bookings.WipedUsers.Should().BeEmpty();
+    storage.RemovedKeys.Should().BeEmpty();
+  }
+
+  [Theory]
+  [InlineData(WithdrawStatus.Completed)]
+  [InlineData(WithdrawStatus.Rejected)]
+  [InlineData(WithdrawStatus.Cancel)]
+  public async Task Wipe_proceeds_when_only_settled_withdrawals_exist(WithdrawStatus status)
+  {
+    // settled payouts are financial history, not in-flight money — the fake
+    // only reports rows for the exact status searched, so a settled-only
+    // history must not block
+    var (service, users, _, _, _, _, _) = Make(UserWith(), inFlight: [status]);
+
+    var result = await service.Wipe(UserId, AdminId);
+
+    result.IsSuccess().Should().BeTrue();
+    users.WipeCalls.Should().ContainSingle();
+  }
+
+  // ---- the wipe itself ----------------------------------------------------
+
+  [Fact]
+  public async Task Wipe_deletes_passengers_scrubs_bookings_and_anonymizes_the_user()
+  {
+    var (service, users, passengers, bookings, storage, _, _) = Make(
+      UserWith(),
+      ticketKeys: ["bookings/t1.pdf", "bookings/t2.pdf"]
+    );
+
+    var result = await service.Wipe(UserId, AdminId);
+
+    result.IsSuccess().Should().BeTrue();
+    var wipe = result.Get();
+    wipe.Should().NotBeNull();
+    wipe!.Id.Should().Be(UserId);
+    wipe.WipedAt.Should().Be(WipeStamp);
+
+    passengers.DeletedUsers.Should().Equal(UserId);
+    bookings.WipedUsers.Should().Equal(UserId);
+    storage.RemovedKeys.Should().Equal("bookings/t1.pdf", "bookings/t2.pdf");
+    users.WipeCalls.Should().Equal((UserId, AdminId));
+  }
+
+  [Fact]
+  public async Task Wipe_removes_ticket_blobs_before_any_db_scrub()
+  {
+    var (service, _, _, _, _, _, calls) = Make(UserWith(), ticketKeys: ["bookings/t1.pdf"]);
+
+    await service.Wipe(UserId, AdminId);
+
+    var removeAt = calls.IndexOf("storage.Remove:bookings/t1.pdf");
+    removeAt.Should().BeGreaterThanOrEqualTo(0);
+    calls.IndexOf($"passengers.DeleteByUser:{UserId}").Should().BeGreaterThan(removeAt);
+    calls.IndexOf($"bookings.WipePersonalData:{UserId}").Should().BeGreaterThan(removeAt);
+    calls.IndexOf($"users.Wipe:{UserId}").Should().BeGreaterThan(removeAt);
+  }
+
+  [Fact]
+  public async Task Wipe_aborts_without_db_changes_when_a_blob_removal_fails()
+  {
+    var (service, users, passengers, bookings, _, _, _) = Make(
+      UserWith(),
+      ticketKeys: ["bookings/t1.pdf"],
+      storageFails: true
+    );
+
+    var result = await service.Wipe(UserId, AdminId);
+
+    result.IsFailure().Should().BeTrue();
+    passengers.DeletedUsers.Should().BeEmpty();
+    bookings.WipedUsers.Should().BeEmpty();
+    users.WipeCalls.Should().BeEmpty();
+  }
+
+  // ---- anonymization shape ------------------------------------------------
+
+  [Fact]
+  public void Anonymized_username_is_deleted_plus_first_8_chars_of_the_id()
+  {
+    UserWipeService.AnonymizedUsername("abcdefgh-rest-of-sub").Should().Be("deleted-abcdefgh");
+  }
+
+  [Fact]
+  public void Anonymized_username_uses_the_whole_id_when_shorter_than_8()
+  {
+    UserWipeService.AnonymizedUsername("ab12").Should().Be("deleted-ab12");
+  }
+
+  // ---- fakes ----------------------------------------------------------
+
+  private sealed class PassThroughTransactionManager : ITransactionManager
+  {
+    public Task<Result<T>> Start<T>(Func<Task<Result<T>>> func) => func();
+  }
+
+  private sealed class FakeUserRepository(User? user, List<string> calls) : IUserRepository
+  {
+    public List<(string Id, string WipedById)> WipeCalls { get; } = [];
+
+    public Task<Result<User?>> GetById(string id) => Task.FromResult((Result<User?>)user);
+
+    public Task<Result<UserPrincipal?>> Wipe(string id, string wipedById)
+    {
+      calls.Add($"users.Wipe:{id}");
+      this.WipeCalls.Add((id, wipedById));
+      return Task.FromResult(
+        (Result<UserPrincipal?>)
+          new UserPrincipal
+          {
+            Id = id,
+            Record = new UserRecord
+            {
+              Username = UserWipeService.AnonymizedUsername(id),
+              Email = "",
+              EmailVerified = false,
+            },
+            WipedAt = WipeStamp,
+            WipedById = wipedById,
+          }
+      );
+    }
+
+    public Task<Result<IEnumerable<UserPrincipal>>> Search(UserSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<User?>> GetByUsername(string username) =>
+      throw new NotImplementedException();
+
+    public Task<Result<bool>> Exists(string username) => throw new NotImplementedException();
+
+    public Task<Result<UserPrincipal>> Create(string id, UserRecord record) =>
+      throw new NotImplementedException();
+
+    public Task<Result<UserPrincipal?>> Update(string id, UserRecord record) =>
+      throw new NotImplementedException();
+
+    public Task<Result<UserPrincipal?>> AddExtraRole(string id, string role) =>
+      throw new NotImplementedException();
+
+    public Task<Result<UserPrincipal?>> RemoveExtraRole(string id, string role) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Unit?>> Delete(string id) => throw new NotImplementedException();
+  }
+
+  private sealed class FakePassengerRepository(List<string> calls) : IPassengerRepository
+  {
+    public List<string> DeletedUsers { get; } = [];
+
+    public Task<Result<int>> DeleteByUser(string userId)
+    {
+      calls.Add($"passengers.DeleteByUser:{userId}");
+      this.DeletedUsers.Add(userId);
+      return Task.FromResult((Result<int>)2);
+    }
+
+    public Task<Result<IEnumerable<PassengerPrincipal>>> Search(PassengerSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Passenger?>> Get(string? userId, Guid id) =>
+      throw new NotImplementedException();
+
+    public Task<Result<PassengerPrincipal>> Create(string userId, PassengerRecord record) =>
+      throw new NotImplementedException();
+
+    public Task<Result<PassengerPrincipal?>> Update(
+      string? userId,
+      Guid id,
+      PassengerRecord record
+    ) => throw new NotImplementedException();
+
+    public Task<Result<Unit?>> Delete(string? userId, Guid id) =>
+      throw new NotImplementedException();
+  }
+
+  private sealed class FakeBookingStorage(bool fails, List<string> calls) : IBookingStorage
+  {
+    public List<string> RemovedKeys { get; } = [];
+
+    public Task<Result<Unit>> Remove(string key)
+    {
+      if (fails)
+        return Task.FromResult((Result<Unit>)new ApplicationException("storage down"));
+      calls.Add($"storage.Remove:{key}");
+      this.RemovedKeys.Add(key);
+      return Task.FromResult((Result<Unit>)new Unit());
+    }
+
+    public Task<Result<string>> Save(Stream stream) => throw new NotImplementedException();
+
+    public Task<Result<string>> Get(string key) => throw new NotImplementedException();
+
+    public Task<Result<bool>> Exists(string key) => throw new NotImplementedException();
+  }
+
+  private sealed class FakeWithdrawalRepository(WithdrawStatus[] inFlight, List<string> calls)
+    : IWithdrawalRepository
+  {
+    public Task<Result<IEnumerable<WithdrawalPrincipal>>> Search(WithdrawalSearch search)
+    {
+      calls.Add($"withdrawals.Search:{search.Status}");
+      // report a row only for the exact status searched — the wipe probes
+      // each in-flight status with Limit 1
+      IEnumerable<WithdrawalPrincipal> rows =
+        search.Status != null && inFlight.Contains(search.Status.Value)
+          ? [Principal(search.Status.Value)]
+          : [];
+      return Task.FromResult((Result<IEnumerable<WithdrawalPrincipal>>)rows.ToResult());
+    }
+
+    private static WithdrawalPrincipal Principal(WithdrawStatus status) =>
+      new()
+      {
+        Id = Guid.NewGuid(),
+        CreatedAt = DateTime.UtcNow,
+        Status = new WithdrawalStatus { Status = status },
+        Record = new WithdrawalRecord
+        {
+          Amount = 10m,
+          Method = WithdrawalMethod.PayNow,
+          PayNowNumber = "91234567",
+        },
+        Complete = null,
+        Payout = null,
+      };
+
+    public Task<Result<Withdrawal?>> Get(Guid id, string? userId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WithdrawalPrincipal>> Create(Guid walletId, WithdrawalRecord record) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WithdrawalPrincipal?>> Update(
+      string? userId,
+      Guid id,
+      WithdrawalRecord? record,
+      WithdrawalStatus? status,
+      WithdrawalComplete? complete,
+      WithdrawalPayout? payout = null
+    ) => throw new NotImplementedException();
+
+    public Task<Result<Unit?>> Delete(Guid id) => throw new NotImplementedException();
+  }
+
+  private sealed class FakeBookingRepository(string[] ticketKeys, List<string> calls)
+    : IBookingRepository
+  {
+    public List<string> WipedUsers { get; } = [];
+
+    public Task<Result<string[]>> ListTicketKeys(string userId)
+    {
+      calls.Add($"bookings.ListTicketKeys:{userId}");
+      return Task.FromResult((Result<string[]>)ticketKeys);
+    }
+
+    public Task<Result<int>> WipePersonalData(string userId)
+    {
+      calls.Add($"bookings.WipePersonalData:{userId}");
+      this.WipedUsers.Add(userId);
+      return Task.FromResult((Result<int>)ticketKeys.Length);
+    }
+
+    public Task<Result<IEnumerable<BookingPrincipal>>> Search(BookingSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<int>> SearchCount(BookingSearch search) =>
+      throw new NotImplementedException();
+
+    public Task<Result<BookingQueuePosition?>> QueuePosition(string? userId, Guid id) =>
+      throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingStatRow>>> Stats(BookingStatsQuery query) =>
+      throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingPrincipal>>> RefundList(DateOnly date, TimeOnly time) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Booking?>> Get(string? userId, Guid id) =>
+      throw new NotImplementedException();
+
+    public Task<Result<BookingPrincipal>> Create(
+      string userId,
+      Guid transactionId,
+      BookingRecord record,
+      BookingPriceBreakdown? breakdown
+    ) => throw new NotImplementedException();
+
+    public Task<Result<BookingPrincipal?>> Update(
+      string? userId,
+      Guid id,
+      BookingStatus? status,
+      BookingRecord? record,
+      BookingComplete? complete
+    ) => throw new NotImplementedException();
+
+    public Task<Result<BookingPrincipal?>> Reserve(
+      TrainDirection direction,
+      DateOnly date,
+      TimeOnly time
+    ) => throw new NotImplementedException();
+
+    public Task<Result<int>> CountSlotPriority(
+      TrainDirection direction,
+      DateOnly date,
+      TimeOnly time
+    ) => throw new NotImplementedException();
+
+    public Task<Result<BookingPrincipal?>> Prioritize(
+      string? userId,
+      Guid id,
+      decimal? fee,
+      string? grantedBy
+    ) => throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbCost(
+      BookStatus status,
+      int limit,
+      int skip
+    ) => throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingKtmbCostMissing>>> ListMissingKtmbRefund(
+      int limit,
+      int skip
+    ) => throw new NotImplementedException();
+
+    public Task<Result<BookingPrincipal?>> IncrementRecoveryRetries(Guid id) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Unit?>> Delete(string? userId, Guid id) =>
+      throw new NotImplementedException();
+
+    public Task<Result<IEnumerable<BookingCount>>> Count(
+      DateOnly date,
+      TimeOnly time,
+      DateOnly? filterDate,
+      TrainDirection? filterDirection
+    ) => throw new NotImplementedException();
+  }
+}

--- a/UnitTest/Users/UserWipeWireContractTests.cs
+++ b/UnitTest/Users/UserWipeWireContractTests.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using App.Error.V1;
+using App.Modules.Users.API.V1;
+using App.StartUp.Registry;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace UnitTest.Users;
+
+// argon builds its account-deletion UI against this EXACT wire shape — the
+// contract was pinned BEFORE the UI exists, so a rename here can never
+// silently break it. ASP.NET Core serializes with JsonSerializerDefaults.Web
+// (camelCase).
+public class UserWipeWireContractTests
+{
+  private static readonly JsonSerializerOptions Web = new(JsonSerializerDefaults.Web);
+
+  [Fact]
+  public void Wipe_receipt_serializes_as_id_and_wipedAt()
+  {
+    var at = new DateTime(2026, 7, 15, 8, 0, 0, DateTimeKind.Utc);
+
+    var json = JsonSerializer.Serialize(new UserWipeRes("user-1", at), Web);
+
+    json.Should().Be("{\"id\":\"user-1\",\"wipedAt\":\"2026-07-15T08:00:00Z\"}");
+  }
+
+  [Fact]
+  public void Wipe_refusal_problem_serializes_detail_userId_and_reason()
+  {
+    var problem = new InvalidUserWipeOperation(
+      "the wallet still holds money; pay the user out fully before wiping",
+      "user-1",
+      "wallet_not_empty"
+    );
+
+    var json = JsonSerializer.Serialize(problem, Web);
+
+    json.Should().Be(
+      "{\"detail\":\"the wallet still holds money; pay the user out fully before wiping\","
+        + "\"userId\":\"user-1\",\"reason\":\"wallet_not_empty\"}"
+    );
+    problem.Id.Should().Be("invalid_user_wipe_operation");
+  }
+
+  [Fact]
+  public void Wipe_route_is_admin_only_POST_id_wipe()
+  {
+    var method = typeof(UserController).GetMethod(nameof(UserController.Wipe))!;
+
+    var post = method.GetCustomAttributes(typeof(HttpPostAttribute), false)
+      .Cast<HttpPostAttribute>()
+      .Single();
+    post.Template.Should().Be("{id}/wipe");
+
+    var auth = method.GetCustomAttributes(typeof(AuthorizeAttribute), false)
+      .Cast<AuthorizeAttribute>()
+      .Single();
+    auth.Policy.Should().Be(AuthPolicies.OnlyAdmin);
+  }
+}


### PR DESCRIPTION
## Summary

PDPA right-to-erasure account wipe: **`POST /api/v{version}/User/{id}/wipe`** (OnlyAdmin). Deletes/anonymizes all personal data while retaining financial records (IRAS 5-year accounting retention + payee identification). The surgical alternative to `DELETE /User/{id}`, which removes the row (and its cascade) entirely.

### Pinned wire contract (argon UI is built against this)

- `200` → `{ "id": string, "wipedAt": ISO timestamp }`
- `404` → unknown user
- `409` → `invalid_user_wipe_operation` problem (`detail`, `userId`, `reason`) when:
  - the wallet still holds money (`Usable`/`WithdrawReserve`/`BookingReserve` > 0) — `wallet_not_empty`
  - any withdrawal is `Pending`/`Processing`/`RequireManualIntervention` — `withdrawal_in_flight`
  - the user is already wiped — `already_wiped`

### What the wipe does

| Data | Action |
|---|---|
| Passengers rows | **Deleted** (FullName, PassportNumber, PassportExpiry, Gender — the PII core) |
| Users row | **Anonymized in place**: `Username → 'deleted-' + first 8 chars of id`, `Email → ''`, `EmailVerified → false`, `Roles → null`, `ExtraRoles → []`; row + id kept for FK/financial linkage |
| Bookings rows | **Kept** (revenue records) but the embedded passenger snapshot is blanked and the `Ticket` blob reference nulled; `BookingNo`/`TicketNo`/amounts/KTMB costs/refunds untouched |
| Ticket blobs (MinIO) | **Deleted** (PDFs contain passenger name/passport) — removed *before* the DB transaction so failures stay retryable in both directions |
| Wallets, Transactions, Payments, Withdrawals (incl. PayNowNumber/ConfirmationNumber/Receipt), WithdrawalRefunds, GatewayFees | **Untouched** (payee identification + accounting retention) |
| Audit | New nullable `Users.WipedAt` (timestamptz) + `WipedById` via migration `AddUserWipeAudit`; re-wipe refused |

### Login/identity notes (investigated)

- The existing `DELETE /User/{id}` flow does **no server-side Descope call** — it only deletes the DB row (FK cascade). The wipe mirrors that seam: no auth-provider integration exists in zinc, so identity removal at Descope remains an operational step, and the wipe instead **hard-blocks the resurrection path**:
- The frontend **token sync** (`PUT /User/{id}`, which overwrites `Username`/`Email`/`Roles` from the JWT) now treats a wiped row as **not-found**, so a still-live Descope session can never repopulate identity fields. `POST /User` for the same sub hits the PK and 409s.
- Partner listing (`GET /User/partners`) excludes wiped rows (`WipedAt IS NULL`), belt-and-braces on top of `ExtraRoles` being cleared.

### Tests

- `UserWipeServiceTests` — guard refusals (unknown, already wiped, wallet money ×4, in-flight withdrawal ×3, settled-withdrawals-pass ×3), full-wipe call shape, blob-before-DB ordering, blob-failure abort; every financial repo fake throws on any mutating call, so retention is enforced by construction.
- `UserWipeAnonymizationTests` — row-level anonymization shape (what is blanked vs kept).
- `UserWipeWireContractTests` — pins the 200 receipt JSON, the 409 problem JSON, and the route/policy.

Known local-only failure `Terminate_keeps_the_priority_fee` (wall-clock) is unrelated; the rest of the suite (776) passes.