### PR TITLE
fix(payments): tolerate repeated statuses when mapping history to dictionary

### DIFF
--- a/App/Modules/Payments/Data/PaymentMapper.cs
+++ b/App/Modules/Payments/Data/PaymentMapper.cs
@@ -32,9 +32,12 @@ public static class PaymentMapper
       Reference = data.ToReference(),
       Record = data.ToRecord(),
       CreatedAt = data.CreatedAt,
+      // history is an append-only list, so a status can repeat (e.g. a 3DS
+      // retry loop) — keep the latest occurrence per status or ToDictionary
+      // throws on the duplicate key and 500s every read of the payment
       Statuses = data
-        .Statuses.Statuses.Select(x => new KeyValuePair<string, DateTime>(x.Status, x.Updated))
-        .ToDictionary(),
+        .Statuses.Statuses.GroupBy(x => x.Status)
+        .ToDictionary(g => g.Key, g => g.Max(x => x.Updated)),
     };
 
   public static Payment ToDomain(this PaymentData data) =>

--- a/UnitTest/Payments/PaymentMapperStatusesTests.cs
+++ b/UnitTest/Payments/PaymentMapperStatusesTests.cs
@@ -1,0 +1,81 @@
+using App.Modules.Payments.Data;
+using FluentAssertions;
+
+namespace UnitTest.Payments;
+
+// The status history is an append-only list, so a status can repeat (e.g. a
+// 3DS retry loop bouncing REQUIRES_PAYMENT_METHOD ↔ REQUIRES_CUSTOMER_ACTION).
+// ToPrincipal must collapse repeats to the latest occurrence per status
+// instead of throwing on the duplicate dictionary key — that exception 500ed
+// every read AND every webhook update of such payments.
+public class PaymentMapperStatusesTests
+{
+  private static PaymentData Make(params (string Status, DateTime Updated)[] history) =>
+    new()
+    {
+      Id = Guid.NewGuid(),
+      ExternalReference = "int_test",
+      Gateway = "airwallex",
+      CreatedAt = DateTime.UtcNow,
+      Amount = 50m,
+      CapturedAmount = 0m,
+      Currency = "SGD",
+      LastUpdated = DateTime.UtcNow,
+      Status = history.Length == 0 ? "created" : history[^1].Status,
+      Statuses = new PaymentStatusData
+      {
+        Statuses = history
+          .Select(x => new PaymentStatusEntryData { Status = x.Status, Updated = x.Updated })
+          .ToList(),
+      },
+      WalletId = Guid.NewGuid(),
+    };
+
+  [Fact]
+  public void ToPrincipal_WithRepeatedStatuses_KeepsLatestPerStatus()
+  {
+    var t0 = new DateTime(2026, 7, 22, 0, 21, 0, DateTimeKind.Utc);
+    var t1 = new DateTime(2026, 7, 22, 0, 31, 0, DateTimeKind.Utc);
+    var t2 = new DateTime(2026, 7, 22, 5, 54, 0, DateTimeKind.Utc);
+
+    var data = Make(
+      ("created", t0),
+      ("REQUIRES_PAYMENT_METHOD", t0),
+      ("REQUIRES_CUSTOMER_ACTION", t0),
+      ("REQUIRES_PAYMENT_METHOD", t1),
+      ("REQUIRES_CUSTOMER_ACTION", t1),
+      ("REQUIRES_PAYMENT_METHOD", t2),
+      ("REQUIRES_CUSTOMER_ACTION", t2)
+    );
+
+    var principal = data.ToPrincipal();
+
+    principal.Statuses.Should().HaveCount(3);
+    principal.Statuses["created"].Should().Be(t0);
+    principal.Statuses["REQUIRES_PAYMENT_METHOD"].Should().Be(t2);
+    principal.Statuses["REQUIRES_CUSTOMER_ACTION"].Should().Be(t2);
+  }
+
+  [Fact]
+  public void ToPrincipal_WithUniqueStatuses_MapsAll()
+  {
+    var t0 = new DateTime(2026, 7, 20, 2, 57, 0, DateTimeKind.Utc);
+    var t1 = new DateTime(2026, 7, 20, 2, 59, 0, DateTimeKind.Utc);
+
+    var data = Make(("created", t0), ("SUCCEEDED", t1));
+
+    var principal = data.ToPrincipal();
+
+    principal.Statuses.Should().HaveCount(2);
+    principal.Statuses["created"].Should().Be(t0);
+    principal.Statuses["SUCCEEDED"].Should().Be(t1);
+  }
+
+  [Fact]
+  public void ToPrincipal_WithEmptyHistory_MapsEmpty()
+  {
+    var principal = Make().ToPrincipal();
+
+    principal.Statuses.Should().BeEmpty();
+  }
+}


### PR DESCRIPTION
## Summary

- **Prod bug**: `PaymentMapper.ToPrincipal` flattens the append-only status history into a `Dictionary` keyed by status name via `ToDictionary()`, which throws `ArgumentException` on the first repeated status.
- A payment stuck in a 3DS retry loop (e.g. `REQUIRES_PAYMENT_METHOD` ↔ `REQUIRES_CUSTOMER_ACTION` bouncing for hours) accumulates dozens of duplicate entries, after which:
  - `GET /Payment?WalletId=…` **500s for the whole wallet** (breaks the admin per-user payments card), and
  - **every Airwallex webhook update 500s** after `SaveChangesAsync` when mapping the result back — Airwallex keeps retrying (observed live on raichu: intents `int_sgpdvjrlkhkm6ijzcc4` and payment `73018b85…`).
- Fix: collapse repeats to the **latest occurrence per status** (`GroupBy(...).ToDictionary(g => g.Key, g => g.Max(x => x.Updated))`). API shape unchanged (`statuses: Record<string, string>` already has per-status semantics).
- **Read-path only** — stored history untouched, no migration; all existing affected rows map fine once deployed.

## Test plan

- new `PaymentMapperStatusesTests`: repeated statuses keep latest per status; unique statuses map all; empty history maps empty — 3/3 pass
- full `UnitTest.Payments` suite: 46/46 pass
- `dotnet build`: 0 errors

https://claude.ai/code/session_01XDtmdmD8g5HDY1kEDH3i8b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed payment status processing when the same status appears multiple times in its history.
  * Payment records now retain the latest timestamp for each status instead of failing during retrieval.

* **Tests**
  * Added coverage for repeated statuses, unique statuses, and empty status histories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->