### PR TITLE
fix: partner consumption counting, reselling signal, owner-only access

### DIFF
--- a/App/Modules/Common/BaseController.cs
+++ b/App/Modules/Common/BaseController.cs
@@ -194,11 +194,34 @@ public class AtomiControllerBase(IAuthHelper h) : ControllerBase
     return Task.FromResult(this.GuardOrAny(target, field, value));
   }
 
+  protected Result<Unit> GuardRoleIgnoreCase(string role)
+  {
+    if (this.HasRoleIgnoreCase(role))
+      return new Unit().ToResult();
+
+    var tokenRoles = h.FieldToScope(this.HttpContext.User, AuthRoles.Field).ToArray();
+    h.Logger.LogInformation(
+      "Auth Failed (case-insensitive role): Role: {Role}, Token: {@TokenRoles}",
+      role,
+      tokenRoles
+    );
+    return new Unauthorized(
+      "You are not authorized to access this resource",
+      tokenRoles.Select(x => new Scope(AuthRoles.Field, x)).ToArray(),
+      [new Scope(AuthRoles.Field, role)]
+    ).ToException();
+  }
+
+  protected Task<Result<Unit>> GuardRoleIgnoreCaseAsync(string role)
+  {
+    return Task.FromResult(this.GuardRoleIgnoreCase(role));
+  }
+
   protected string? Sub() => this.HttpContext.User?.Identity?.Name;
 
   // case-insensitive JWT role probe (legacy/manual Descope role casing is
-  // not guaranteed) — for data-scoping decisions like the analysis history
-  // clamp, never for endpoint authorization (policies own that)
+  // not guaranteed) — used for data scoping and explicit secondary role
+  // gates layered on top of endpoint authorization policies
   protected bool HasRoleIgnoreCase(string role) =>
     h.FieldToScope(this.HttpContext.User, AuthRoles.Field)
       .Any(r => string.Equals(r, role, StringComparison.OrdinalIgnoreCase));

--- a/App/Modules/Users/API/V1/UserController.cs
+++ b/App/Modules/Users/API/V1/UserController.cs
@@ -60,19 +60,20 @@ public class UserController(
     return this.ReturnResult(x);
   }
 
-  // Users explicitly tagged as partners through ExtraRoles. Role matching is
-  // case-insensitive so legacy/manual role casing cannot hide a partner.
+  // Owner-only listing of users explicitly tagged as partners through
+  // ExtraRoles. Role matching is case-insensitive so legacy/manual role
+  // casing cannot hide a partner or deny a legitimate owner.
   [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("partners")]
   public async Task<ActionResult<IEnumerable<PartnerUserRes>>> Partners()
   {
-    var x = await partnerEconomicsRepo
-      .ListPartners()
+    var x = await this.GuardRoleIgnoreCaseAsync(AuthRoles.Owner)
+      .ThenAwait(_ => partnerEconomicsRepo.ListPartners())
       .Then(users => users.Select(u => u.ToRes()), Errors.MapAll);
     return this.ReturnResult(x);
   }
 
-  // Monthly economics for this user's wallet only. Each event is bucketed by
-  // its inclusive SGT source date; empty months are omitted.
+  // Owner-only monthly economics for this user's wallet. Each event is
+  // bucketed by its inclusive SGT source date; empty months are omitted.
   [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("{id}/pnl")]
   public async Task<ActionResult<IEnumerable<PartnerPnlRowRes>>> PartnerPnl(
     string id,
@@ -80,15 +81,10 @@ public class UserController(
     [FromServices] PartnerPnlQueryReqValidator partnerPnlValidator
   )
   {
-    // non-owners only see history from RangeClamp.NonOwnerFloor onward — a
-    // clamp, not an error (same gate as the booking analysis endpoints)
-    var x = await partnerPnlValidator
-      .ValidateAsyncResult(query, "Invalid PartnerPnlQueryReq")
+    var x = await this.GuardRoleIgnoreCaseAsync(AuthRoles.Owner)
+      .ThenAwait(_ => partnerPnlValidator.ValidateAsyncResult(query, "Invalid PartnerPnlQueryReq"))
       .ThenAwait(q =>
-        partnerEconomicsRepo.Pnl(
-          id,
-          q.ToDomain().ClampHistory(this.HasRoleIgnoreCase(AuthRoles.Owner))
-        )
+        partnerEconomicsRepo.Pnl(id, q.ToDomain().ClampHistory(fullHistory: true))
       )
       .Then(rows => rows.Select(r => r.ToRes()), Errors.MapAll);
     return this.ReturnResult(x);
@@ -170,9 +166,9 @@ public class UserController(
     var token = await tokenDataExtractor.ExtractFromToken(req.IdToken, req.AccessToken);
 
     var userRecord = from u in validatedUser
-      from t in token
-      select u.ToRecord(t);
-    
+                     from t in token
+                     select u.ToRecord(t);
+
     var user = await userRecord.ToAsyncResult()
       .ThenAwait(record => service.Create(id, record))
       .Then(x => x.ToRes(), Errors.MapAll);
@@ -186,8 +182,8 @@ public class UserController(
       .ThenAwait(_ => updateUserReqValidator.ValidateAsyncResult(req, "Invalid UpdateUserReq"));
     var token = await tokenDataExtractor.ExtractFromToken(req.IdToken, req.AccessToken);
     var userRecord = from u in validatedUser
-        from t in token
-        select u.ToRecord(t);
+                     from t in token
+                     select u.ToRecord(t);
     var user = await userRecord.ToAsyncResult()
       .ThenAwait(record => service.Update(id, record))
       .Then(x => (x?.ToRes()).ToResult());

--- a/App/Modules/Users/API/V1/UserMapper.cs
+++ b/App/Modules/Users/API/V1/UserMapper.cs
@@ -30,7 +30,8 @@ public static class UserMapper
       row.WithdrawalGross,
       row.WithdrawalFeeIncome,
       row.BoostCount,
-      row.BoostAmount
+      row.BoostAmount,
+      row.DistinctPassengers
     );
 
   // REQ

--- a/App/Modules/Users/API/V1/UserModel.cs
+++ b/App/Modules/Users/API/V1/UserModel.cs
@@ -21,8 +21,9 @@ public record UserWipeRes(string Id, DateTime WipedAt);
 
 public record PartnerUserRes(string Id, string Username, string Email);
 
-// Bookings is the full ticket count; BoostCount/BoostAmount cover the subset
-// with a consumed priority boost (appended fields — additive wire change)
+// Bookings is the full ticket count; BoostCount counts every consumed boost,
+// including FREE boosts whose null fee contributes 0 to BoostAmount.
+// DistinctPassengers is appended as an additive reselling-signal wire field.
 public record PartnerPnlRowRes(
   string Month,
   int Bookings,
@@ -32,7 +33,8 @@ public record PartnerPnlRowRes(
   decimal WithdrawalGross,
   decimal WithdrawalFeeIncome,
   int BoostCount,
-  decimal BoostAmount
+  decimal BoostAmount,
+  int DistinctPassengers
 );
 
 // ExtraRoles: admin-managed roles for discount/pricing targeting — distinct

--- a/App/Modules/Users/Data/PartnerEconomicsRepository.cs
+++ b/App/Modules/Users/Data/PartnerEconomicsRepository.cs
@@ -45,6 +45,8 @@ public class PartnerEconomicsRepository(
     public int BoostCount { get; set; }
 
     public decimal BoostAmount { get; set; }
+
+    public int DistinctPassengers { get; set; }
   }
 
   public async Task<Result<PartnerUser[]>> ListPartners()
@@ -113,7 +115,9 @@ public class PartnerEconomicsRepository(
             WHERE w."UserId" = {userId}
           )
           SELECT
-            CAST((b."CompletedAt" AT TIME ZONE 'UTC' + INTERVAL '8 hours') AS date) AS "Date",
+            CAST(
+              MIN(b."CompletedAt" AT TIME ZONE 'UTC' + INTERVAL '8 hours') AS date
+            ) AS "Date",
             CAST(COUNT(*) AS int) AS "Bookings",
             SUM(t."Amount") AS "Collected",
             SUM(
@@ -129,15 +133,20 @@ public class PartnerEconomicsRepository(
             CAST(0 AS numeric) AS "Deposits",
             CAST(0 AS numeric) AS "WithdrawalGross",
             CAST(0 AS numeric) AS "WithdrawalFeeIncome",
-            CAST(
-              COUNT(*) FILTER (WHERE b."Priority" AND COALESCE(b."PriorityFee", 0) > 0) AS int
-            ) AS "BoostCount",
+            -- A FREE boost snapshots PriorityFee = NULL: Priority alone is
+            -- consumption, while the amount actually paid is zero.
+            CAST(COUNT(*) FILTER (WHERE b."Priority") AS int) AS "BoostCount",
             SUM(
               CASE
-                WHEN b."Priority" AND COALESCE(b."PriorityFee", 0) > 0 THEN b."PriorityFee"
+                WHEN b."Priority" THEN COALESCE(b."PriorityFee", 0)
                 ELSE 0
               END
-            ) AS "BoostAmount"
+            ) AS "BoostAmount",
+            -- One account carrying many passenger passports is a reseller
+            -- signal; NULL and empty legacy values do not count.
+            CAST(
+              COUNT(DISTINCT NULLIF(b."Passenger_PassportNumber", '')) AS int
+            ) AS "DistinctPassengers"
           FROM "Bookings" b
           JOIN wallet w ON w."UserId" = b."UserId"
           JOIN "Transactions" t ON t."Id" = b."TransactionId"
@@ -152,7 +161,10 @@ public class PartnerEconomicsRepository(
             AND b."CompletedAt" IS NOT NULL
             AND b."CompletedAt" >= {afterUtc}
             AND b."CompletedAt" < {beforeUtc}
-          GROUP BY 1
+          GROUP BY date_trunc(
+            'month',
+            b."CompletedAt" AT TIME ZONE 'UTC' + INTERVAL '8 hours'
+          )
 
           UNION ALL
 
@@ -165,7 +177,8 @@ public class PartnerEconomicsRepository(
             CAST(0 AS numeric) AS "WithdrawalGross",
             CAST(0 AS numeric) AS "WithdrawalFeeIncome",
             CAST(0 AS int) AS "BoostCount",
-            CAST(0 AS numeric) AS "BoostAmount"
+            CAST(0 AS numeric) AS "BoostAmount",
+            CAST(0 AS int) AS "DistinctPassengers"
           FROM "Payments" p
           JOIN wallet w ON w."Id" = p."WalletId"
           WHERE p."Status" = 'SUCCEEDED'
@@ -184,7 +197,8 @@ public class PartnerEconomicsRepository(
             SUM(x."Amount") AS "WithdrawalGross",
             SUM(COALESCE(x."Fee", 0)) AS "WithdrawalFeeIncome",
             CAST(0 AS int) AS "BoostCount",
-            CAST(0 AS numeric) AS "BoostAmount"
+            CAST(0 AS numeric) AS "BoostAmount",
+            CAST(0 AS int) AS "DistinctPassengers"
           FROM "Withdrawals" x
           JOIN wallet w ON w."Id" = x."WalletId"
           WHERE x."Status" = {completedWithdrawal}
@@ -208,6 +222,7 @@ public class PartnerEconomicsRepository(
           WithdrawalFeeIncome = d.WithdrawalFeeIncome,
           BoostCount = d.BoostCount,
           BoostAmount = d.BoostAmount,
+          DistinctPassengers = d.DistinctPassengers,
         }),
         query.After,
         query.Before

--- a/Domain/User/PartnerEconomics.cs
+++ b/Domain/User/PartnerEconomics.cs
@@ -23,19 +23,25 @@ public record PartnerPnlQuery
   public DateOnly? Before { get; init; }
 }
 
-// One DB-side daily subtotal from one source. UNION ALL emits sparse rows;
-// the pure calculator below merges them by SGT calendar month.
+// One DB-side source subtotal. UNION ALL emits sparse rows; booking rows are
+// already monthly so passenger passports stay genuinely distinct for the
+// month, while the pure calculator merges every source by SGT calendar month.
 public record PartnerPnlDailySum
 {
   public required DateOnly Date { get; init; }
 
   public required int Bookings { get; init; }
 
-  // completed bookings with a consumed priority boost (Priority && a positive
-  // PriorityFee — the same guard the analysis page uses) and their fee sum
+  // completed bookings with a consumed priority boost (Priority = true,
+  // including FREE boosts whose PriorityFee snapshot is null) and what the
+  // partner actually paid for them
   public required int BoostCount { get; init; }
 
   public required decimal BoostAmount { get; init; }
+
+  // distinct non-null, non-empty passenger passport numbers across the
+  // completed bookings represented by this subtotal
+  public required int DistinctPassengers { get; init; }
 
   public required decimal Collected { get; init; }
 
@@ -71,6 +77,9 @@ public record PartnerPnlRow
   public required int BoostCount { get; init; }
 
   public required decimal BoostAmount { get; init; }
+
+  // many distinct passenger passports on one account is a reselling signal
+  public required int DistinctPassengers { get; init; }
 }
 
 public static class PartnerPnlCalculator
@@ -95,6 +104,7 @@ public static class PartnerPnlCalculator
           WithdrawalFeeIncome = g.Sum(d => d.WithdrawalFeeIncome),
           BoostCount = g.Sum(d => d.BoostCount),
           BoostAmount = g.Sum(d => d.BoostAmount),
+          DistinctPassengers = g.Sum(d => d.DistinctPassengers),
         })
         .Where(r =>
           r.Bookings != 0
@@ -105,6 +115,7 @@ public static class PartnerPnlCalculator
           || r.WithdrawalFeeIncome != 0m
           || r.BoostCount != 0
           || r.BoostAmount != 0m
+          || r.DistinctPassengers != 0
         )
         .OrderBy(r => r.Month[3..])
         .ThenBy(r => r.Month[..2]),

--- a/UnitTest/Users/PartnerEconomicsOwnerAuthorizationTests.cs
+++ b/UnitTest/Users/PartnerEconomicsOwnerAuthorizationTests.cs
@@ -1,0 +1,123 @@
+using App.Modules.Users.API.V1;
+using App.StartUp.Registry;
+using App.StartUp.Services.Auth;
+using CSharp_Result;
+using Domain.User;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace UnitTest.Users;
+
+public class PartnerEconomicsOwnerAuthorizationTests
+{
+  [Fact]
+  public async Task Partners_rejects_non_owner_before_repository_access()
+  {
+    var repository = new FakePartnerEconomicsRepository();
+    var controller = Controller([AuthRoles.Admin], repository);
+
+    var response = await controller.Partners();
+
+    response.Result.Should().BeOfType<StatusCodeResult>()
+      .Which.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+    repository.ListCalls.Should().Be(0);
+  }
+
+  [Fact]
+  public async Task Partner_pnl_rejects_non_owner_before_validation_or_repository_access()
+  {
+    var repository = new FakePartnerEconomicsRepository();
+    var controller = Controller([AuthRoles.Admin], repository);
+
+    var response = await controller.PartnerPnl(
+      "partner-1",
+      new PartnerPnlQueryReq("not-a-date", null),
+      new PartnerPnlQueryReqValidator()
+    );
+
+    response.Result.Should().BeOfType<StatusCodeResult>()
+      .Which.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+    repository.PnlCalls.Should().Be(0);
+  }
+
+  [Fact]
+  public async Task Partners_accepts_owner_role_case_insensitively()
+  {
+    var repository = new FakePartnerEconomicsRepository();
+    var controller = Controller([AuthRoles.Admin, "OwNeR"], repository);
+
+    var response = await controller.Partners();
+
+    response.Result.Should().BeOfType<OkObjectResult>();
+    repository.ListCalls.Should().Be(1);
+  }
+
+  [Fact]
+  public async Task Partner_pnl_accepts_owner_role_case_insensitively()
+  {
+    var repository = new FakePartnerEconomicsRepository();
+    var controller = Controller([AuthRoles.Admin, "OWNER"], repository);
+
+    var response = await controller.PartnerPnl(
+      "partner-1",
+      new PartnerPnlQueryReq(null, null),
+      new PartnerPnlQueryReqValidator()
+    );
+
+    response.Result.Should().BeOfType<OkObjectResult>();
+    repository.PnlCalls.Should().Be(1);
+  }
+
+  private static UserController Controller(
+    string[] roles,
+    IPartnerEconomicsRepository repository
+  ) =>
+    new(null!, null!, repository, null!, null!, null!, null!, new FakeAuthHelper(roles))
+    {
+      ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
+    };
+
+  private sealed class FakePartnerEconomicsRepository : IPartnerEconomicsRepository
+  {
+    public int ListCalls { get; private set; }
+
+    public int PnlCalls { get; private set; }
+
+    public Task<Result<PartnerUser[]>> ListPartners()
+    {
+      this.ListCalls++;
+      return Task.FromResult((Result<PartnerUser[]>)Array.Empty<PartnerUser>());
+    }
+
+    public Task<Result<PartnerPnlRow[]>> Pnl(string userId, PartnerPnlQuery query)
+    {
+      this.PnlCalls++;
+      return Task.FromResult((Result<PartnerPnlRow[]>)Array.Empty<PartnerPnlRow>());
+    }
+  }
+
+  private sealed class FakeAuthHelper(string[] roles) : IAuthHelper
+  {
+    public bool HasAll(
+      System.Security.Claims.ClaimsPrincipal? user,
+      string field,
+      params string[] scopes
+    ) => scopes.All(scope => roles.Contains(scope));
+
+    public bool HasAny(
+      System.Security.Claims.ClaimsPrincipal? user,
+      string field,
+      params string[] scopes
+    ) => scopes.Any(scope => roles.Contains(scope));
+
+    public IEnumerable<string> FieldToScope(
+      System.Security.Claims.ClaimsPrincipal? user,
+      string field
+    ) => field == AuthRoles.Field ? roles : [];
+
+    public ILogger<IAuthHelper> Logger => NullLogger<IAuthHelper>.Instance;
+  }
+}

--- a/UnitTest/Users/PartnerEconomicsWireContractTests.cs
+++ b/UnitTest/Users/PartnerEconomicsWireContractTests.cs
@@ -42,6 +42,7 @@ public class PartnerEconomicsWireContractTests
         WithdrawalFeeIncome = 4m,
         BoostCount = 2,
         BoostAmount = 9.9m,
+        DistinctPassengers = 3,
       },
     };
 
@@ -51,7 +52,8 @@ public class PartnerEconomicsWireContractTests
       .Be(
         "[{\"month\":\"08-2026\",\"bookings\":3,\"collected\":135.5,"
           + "\"ktmbCost\":61.2,\"deposits\":200,\"withdrawalGross\":90,"
-          + "\"withdrawalFeeIncome\":4,\"boostCount\":2,\"boostAmount\":9.9}]"
+          + "\"withdrawalFeeIncome\":4,\"boostCount\":2,\"boostAmount\":9.9,"
+          + "\"distinctPassengers\":3}]"
       );
   }
 

--- a/UnitTest/Users/PartnerPnlCalculatorTests.cs
+++ b/UnitTest/Users/PartnerPnlCalculatorTests.cs
@@ -16,7 +16,8 @@ public class PartnerPnlCalculatorTests
     decimal withdrawalGross = 0m,
     decimal withdrawalFeeIncome = 0m,
     int boostCount = 0,
-    decimal boostAmount = 0m
+    decimal boostAmount = 0m,
+    int distinctPassengers = 0
   ) =>
     new()
     {
@@ -29,6 +30,7 @@ public class PartnerPnlCalculatorTests
       WithdrawalFeeIncome = withdrawalFeeIncome,
       BoostCount = boostCount,
       BoostAmount = boostAmount,
+      DistinctPassengers = distinctPassengers,
     };
 
   [Fact]
@@ -48,7 +50,8 @@ public class PartnerPnlCalculatorTests
           collected: 135m,
           ktmbCost: 61.2m,
           boostCount: 2,
-          boostAmount: 9.9m
+          boostAmount: 9.9m,
+          distinctPassengers: 3
         ),
       ],
       null,
@@ -70,6 +73,7 @@ public class PartnerPnlCalculatorTests
           WithdrawalFeeIncome = 4m,
           BoostCount = 2,
           BoostAmount = 9.9m,
+          DistinctPassengers = 3,
         }
       );
   }
@@ -92,6 +96,22 @@ public class PartnerPnlCalculatorTests
     rows.Select(r => r.Month).Should().Equal("08-2026", "09-2026", "01-2027");
     rows[0].Deposits.Should().Be(5m);
     rows[1].Bookings.Should().Be(1, "a completed zero-price booking still makes the month non-empty");
+  }
+
+  [Fact]
+  public void Free_boost_consumption_remains_visible_when_the_amount_paid_is_zero()
+  {
+    // The repository normalizes a FREE boost's null PriorityFee snapshot to
+    // zero, but Priority = true still contributes one consumed boost.
+    var rows = PartnerPnlCalculator.Analyze(
+      [Day(bookings: 1, boostCount: 1, boostAmount: 0m)],
+      null,
+      null
+    );
+
+    rows.Should().ContainSingle();
+    rows[0].BoostCount.Should().Be(1);
+    rows[0].BoostAmount.Should().Be(0m);
   }
 
   [Fact]


### PR DESCRIPTION
## Summary
- count every completed `Priority = true` booking as consumed boost, including FREE boosts whose null fee contributes S$0 paid
- add monthly `distinctPassengers` from distinct non-empty passenger passport numbers
- require a case-insensitive `owner` role for both partner listing and partner P&L endpoints

## Verification
- partner-focused unit tests: 12 passed
- full unit suite excluding the documented local-only wall-clock failure: 782 passed
- full unit suite otherwise reaches only the documented `Terminate_keeps_the_priority_fee` failure
- `dotnet format --verify-no-changes` passed for all touched C# files