### PR TITLE
fix: review findings in P&L/partner endpoints

### DIFF
--- a/App/Modules/Bookings/Data/BookingAnalysisRepository.cs
+++ b/App/Modules/Bookings/Data/BookingAnalysisRepository.cs
@@ -603,12 +603,8 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
     {
       logger.LogInformation("Computing P&L analysis with {@Query}", query.ToJson());
       var sgt = TimeZoneInfo.FindSystemTimeZoneById("Asia/Singapore");
-      var afterUtc =
-        query.After?.ToZonedDateTime(TimeOnly.MinValue, sgt)
-        ?? DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc);
-      var beforeUtc =
-        query.Before?.AddDays(1).ToZonedDateTime(TimeOnly.MinValue, sgt)
-        ?? DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc);
+      var afterUtc = query.After.ToUtcRangeStart(sgt);
+      var beforeUtc = query.Before.ToUtcRangeEndExclusive(sgt);
       var completedBooking = (byte)BookStatus.Completed;
       var completedWithdrawal = (byte)Domain.Withdrawal.WithdrawStatus.Completed;
 
@@ -754,12 +750,8 @@ public class BookingAnalysisRepository(MainDbContext db, ILogger<BookingAnalysis
     {
       logger.LogInformation("Computing terminal-event P&L with {@Query}", query.ToJson());
       var sgt = TimeZoneInfo.FindSystemTimeZoneById("Asia/Singapore");
-      var afterUtc =
-        query.After?.ToZonedDateTime(TimeOnly.MinValue, sgt)
-        ?? DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc);
-      var beforeUtc =
-        query.Before?.AddDays(1).ToZonedDateTime(TimeOnly.MinValue, sgt)
-        ?? DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc);
+      var afterUtc = query.After.ToUtcRangeStart(sgt);
+      var beforeUtc = query.Before.ToUtcRangeEndExclusive(sgt);
       var completedBooking = (byte)BookStatus.Completed;
       var terminatedBooking = (byte)BookStatus.Terminated;
       var terminatedLedger = (short)TransactionType.BookingTerminated;

--- a/App/Modules/Users/Data/PartnerEconomicsRepository.cs
+++ b/App/Modules/Users/Data/PartnerEconomicsRepository.cs
@@ -95,12 +95,8 @@ public class PartnerEconomicsRepository(
     {
       logger.LogInformation("Computing partner P&L for User '{UserId}' with {@Query}", userId, query.ToJson());
       var sgt = TimeZoneInfo.FindSystemTimeZoneById("Asia/Singapore");
-      var afterUtc =
-        query.After?.ToZonedDateTime(TimeOnly.MinValue, sgt)
-        ?? DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc);
-      var beforeUtc =
-        query.Before?.AddDays(1).ToZonedDateTime(TimeOnly.MinValue, sgt)
-        ?? DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc);
+      var afterUtc = query.After.ToUtcRangeStart(sgt);
+      var beforeUtc = query.Before.ToUtcRangeEndExclusive(sgt);
       var completedBooking = (byte)BookStatus.Completed;
       var completedWithdrawal = (byte)WithdrawStatus.Completed;
 

--- a/Domain/Utility.cs
+++ b/Domain/Utility.cs
@@ -30,4 +30,39 @@ public static class Utility
     var dt = date.ToDateTime(time);
     return TimeZoneInfo.ConvertTimeToUtc(dt, timezone);
   }
+
+  // Inclusive local-calendar bounds are scanned as a half-open UTC range.
+  // DateOnly's endpoints need special treatment: converting 01-01-0001 can
+  // underflow UTC, while AddDays(1) on 31-12-9999 overflows before conversion.
+  // Use the exact boundary when representable, otherwise saturate at UTC Min/
+  // Max so valid API dates never fail before the query runs.
+  public static DateTime ToUtcRangeStart(this DateOnly? date, TimeZoneInfo timezone)
+  {
+    if (date is null)
+      return DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc);
+    try
+    {
+      return date.Value.ToZonedDateTime(TimeOnly.MinValue, timezone);
+    }
+    catch (ArgumentException) when (date == DateOnly.MinValue)
+    {
+      return DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc);
+    }
+  }
+
+  public static DateTime ToUtcRangeEndExclusive(this DateOnly? date, TimeZoneInfo timezone)
+  {
+    if (date is null)
+      return DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc);
+    try
+    {
+      return date == DateOnly.MaxValue
+        ? date.Value.ToZonedDateTime(TimeOnly.MaxValue, timezone).AddTicks(1)
+        : date.Value.AddDays(1).ToZonedDateTime(TimeOnly.MinValue, timezone);
+    }
+    catch (ArgumentException) when (date == DateOnly.MaxValue)
+    {
+      return DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc);
+    }
+  }
 }

--- a/UnitTest/DateRangeTests.cs
+++ b/UnitTest/DateRangeTests.cs
@@ -1,0 +1,49 @@
+using Domain;
+using FluentAssertions;
+
+namespace UnitTest;
+
+public class DateRangeTests
+{
+  private static readonly TimeZoneInfo Singapore = TimeZoneInfo.FindSystemTimeZoneById(
+    "Asia/Singapore"
+  );
+
+  [Fact]
+  public void Inclusive_sgt_dates_convert_to_half_open_utc_bounds()
+  {
+    var date = new DateOnly(2026, 8, 1);
+
+    ((DateOnly?)date)
+      .ToUtcRangeStart(Singapore)
+      .Should()
+      .Be(new DateTime(2026, 7, 31, 16, 0, 0, DateTimeKind.Utc));
+    ((DateOnly?)date)
+      .ToUtcRangeEndExclusive(Singapore)
+      .Should()
+      .Be(new DateTime(2026, 8, 1, 16, 0, 0, DateTimeKind.Utc));
+  }
+
+  [Fact]
+  public void Null_and_dateonly_extremes_saturate_without_overflow()
+  {
+    DateOnly? unbounded = null;
+
+    unbounded
+      .ToUtcRangeStart(Singapore)
+      .Should()
+      .Be(DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc));
+    ((DateOnly?)DateOnly.MinValue)
+      .ToUtcRangeStart(Singapore)
+      .Should()
+      .Be(DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc));
+    unbounded
+      .ToUtcRangeEndExclusive(Singapore)
+      .Should()
+      .Be(DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc));
+    ((DateOnly?)DateOnly.MaxValue)
+      .ToUtcRangeEndExclusive(Singapore)
+      .Should()
+      .Be(new DateTime(9999, 12, 31, 16, 0, 0, DateTimeKind.Utc));
+  }
+}


### PR DESCRIPTION
## Summary

- convert inclusive SGT report dates through overflow-safe half-open UTC bounds
- keep exact normal-date boundaries while saturating only unrepresentable `DateOnly` edges
- apply the fix to monthly P&L, terminal P&L, and per-user partner P&L
- pin normal, null, minimum, and maximum date behavior

## Confirmed failure

The API validators accept `after=01-01-0001` and `before=31-12-9999`, but the prior repository arithmetic underflowed while converting the minimum SGT date and overflowed at `DateOnly.AddDays(1)` for the maximum date. Both valid requests therefore failed before SQL and surfaced as 500s.

## Validation

- focused `DateRangeTests`: 2 passed
- `dotnet format ... --verify-no-changes` for touched files
- rebased on latest `main`; `dotnet test --filter FullyQualifiedName!~Terminate_keeps_the_priority_fee`: 778 unit + 1 integration passed
- unfiltered pre-rebase suite: only the documented local wall-clock `Terminate_keeps_the_priority_fee` baseline failure