### PR TITLE
feat(withdrawals): export tax evidence csv

### DIFF
--- a/App/Migrations/20260728021150_AddWithdrawalCreatedAtIdIndex.Designer.cs
+++ b/App/Migrations/20260728021150_AddWithdrawalCreatedAtIdIndex.Designer.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using App.StartUp.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace App.Migrations
 {
     [DbContext(typeof(MainDbContext))]
-    partial class MainDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260728021150_AddWithdrawalCreatedAtIdIndex")]
+    partial class AddWithdrawalCreatedAtIdIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/App/Migrations/20260728021150_AddWithdrawalCreatedAtIdIndex.cs
+++ b/App/Migrations/20260728021150_AddWithdrawalCreatedAtIdIndex.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace App.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWithdrawalCreatedAtIdIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_Withdrawals_CreatedAt_Id",
+                table: "Withdrawals",
+                columns: new[] { "CreatedAt", "Id" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Withdrawals_CreatedAt_Id",
+                table: "Withdrawals");
+        }
+    }
+}

--- a/App/Modules/DomainServices.cs
+++ b/App/Modules/DomainServices.cs
@@ -120,12 +120,19 @@ public static class DomainServices
     // Withdrawal
     s.AddScoped<IWithdrawalService, WithdrawalService>().AutoTrace<IWithdrawalService>();
 
-    s.AddScoped<IWithdrawalRepository, WithdrawalRepository>().AutoTrace<IWithdrawalRepository>();
+    s.AddScoped<WithdrawalRepository>();
+    s.AddScoped<IWithdrawalRepository>(sp => sp.GetRequiredService<WithdrawalRepository>())
+      .AutoTrace<IWithdrawalRepository>();
+
+    s.AddScoped<IWithdrawalExportRepository>(sp => sp.GetRequiredService<WithdrawalRepository>())
+      .AutoTrace<IWithdrawalExportRepository>();
 
     s.AddScoped<IWithdrawalStorage, WithdrawalStorage>().AutoTrace<IWithdrawalStorage>();
 
     s.AddScoped<IWithdrawalImageEnricher, WithdrawalImageEnricher>()
       .AutoTrace<IWithdrawalImageEnricher>();
+
+    s.AddScoped<IWithdrawalExporter, WithdrawalExporter>().AutoTrace<IWithdrawalExporter>();
 
     s.AddScoped<IFeeCalculator, FeeCalculator>().AutoTrace<IFeeCalculator>();
 

--- a/App/Modules/Withdrawals/API/V1/WithdrawalController.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalController.cs
@@ -1,4 +1,5 @@
 using System.Net.Mime;
+using System.Text;
 using App.Error.V1;
 using App.Modules.Common;
 using App.StartUp.Options;
@@ -26,8 +27,10 @@ public class WithdrawalController(
   RejectWithdrawalReqValidator rejectWithdrawalReqValidator,
   CancelWithdrawalReqValidator cancelWithdrawalReqValidator,
   SearchWithdrawalQueryValidator searchWithdrawalQueryValidator,
+  ExportWithdrawalQueryValidator exportWithdrawalQueryValidator,
   SetWithdrawalSettingsReqValidator setWithdrawalSettingsReqValidator,
   IWithdrawalImageEnricher enrich,
+  IWithdrawalExporter exporter,
   IFeeCalculator feeCalculator,
   IOptionsSnapshot<WithdrawalOption> withdrawalOptions,
   IAuthHelper h
@@ -61,6 +64,69 @@ public class WithdrawalController(
       .ThenAwait(x => enrich.Enrich(x));
 
     return this.ReturnResult(x);
+  }
+
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("export")]
+  [ProducesResponseType<string>(StatusCodes.Status200OK, "text/csv")]
+  public async Task<ActionResult> Export([FromQuery] ExportWithdrawalQuery query)
+  {
+    var validated = await exportWithdrawalQueryValidator.ValidateAsyncResult(
+      query,
+      "Invalid ExportWithdrawalQuery"
+    );
+    if (validated.IsFailure())
+      return this.ReturnUnitResult((Result<Unit>)validated.FailureOrDefault());
+
+    PreparedWithdrawalExport prepared;
+    try
+    {
+      var preparedResult = await exporter.Prepare(
+        validated.SuccessOrDefault().ToDomain(),
+        this.HttpContext.RequestAborted
+      );
+      if (preparedResult.IsFailure())
+        return this.ReturnUnitResult((Result<Unit>)preparedResult.FailureOrDefault());
+      prepared = preparedResult.SuccessOrDefault();
+    }
+    catch (OperationCanceledException) when (this.HttpContext.RequestAborted.IsCancellationRequested)
+    {
+      this.HttpContext.Abort();
+      return new EmptyResult();
+    }
+
+    this.Response.ContentType = "text/csv; charset=utf-8";
+    this.Response.Headers.ContentDisposition =
+      $"attachment; filename=\"{WithdrawalCsv.FileName(query.After, query.Before)}\"";
+    this.Response.Headers["Access-Control-Expose-Headers"] = "Content-Disposition";
+    this.Response.Headers.CacheControl = "no-store";
+
+    try
+    {
+      Result<Unit> written;
+      {
+        await using var writer = new StreamWriter(
+          this.Response.Body,
+          new UTF8Encoding(false),
+          bufferSize: 64 * 1024,
+          leaveOpen: true
+        );
+        written = await exporter.Write(prepared, writer, this.HttpContext.RequestAborted);
+        await writer.FlushAsync();
+      }
+      if (written.IsFailure())
+        this.HttpContext.Abort();
+    }
+    catch (OperationCanceledException) when (this.HttpContext.RequestAborted.IsCancellationRequested)
+    {
+      this.HttpContext.Abort();
+    }
+    catch
+    {
+      this.HttpContext.Abort();
+      throw;
+    }
+
+    return new EmptyResult();
   }
 
   [Authorize, HttpGet("{id:guid}")]

--- a/App/Modules/Withdrawals/API/V1/WithdrawalCsv.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalCsv.cs
@@ -1,0 +1,254 @@
+using System.Globalization;
+using System.Text;
+using Domain.Withdrawal;
+
+namespace App.Modules.Withdrawals.API.V1;
+
+// One fully-rendered line of the tax-evidence export. Every member is already
+// a display string: the flattening (null payout -> blank, fragment lists ->
+// ';'-joined) happens once, in ToExportRow, so the writer only quotes.
+public record WithdrawalExportRow
+{
+  public required string WithdrawalId { get; init; }
+  public required string CreatedAt { get; init; }
+  public required string CompletedAt { get; init; }
+  public required string Status { get; init; }
+  public required string Method { get; init; }
+  public required string UserId { get; init; }
+  public required string UserEmail { get; init; }
+  public required string GrossAmount { get; init; }
+  public required string Fee { get; init; }
+  public required string NetAmount { get; init; }
+  public required string PayNowNumber { get; init; }
+  public required string AirwallexConfirmation { get; init; }
+  public required string PayoutAttempt { get; init; }
+  public required string ReconcileAttempts { get; init; }
+  public required string CompleterId { get; init; }
+  public required string CompletionNote { get; init; }
+  public required string ReceiptUrl { get; init; }
+  public required string RefundPaymentIntentIds { get; init; }
+  public required string RefundAirwallexIds { get; init; }
+  public required string RefundAmounts { get; init; }
+  public required string RefundStatuses { get; init; }
+  public required string RefundSettledAts { get; init; }
+
+  // The presigned receipt_url expires; this permanent object key is the
+  // durable reference an admin can re-resolve long after the export.
+  public required string ReceiptKey { get; init; }
+
+  // Delegates to the one ordered column table so a cell can never drift out
+  // of alignment with its header.
+  public string[] ToFields() => WithdrawalCsv.Fields(this);
+}
+
+// RFC 4180 rendering for the withdrawal tax export. The file is opened in
+// Excel/Sheets by an accountant, so two things matter beyond plain quoting:
+// a UTF-8 BOM (so non-ASCII names survive) and formula-injection defanging.
+public static class WithdrawalCsv
+{
+  // The single source of truth for the export contract: each header paired
+  // with the cell that fills it. Headers and data rows are both derived from
+  // this table, so a column can only be added or removed on both sides at
+  // once — misalignment is impossible by construction.
+  //
+  // Column order is part of the contract with the accountant's importer —
+  // append only, never reorder.
+  private static readonly (string Header, Func<WithdrawalExportRow, string> Get)[] Columns =
+  [
+    ("withdrawal_id", r => r.WithdrawalId),
+    ("created_at", r => r.CreatedAt),
+    ("completed_at", r => r.CompletedAt),
+    ("status", r => r.Status),
+    ("method", r => r.Method),
+    ("user_id", r => r.UserId),
+    ("user_email", r => r.UserEmail),
+    ("gross_amount", r => r.GrossAmount),
+    ("fee", r => r.Fee),
+    ("net_amount", r => r.NetAmount),
+    ("paynow_number", r => r.PayNowNumber),
+    ("airwallex_confirmation", r => r.AirwallexConfirmation),
+    ("payout_attempt", r => r.PayoutAttempt),
+    ("reconcile_attempts", r => r.ReconcileAttempts),
+    ("completer_id", r => r.CompleterId),
+    ("completion_note", r => r.CompletionNote),
+    ("receipt_url", r => r.ReceiptUrl),
+    ("refund_payment_intent_ids", r => r.RefundPaymentIntentIds),
+    ("refund_airwallex_ids", r => r.RefundAirwallexIds),
+    ("refund_amounts", r => r.RefundAmounts),
+    ("refund_statuses", r => r.RefundStatuses),
+    ("refund_settled_ats", r => r.RefundSettledAts),
+    ("receipt_key", r => r.ReceiptKey),
+  ];
+
+  public static readonly string[] Headers = Columns.Select(c => c.Header).ToArray();
+
+  internal static string[] Fields(WithdrawalExportRow row) =>
+    Columns.Select(c => c.Get(row)).ToArray();
+
+  // RFC 4180 mandates CRLF between records
+  public const string LineEnding = "\r\n";
+
+  public const string Bom = "\uFEFF";
+
+  // Separator inside the five index-aligned refund_* columns. Gateway ids,
+  // fixed-point amounts, status names and ISO timestamps never contain it,
+  // so the lists stay losslessly splittable.
+  public const char RefundSeparator = ';';
+
+  private const string DecimalFormat = "0.00";
+
+  // Withdrawals have existed only since 2024, long after Singapore settled on
+  // UTC+08:00 without daylight saving. A fixed offset keeps export rendering
+  // deterministic without making this type depend on host tzdata.
+  private static readonly TimeSpan SingaporeOffset = TimeSpan.FromHours(8);
+
+  // Excel/Sheets evaluate a cell as a formula when it opens with one of
+  // these; a leading tab or CR also lets the payload sneak past naive
+  // filters. Prefixing with an apostrophe forces the cell to text.
+  private static readonly char[] FormulaTriggers = ['=', '+', '-', '@', '\t', '\r'];
+
+  // Encoded through the same line writer as the data rows. Every header is a
+  // lowercase snake_case identifier, so Field is a no-op on them and the
+  // output is byte-identical to a plain join — but there is now only one
+  // place that decides how a line is assembled.
+  public static string HeaderLine => Line(Headers);
+
+  // Defang first, then quote: the apostrophe must live INSIDE the quotes so
+  // the spreadsheet sees it as the cell's first character.
+  public static string Field(string? raw)
+  {
+    var value = raw ?? "";
+    if (value.Length > 0 && FormulaTriggers.Contains(value[0]))
+      value = "'" + value;
+
+    var needsQuoting =
+      value.Contains(',')
+      || value.Contains('"')
+      || value.Contains('\r')
+      || value.Contains('\n');
+
+    if (!needsQuoting)
+      return value;
+
+    return "\"" + value.Replace("\"", "\"\"") + "\"";
+  }
+
+  private static string Line(IEnumerable<string> fields) => string.Join(",", fields.Select(Field));
+
+  public static string Line(WithdrawalExportRow row) => Line(row.ToFields());
+
+  // Fixed 2dp, invariant culture: no thousands separator, no currency symbol
+  public static string Amount(decimal value) =>
+    value.ToString(DecimalFormat, CultureInfo.InvariantCulture);
+
+  // Export timestamps in the same business timezone that defines the
+  // repository's Before/After calendar-day filters. Database values returned
+  // as Unspecified are UTC in this stack, never server-local wall-clock time.
+  public static string Timestamp(DateTime value)
+  {
+    var singapore = new DateTimeOffset(ToUtc(value)).ToOffset(SingaporeOffset);
+    return singapore.ToString("yyyy-MM-dd'T'HH:mm:sszzz", CultureInfo.InvariantCulture);
+  }
+
+  public static string Timestamp(DateTime? value) => value is null ? "" : Timestamp(value.Value);
+
+  private static DateTime ToUtc(DateTime value) =>
+    value.Kind switch
+    {
+      DateTimeKind.Utc => value,
+      DateTimeKind.Unspecified => DateTime.SpecifyKind(value, DateTimeKind.Utc),
+      _ => value.ToUniversalTime(),
+    };
+
+  private static string JoinFragments(
+    IReadOnlyList<WithdrawalRefundFragment> fragments,
+    Func<WithdrawalRefundFragment, string?> select
+  ) => string.Join(RefundSeparator, fragments.Select(f => select(f) ?? ""));
+
+  // Domain -> one export line.
+  //
+  // Fee/net stay BLANK for terminal no-payment statuses (Pending, Rejected,
+  // Cancel) even when stale approval-time payout data remains: emitting gross
+  // as net there would overstate the deduction, and a 0.00 would wrongly
+  // imply money moved.
+  //
+  // They also stay blank for a null payout in Processing and
+  // RequireManualIntervention. Those statuses were appended alongside the
+  // payout feature and Approve always writes a payout before a row can reach
+  // them, so a null payout there is impossible by construction — and even if
+  // one appeared, that money is initiated, not settled, so blank is honest.
+  public static WithdrawalExportRow ToExportRow(this Withdrawal w, string? receiptUrl)
+  {
+    var p = w.Principal;
+    var payout = p.Payout;
+    var fragments = w.Refunds;
+    var isCardRefund = p.Record.Method == WithdrawalMethod.CardRefund;
+    var hasPayment = payout is not null
+      && p.Status.Status is not (WithdrawStatus.Pending or WithdrawStatus.Rejected or WithdrawStatus.Cancel);
+    // Withdrawals completed before the payout columns existed (migration
+    // 20260708060802, Jul 2026) have no payout row at all: the pre-fee
+    // Complete transferred the full amount and charged nothing. Exporting
+    // those as blank would empty both money columns for ~2.5 years of
+    // history — exactly the rows a tax export exists to produce.
+    var legacyCompleted = payout is null && p.Status.Status is WithdrawStatus.Completed;
+
+    return new WithdrawalExportRow
+    {
+      WithdrawalId = p.Id.ToString(),
+      CreatedAt = Timestamp(p.CreatedAt),
+      CompletedAt = Timestamp(p.Complete?.CompletedAt),
+      Status = p.Status.Status.ToRes(),
+      Method = p.Record.Method.ToRes(),
+      UserId = w.User.Id,
+      UserEmail = w.User.Record.Email ?? "",
+      GrossAmount = Amount(p.Record.Amount),
+      Fee = hasPayment ? Amount(payout!.Fee)
+        : legacyCompleted ? Amount(0m)
+        : "",
+      // the fee is retained by the business; the user receives gross - fee.
+      // Snapshotted at approval, so it matches the transfer that happened —
+      // never re-derived from the current fee configuration.
+      NetAmount = hasPayment ? Amount(p.Record.Amount - payout!.Fee)
+        : legacyCompleted ? Amount(p.Record.Amount)
+        : "",
+      PayNowNumber = isCardRefund ? "" : p.Record.PayNowNumber ?? "",
+      AirwallexConfirmation = payout?.ConfirmationNumber ?? "",
+      PayoutAttempt = payout is null ? "" : payout.Attempt.ToString(CultureInfo.InvariantCulture),
+      ReconcileAttempts = payout is null
+        ? ""
+        : payout.ReconcileAttempts.ToString(CultureInfo.InvariantCulture),
+      CompleterId = p.Complete?.CompleterId ?? "",
+      CompletionNote = p.Complete?.Note ?? "",
+      ReceiptUrl = receiptUrl ?? "",
+      RefundPaymentIntentIds = isCardRefund
+        ? JoinFragments(fragments, f => f.PaymentIntentId)
+        : "",
+      RefundAirwallexIds = isCardRefund
+        ? JoinFragments(fragments, f => f.AirwallexRefundId)
+        : "",
+      RefundAmounts = isCardRefund ? JoinFragments(fragments, f => Amount(f.Amount)) : "",
+      RefundStatuses = isCardRefund ? JoinFragments(fragments, f => f.Status.ToRes()) : "",
+      RefundSettledAts = isCardRefund ? JoinFragments(fragments, f => Timestamp(f.SettledAt)) : "",
+      // permanent storage key; receipt_url next to it is a presigned link
+      // that expires, so this is what survives in an archived CSV
+      ReceiptKey = p.Complete?.Receipt ?? "",
+    };
+  }
+
+  // filename hint: withdrawals-{after}_{before}.csv, with readable stand-ins
+  // for an open-ended bound
+  public static string FileName(string? after, string? before)
+  {
+    var from = string.IsNullOrWhiteSpace(after) ? "earliest" : after;
+    var to = string.IsNullOrWhiteSpace(before) ? "latest" : before;
+    return $"withdrawals-{Sanitize(from)}_{Sanitize(to)}.csv";
+  }
+
+  private static string Sanitize(string value)
+  {
+    var sb = new StringBuilder(value.Length);
+    foreach (var c in value)
+      sb.Append(char.IsLetterOrDigit(c) || c is '-' or '_' ? c : '-');
+    return sb.ToString();
+  }
+}

--- a/App/Modules/Withdrawals/API/V1/WithdrawalExporter.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalExporter.cs
@@ -1,0 +1,141 @@
+using CSharp_Result;
+using Domain;
+using Domain.Withdrawal;
+
+namespace App.Modules.Withdrawals.API.V1;
+
+public record PreparedWithdrawalExport(
+  WithdrawalSearch Search,
+  IReadOnlyList<Withdrawal> FirstPage,
+  IReadOnlyList<string> FirstReceiptLinks
+);
+
+public interface IWithdrawalExporter
+{
+  // Fetches the first page before HTTP headers/body are written, allowing a
+  // repository or storage failure to remain a normal API error response.
+  Task<Result<PreparedWithdrawalExport>> Prepare(
+    WithdrawalSearch search,
+    CancellationToken cancellationToken = default
+  );
+
+  // Writes one complete CSV stream. A failure after output begins is returned
+  // to the controller so it can abort the connection rather than hand over a
+  // plausible-but-truncated evidence file.
+  Task<Result<Unit>> Write(
+    PreparedWithdrawalExport export,
+    TextWriter writer,
+    CancellationToken cancellationToken = default
+  );
+}
+
+public class WithdrawalExporter(
+  IWithdrawalExportRepository repository,
+  IWithdrawalStorage storage
+) : IWithdrawalExporter
+{
+  public const int PageSize = 100;
+
+  public async Task<Result<PreparedWithdrawalExport>> Prepare(
+    WithdrawalSearch search,
+    CancellationToken cancellationToken = default
+  )
+  {
+    cancellationToken.ThrowIfCancellationRequested();
+    var firstPage = await repository.SearchExport(
+      search,
+      PageSize,
+      cursor: null,
+      cancellationToken: cancellationToken
+    );
+    if (firstPage.IsFailure())
+      return firstPage.FailureOrDefault();
+
+    var receiptLinks = await this.GetReceiptLinks(firstPage.SuccessOrDefault());
+    return receiptLinks.IsFailure()
+      ? receiptLinks.FailureOrDefault()
+      : new PreparedWithdrawalExport(
+        search,
+        firstPage.SuccessOrDefault(),
+        receiptLinks.SuccessOrDefault()
+      );
+  }
+
+  public async Task<Result<Unit>> Write(
+    PreparedWithdrawalExport export,
+    TextWriter writer,
+    CancellationToken cancellationToken = default
+  )
+  {
+    cancellationToken.ThrowIfCancellationRequested();
+    await writer.WriteAsync(WithdrawalCsv.Bom);
+    await writer.WriteAsync(WithdrawalCsv.HeaderLine);
+    await writer.WriteAsync(WithdrawalCsv.LineEnding);
+
+    var page = export.FirstPage;
+    var receiptLinks = export.FirstReceiptLinks;
+    while (true)
+    {
+      await this.WritePage(page, receiptLinks, writer, cancellationToken);
+
+      await writer.FlushAsync();
+      if (page.Count < PageSize)
+        return new Unit();
+
+      var cursor = new WithdrawalExportCursor(page[^1].Principal.CreatedAt, page[^1].Principal.Id);
+      cancellationToken.ThrowIfCancellationRequested();
+      var nextPage = await repository.SearchExport(
+        export.Search,
+        PageSize,
+        cursor,
+        cancellationToken
+      );
+      if (nextPage.IsFailure())
+        return nextPage.FailureOrDefault();
+      page = nextPage.SuccessOrDefault();
+      var nextReceiptLinks = await this.GetReceiptLinks(page);
+      if (nextReceiptLinks.IsFailure())
+        return nextReceiptLinks.FailureOrDefault();
+      receiptLinks = nextReceiptLinks.SuccessOrDefault();
+    }
+  }
+
+  private async Task WritePage(
+    IReadOnlyList<Withdrawal> page,
+    IReadOnlyList<string> receiptLinks,
+    TextWriter writer,
+    CancellationToken cancellationToken
+  )
+  {
+    cancellationToken.ThrowIfCancellationRequested();
+    for (var i = 0; i < page.Count; i++)
+    {
+      cancellationToken.ThrowIfCancellationRequested();
+      await writer.WriteAsync(WithdrawalCsv.Line(page[i].ToExportRow(receiptLinks[i])));
+      await writer.WriteAsync(WithdrawalCsv.LineEnding);
+    }
+  }
+
+  private async Task<Result<IReadOnlyList<string>>> GetReceiptLinks(IReadOnlyList<Withdrawal> page)
+  {
+    var links = await Task.WhenAll(page.Select(this.GetReceiptLink));
+    foreach (var link in links)
+      if (link.IsFailure())
+        return link.FailureOrDefault();
+    return links.Select(x => x.SuccessOrDefault()).ToArray();
+  }
+
+  // S3/MinIO cap presigned GET expiry at 7 days, so use the documented maximum
+  // so a freshly exported link lasts as long as the object store allows. The
+  // durable reference an accountant files the CSV against is the trailing
+  // `receipt_key` column, which stays re-signable long after this link lapses.
+  private static readonly TimeSpan ReceiptLinkExpiry = TimeSpan.FromDays(7);
+
+  private Task<Result<string>> GetReceiptLink(Withdrawal withdrawal)
+  {
+    var receipt = withdrawal.Principal.Complete?.Receipt;
+    return receipt is null
+      ? Task.FromResult<Result<string>>("")
+      : storage.Get(receipt, ReceiptLinkExpiry);
+  }
+}

--- a/App/Modules/Withdrawals/API/V1/WithdrawalMapper.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalMapper.cs
@@ -154,4 +154,19 @@ public static class WithdrawalMapper
       Limit = query.Limit ?? 20,
       Skip = query.Skip ?? 0,
     };
+
+  public static WithdrawalSearch ToDomain(this ExportWithdrawalQuery query) =>
+    new()
+    {
+      Id = query.Id,
+      UserId = query.UserId,
+      CompleterId = query.CompleterId,
+      Min = query.Min,
+      Max = query.Max,
+      Status = query.Status?.ToWithdrawStatus(),
+      Before = query.Before?.ToDate(),
+      After = query.After?.ToDate(),
+      // Export paging uses a separate explicit limit and cursor, so the
+      // normal-search pagination defaults are ignored.
+    };
 }

--- a/App/Modules/Withdrawals/API/V1/WithdrawalModel.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalModel.cs
@@ -16,6 +16,19 @@ public record SearchWithdrawalQuery(
   int? Skip
 );
 
+// An export covers every matching withdrawal, so pagination is deliberately
+// absent from the public contract. The exporter supplies its own page size.
+public record ExportWithdrawalQuery(
+  Guid? Id,
+  string? UserId,
+  string? CompleterId,
+  decimal? Min,
+  decimal? Max,
+  string? Status,
+  string? Before,
+  string? After
+);
+
 // Method: "PayNow" (default when omitted, rollout compat) or "CardRefund".
 // PayNowNumber is required for PayNow and must be null/absent for CardRefund.
 public record CreateWithdrawalReq(decimal Amount, string? PayNowNumber, string? Method);

--- a/App/Modules/Withdrawals/API/V1/WithdrawalValidator.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalValidator.cs
@@ -1,5 +1,7 @@
 using App.Utility;
+using Domain.Withdrawal;
 using FluentValidation;
+using System.Linq.Expressions;
 
 namespace App.Modules.Withdrawals.API.V1;
 
@@ -7,14 +9,54 @@ public class SearchWithdrawalQueryValidator : AbstractValidator<SearchWithdrawal
 {
   public SearchWithdrawalQueryValidator()
   {
-    this.RuleFor(x => x.Min).GreaterThanOrEqualTo(0);
-    this.RuleFor(x => x.Max).LessThanOrEqualTo(0);
-
-    this.RuleFor(x => x.Before).NullableDateValid();
-    this.RuleFor(x => x.After).NullableDateValid();
+    this.CommonWithdrawalFilterRules(
+      x => x.Min,
+      x => x.Max,
+      x => x.Before,
+      x => x.After,
+      x => x.Status
+    );
 
     this.RuleFor(x => x.Limit).Limit();
     this.RuleFor(x => x.Skip).Skip();
+  }
+}
+
+public class ExportWithdrawalQueryValidator : AbstractValidator<ExportWithdrawalQuery>
+{
+  public ExportWithdrawalQueryValidator()
+  {
+    this.CommonWithdrawalFilterRules(
+      x => x.Min,
+      x => x.Max,
+      x => x.Before,
+      x => x.After,
+      x => x.Status
+    );
+  }
+}
+
+file static class WithdrawalQueryRules
+{
+  private static readonly string[] Statuses = Enum.GetNames<WithdrawStatus>();
+
+  public static void CommonWithdrawalFilterRules<T>(
+    this AbstractValidator<T> validator,
+    Expression<Func<T, decimal?>> min,
+    Expression<Func<T, decimal?>> max,
+    Expression<Func<T, string?>> before,
+    Expression<Func<T, string?>> after,
+    Expression<Func<T, string?>> status
+  )
+  {
+    validator.RuleFor(min).GreaterThanOrEqualTo(0);
+    validator.RuleFor(max).GreaterThanOrEqualTo(0);
+    validator.RuleFor(before).NullableDateValid();
+    validator.RuleFor(after).NullableDateValid();
+    validator
+      .RuleFor(status)
+      .Must(value => value is null || Statuses.Contains(value))
+      .WithMessage("Status must be one of: " + string.Join(", ", Statuses));
   }
 }
 

--- a/App/Modules/Withdrawals/Data/WithdrawalRepository.cs
+++ b/App/Modules/Withdrawals/Data/WithdrawalRepository.cs
@@ -11,41 +11,17 @@ using Microsoft.EntityFrameworkCore;
 namespace App.Modules.Withdrawals.Data;
 
 public class WithdrawalRepository(MainDbContext db, ILogger<WithdrawalRepository> logger)
-  : IWithdrawalRepository
+  : IWithdrawalRepository, IWithdrawalExportRepository
 {
   public async Task<Result<IEnumerable<WithdrawalPrincipal>>> Search(WithdrawalSearch search)
   {
     try
     {
-      var tz = TimeZoneInfo.FindSystemTimeZoneById("Asia/Singapore");
       logger.LogInformation("Searching for Withdrawal with '{@Search}'", search.ToJson());
       var query = db.Withdrawals.AsQueryable();
       if (!string.IsNullOrWhiteSpace(search.UserId))
-        query = query.Include(x => x.Wallet).Where(x => search.UserId == x.Wallet.UserId);
-      if (search.CompleterId is not null)
-        query = query.Where(x => x.CompleterId == search.CompleterId);
-      if (search.Id is not null)
-        query = query.Where(x => search.Id == x.Id);
-
-      if (search.Min is not null)
-        query = query.Where(x => x.Amount >= search.Min);
-      if (search.Max is not null)
-        query = query.Where(x => x.Amount <= search.Max);
-
-      if (search.Status is not null)
-        query = query.Where(x => x.Status == (byte)search.Status);
-
-      if (search.Before != null)
-      {
-        var dt = search.Before?.ToZonedDateTime(TimeOnly.MaxValue, tz);
-        query = query.Where(x => x.CreatedAt <= dt);
-      }
-
-      if (search.After != null)
-      {
-        var dt = search.After?.ToZonedDateTime(TimeOnly.MinValue, tz);
-        query = query.Where(x => x.CreatedAt >= dt);
-      }
+        query = query.Include(x => x.Wallet);
+      query = this.Filter(query, search);
 
       var result = await query
         .OrderByDescending(x => x.CreatedAt)
@@ -60,6 +36,83 @@ public class WithdrawalRepository(MainDbContext db, ILogger<WithdrawalRepository
       logger.LogError(e, "Failed search for Withdrawal with {@Search}", search.ToJson());
       throw;
     }
+  }
+
+  public async Task<Result<IReadOnlyList<Withdrawal>>> SearchExport(
+    WithdrawalSearch search,
+    int limit,
+    WithdrawalExportCursor? cursor = null,
+    CancellationToken cancellationToken = default
+  )
+  {
+    try
+    {
+      logger.LogInformation("Exporting Withdrawals with '{@Search}'", search.ToJson());
+      var query = this.Filter(db.Withdrawals.AsNoTracking(), search);
+      if (cursor is not null)
+        query = query.Where(x =>
+          x.CreatedAt > cursor.CreatedAt
+          || (x.CreatedAt == cursor.CreatedAt && x.Id.CompareTo(cursor.Id) > 0)
+        );
+
+      var result = await query
+        .Include(x => x.Wallet)
+        .ThenInclude(x => x.User)
+        .Include(x => x.Completer)
+        .Include(x => x.Refunds)
+        // One statement keeps each page and its refund evidence on the same snapshot.
+        .OrderBy(x => x.CreatedAt)
+        .ThenBy(x => x.Id)
+        .Take(limit)
+        .ToArrayAsync(cancellationToken);
+
+      return result.Select(x => x.ToDomain()).ToArray();
+    }
+    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+    {
+      throw;
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed exporting Withdrawals with {@Search}", search.ToJson());
+      return e;
+    }
+  }
+
+  private IQueryable<WithdrawalData> Filter(
+    IQueryable<WithdrawalData> query,
+    WithdrawalSearch search
+  )
+  {
+    var tz = TimeZoneInfo.FindSystemTimeZoneById("Asia/Singapore");
+    if (!string.IsNullOrWhiteSpace(search.UserId))
+      query = query.Where(x => search.UserId == x.Wallet.UserId);
+    if (search.CompleterId is not null)
+      query = query.Where(x => x.CompleterId == search.CompleterId);
+    if (search.Id is not null)
+      query = query.Where(x => search.Id == x.Id);
+
+    if (search.Min is not null)
+      query = query.Where(x => x.Amount >= search.Min);
+    if (search.Max is not null)
+      query = query.Where(x => x.Amount <= search.Max);
+
+    if (search.Status is not null)
+      query = query.Where(x => x.Status == (byte)search.Status);
+
+    if (search.Before != null)
+    {
+      var dt = search.Before?.ToZonedDateTime(TimeOnly.MaxValue, tz);
+      query = query.Where(x => x.CreatedAt <= dt);
+    }
+
+    if (search.After != null)
+    {
+      var dt = search.After?.ToZonedDateTime(TimeOnly.MinValue, tz);
+      query = query.Where(x => x.CreatedAt >= dt);
+    }
+
+    return query;
   }
 
   public async Task<Result<Withdrawal?>> Get(Guid id, string? userId)

--- a/App/Modules/Withdrawals/Data/WithdrawalStorage.cs
+++ b/App/Modules/Withdrawals/Data/WithdrawalStorage.cs
@@ -7,6 +7,9 @@ namespace App.Modules.Withdrawals.Data;
 
 public class WithdrawalStorage(IFileRepository file) : IWithdrawalStorage
 {
+  private static readonly TimeSpan MinimumSignedLinkExpiry = TimeSpan.FromSeconds(1);
+  private static readonly TimeSpan MaximumSignedLinkExpiry = TimeSpan.FromDays(7);
+
   public Task<Result<string>> Save(Stream stream)
   {
     return file.Save(BlockStorages.Main, "withdrawal", Guid.NewGuid().ToString(), stream, true);
@@ -14,6 +17,22 @@ public class WithdrawalStorage(IFileRepository file) : IWithdrawalStorage
 
   public Task<Result<string>> Get(string key)
   {
-    return file.SignedLink(BlockStorages.Main, key, 60 * 60);
+    return this.Get(key, TimeSpan.FromHours(1));
+  }
+
+  public Task<Result<string>> Get(string key, TimeSpan expiry)
+  {
+    if (expiry < MinimumSignedLinkExpiry || expiry > MaximumSignedLinkExpiry)
+    {
+      return Task.FromResult<Result<string>>(
+        new ArgumentOutOfRangeException(
+          nameof(expiry),
+          expiry,
+          "Receipt link expiry must be between one second and seven days."
+        )
+      );
+    }
+
+    return file.SignedLink(BlockStorages.Main, key, (int)expiry.TotalSeconds);
   }
 }

--- a/App/StartUp/Database/MainDbContext.cs
+++ b/App/StartUp/Database/MainDbContext.cs
@@ -231,6 +231,7 @@ public class MainDbContext(
       .Property(x => x.Method)
       .HasDefaultValue((byte)0)
       .HasComment("Payout rail: 0 = PayNow transfer, 1 = card refunds (Airwallex)");
+    withdrawal.HasIndex(x => new { x.CreatedAt, x.Id });
 
     var withdrawalRefund = modelBuilder.Entity<WithdrawalRefundData>();
     withdrawalRefund.HasIndex(x => x.WithdrawalId);

--- a/Domain/Withdrawal/ExportRepository.cs
+++ b/Domain/Withdrawal/ExportRepository.cs
@@ -1,0 +1,18 @@
+using CSharp_Result;
+
+namespace Domain.Withdrawal;
+
+public record WithdrawalExportCursor(DateTime CreatedAt, Guid Id);
+
+// Read-only projection for the tax-evidence CSV. Unlike the normal list
+// repository method, each page carries every relation required to render a
+// self-describing ledger row.
+public interface IWithdrawalExportRepository
+{
+  Task<Result<IReadOnlyList<Withdrawal>>> SearchExport(
+    WithdrawalSearch search,
+    int limit,
+    WithdrawalExportCursor? cursor = null,
+    CancellationToken cancellationToken = default
+  );
+}

--- a/Domain/Withdrawal/Model.cs
+++ b/Domain/Withdrawal/Model.cs
@@ -20,7 +20,7 @@ public record WithdrawalSearch
 
   public DateOnly? After { get; init; }
 
-  public int Limit { get; init; }
+  public int Limit { get; init; } = 20;
 
   public int Skip { get; init; }
 }

--- a/Domain/Withdrawal/Storage.cs
+++ b/Domain/Withdrawal/Storage.cs
@@ -7,4 +7,11 @@ public interface IWithdrawalStorage
   Task<Result<string>> Save(Stream stream);
 
   Task<Result<string>> Get(string key);
+
+  // A presigned link with an explicit lifetime, for the tax export. S3/MinIO
+  // cap presigned GET expiry at 7 days, so this cannot make an archival CSV's
+  // receipt links durable on its own — the export's trailing `receipt_key`
+  // column is the permanent, re-signable reference; this link is a
+  // best-effort convenience.
+  Task<Result<string>> Get(string key, TimeSpan expiry);
 }

--- a/UnitTest/Withdrawals/WithdrawalCardRefundTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalCardRefundTests.cs
@@ -634,6 +634,9 @@ public class WithdrawalCardRefundTests
       Task.FromResult((Result<string>)"receipt-key");
 
     public Task<Result<string>> Get(string key) => Task.FromResult((Result<string>)"url");
+
+    public Task<Result<string>> Get(string key, TimeSpan expiry) =>
+      Task.FromResult((Result<string>)"url");
   }
 
   private sealed class FakeRefundGateway : IRefundGateway

--- a/UnitTest/Withdrawals/WithdrawalCsvTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalCsvTests.cs
@@ -1,0 +1,393 @@
+using System.Globalization;
+using App.Modules.Withdrawals.API.V1;
+using Domain.User;
+using Domain.Wallet;
+using Domain.Withdrawal;
+using FluentAssertions;
+
+namespace UnitTest.Withdrawals;
+
+public class WithdrawalCsvTests
+{
+  private const string ExpectedHeader =
+    "withdrawal_id,created_at,completed_at,status,method,user_id,user_email,gross_amount,fee,net_amount,paynow_number,airwallex_confirmation,payout_attempt,reconcile_attempts,completer_id,completion_note,receipt_url,refund_payment_intent_ids,refund_airwallex_ids,refund_amounts,refund_statuses,refund_settled_ats,receipt_key";
+
+  [Fact]
+  public void To_export_row_uses_the_stored_payout_fee_for_the_fixed_two_decimal_net_amount()
+  {
+    var row = MakeWithdrawal(amount: 100m, payout: Payout(1.3332m)).ToExportRow(receiptUrl: null);
+
+    row.GrossAmount.Should().Be("100.00");
+    row.Fee.Should().Be("1.33");
+    row.NetAmount.Should().Be("98.67", "net is gross minus the fee stored with this payout");
+    row.PayoutAttempt.Should().Be("2");
+    row.ReconcileAttempts.Should().Be("1");
+  }
+
+  [Fact]
+  public void To_export_row_without_a_payout_leaves_all_payout_derived_cells_blank()
+  {
+    // no money moved on a pending withdrawal, so every payout-derived cell —
+    // money columns included — is blank
+    var row = MakeWithdrawal(payout: null, status: WithdrawStatus.Pending)
+      .ToExportRow(receiptUrl: null);
+
+    row.Fee.Should().BeEmpty();
+    row.NetAmount.Should().BeEmpty();
+    row.AirwallexConfirmation.Should().BeEmpty();
+    row.PayoutAttempt.Should().BeEmpty();
+    row.ReconcileAttempts.Should().BeEmpty();
+  }
+
+  // THE most important test in this export: withdrawals completed before the
+  // payout columns existed (Jul 2026) have no payout row, and that is ~2.5
+  // years of the history a tax export exists to produce. The pre-fee Complete
+  // transferred the full amount and charged nothing, so those rows must
+  // report fee 0.00 and net == gross rather than two empty money columns.
+  [Fact]
+  public void Legacy_completed_withdrawal_without_payout_exports_zero_fee_and_gross_net()
+  {
+    var row = MakeWithdrawal(amount: 100m, payout: null, status: WithdrawStatus.Completed)
+      .ToExportRow(receiptUrl: null);
+
+    row.GrossAmount.Should().Be("100.00");
+    row.Fee.Should().Be("0.00", "the pre-payout Complete transferred gross and charged nothing");
+    row.NetAmount.Should().Be("100.00");
+
+    // there genuinely was no gateway payout, so the audit cells stay blank
+    row.AirwallexConfirmation.Should().BeEmpty();
+    row.PayoutAttempt.Should().BeEmpty();
+    row.ReconcileAttempts.Should().BeEmpty();
+  }
+
+  // Processing/RequireManualIntervention were appended with the payout
+  // feature and Approve always writes a payout first, so a null payout here
+  // cannot occur; if it ever did, that money is initiated but not settled, so
+  // blank is the honest value — never a 0.00 that implies a free transfer.
+  [Theory]
+  [InlineData(WithdrawStatus.Processing)]
+  [InlineData(WithdrawStatus.RequireManualIntervention)]
+  public void In_flight_statuses_without_a_payout_leave_fee_and_net_blank(WithdrawStatus status)
+  {
+    var row = MakeWithdrawal(payout: null, status: status).ToExportRow(receiptUrl: null);
+
+    row.Fee.Should().BeEmpty();
+    row.NetAmount.Should().BeEmpty();
+  }
+
+  [Theory]
+  [InlineData(WithdrawStatus.Pending)]
+  [InlineData(WithdrawStatus.Rejected)]
+  [InlineData(WithdrawStatus.Cancel)]
+  public void Terminal_no_payment_statuses_blank_fee_and_net_but_retain_payout_audit_fields(
+    WithdrawStatus status
+  )
+  {
+    var row = MakeWithdrawal(status: status, payout: Payout(4m)).ToExportRow(receiptUrl: null);
+
+    row.Fee.Should().BeEmpty();
+    row.NetAmount.Should().BeEmpty();
+    row.AirwallexConfirmation.Should().Be("payout-confirmation");
+    row.PayoutAttempt.Should().Be("2");
+    row.ReconcileAttempts.Should().Be("1");
+  }
+
+  [Fact]
+  public void Completion_note_with_csv_special_characters_is_rfc_4180_quoted()
+  {
+    const string note = "first, \"quoted\" line\nsecond line";
+    var row = MakeWithdrawal(complete: Complete(note)).ToExportRow(receiptUrl: null);
+
+    WithdrawalCsv.Line(row).Should().Contain("\"first, \"\"quoted\"\" line\nsecond line\"");
+  }
+
+  [Theory]
+  [InlineData("=")]
+  [InlineData("+")]
+  [InlineData("-")]
+  [InlineData("@")]
+  [InlineData("\t")]
+  [InlineData("\r")]
+  public void Field_defangs_every_formula_trigger_inside_quotes_when_quoting_is_required(
+    string trigger
+  )
+  {
+    var raw = $"{trigger}formula,not-a-formula";
+
+    WithdrawalCsv.Field(raw).Should().Be($"\"'{raw}\"");
+  }
+
+  [Fact]
+  public void Field_defangs_an_unquoted_formula()
+  {
+    WithdrawalCsv.Field("=1+1").Should().Be("'=1+1");
+  }
+
+  [Fact]
+  public void Card_refund_fragment_columns_are_semicolon_joined_and_index_aligned()
+  {
+    var row = MakeWithdrawal(
+        method: WithdrawalMethod.CardRefund,
+        refunds:
+        [
+          new RefundSpec(
+            "pi-first",
+            "refund-first",
+            12.5m,
+            RefundFragmentStatus.Settled,
+            new DateTime(2024, 2, 1, 2, 3, 4, DateTimeKind.Utc)
+          ),
+          new RefundSpec("pi-second", null, 0.25m, RefundFragmentStatus.Created, null),
+          new RefundSpec(
+            "pi-third",
+            "refund-third",
+            7m,
+            RefundFragmentStatus.Failed,
+            new DateTime(2024, 2, 3, 4, 5, 6, DateTimeKind.Utc)
+          ),
+        ]
+      )
+      .ToExportRow(receiptUrl: null);
+
+    var paymentIntentIds = row.RefundPaymentIntentIds.Split(WithdrawalCsv.RefundSeparator);
+    var refundIds = row.RefundAirwallexIds.Split(WithdrawalCsv.RefundSeparator);
+    var amounts = row.RefundAmounts.Split(WithdrawalCsv.RefundSeparator);
+    var statuses = row.RefundStatuses.Split(WithdrawalCsv.RefundSeparator);
+    var settledAts = row.RefundSettledAts.Split(WithdrawalCsv.RefundSeparator);
+
+    paymentIntentIds.Should().HaveCount(3);
+    refundIds.Should().HaveCount(3);
+    amounts.Should().HaveCount(3);
+    statuses.Should().HaveCount(3);
+    settledAts.Should().HaveCount(3);
+
+    var zipped = paymentIntentIds.Select(
+      (paymentIntentId, index) =>
+        (
+          paymentIntentId,
+          refundIds[index],
+          amounts[index],
+          statuses[index],
+          settledAts[index]
+        )
+    );
+
+    zipped.Should().Equal(
+      ("pi-first", "refund-first", "12.50", "Settled", "2024-02-01T10:03:04+08:00"),
+      ("pi-second", "", "0.25", "Created", ""),
+      ("pi-third", "refund-third", "7.00", "Failed", "2024-02-03T12:05:06+08:00")
+    );
+  }
+
+  [Fact]
+  public void Card_refund_blanks_a_legacy_paynow_number()
+  {
+    var row = MakeWithdrawal(
+        method: WithdrawalMethod.CardRefund,
+        payNowNumber: "legacy-number-that-must-not-export"
+      )
+      .ToExportRow(receiptUrl: null);
+
+    row.PayNowNumber.Should().BeEmpty();
+  }
+
+  [Fact]
+  public void Paynow_blanks_all_refund_columns_even_when_legacy_fragment_data_exists()
+  {
+    var row = MakeWithdrawal(
+        method: WithdrawalMethod.PayNow,
+        refunds:
+        [
+          new RefundSpec(
+            "bad-payment-intent",
+            "bad-refund-id",
+            99m,
+            RefundFragmentStatus.Settled,
+            new DateTime(2024, 2, 1, 2, 3, 4, DateTimeKind.Utc)
+          ),
+        ]
+      )
+      .ToExportRow(receiptUrl: null);
+
+    new[]
+      {
+        row.RefundPaymentIntentIds,
+        row.RefundAirwallexIds,
+        row.RefundAmounts,
+        row.RefundStatuses,
+        row.RefundSettledAts,
+      }
+      .Should()
+      .OnlyContain(value => value == "");
+  }
+
+  [Fact]
+  public void Header_is_exactly_the_contract_order()
+  {
+    WithdrawalCsv.Headers.Should().Equal(ExpectedHeader.Split(','));
+    WithdrawalCsv.HeaderLine.Should().Be(ExpectedHeader);
+    WithdrawalCsv.Bom.Should().Be("\uFEFF");
+  }
+
+  [Fact]
+  public void Every_data_row_has_exactly_one_cell_per_header()
+  {
+    var row = MakeWithdrawal().ToExportRow(receiptUrl: null);
+
+    row.ToFields()
+      .Should()
+      .HaveSameCount(
+        WithdrawalCsv.Headers,
+        "headers and cells are derived from one ordered column table"
+      );
+  }
+
+  [Fact]
+  public void Receipt_key_exports_the_durable_object_key_alongside_the_expiring_link()
+  {
+    var row = MakeWithdrawal(complete: Complete("done", receipt: "withdrawal/receipt-123.png"))
+      .ToExportRow(receiptUrl: "https://minio.test/signed?expires=soon");
+
+    row.ReceiptKey.Should().Be("withdrawal/receipt-123.png");
+    row.ReceiptUrl.Should().Be("https://minio.test/signed?expires=soon");
+    row.ToFields().Last().Should().Be("withdrawal/receipt-123.png", "receipt_key is appended last");
+  }
+
+  [Fact]
+  public void Receipt_key_is_blank_when_no_receipt_was_uploaded()
+  {
+    MakeWithdrawal(complete: null).ToExportRow(receiptUrl: null).ReceiptKey.Should().BeEmpty();
+    MakeWithdrawal(complete: Complete("done"))
+      .ToExportRow(receiptUrl: null)
+      .ReceiptKey.Should()
+      .BeEmpty();
+  }
+
+  [Fact]
+  public void Amount_uses_fixed_two_decimal_invariant_formatting()
+  {
+    var previousCulture = CultureInfo.CurrentCulture;
+    try
+    {
+      CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+      WithdrawalCsv.Amount(1234.5m).Should().Be("1234.50");
+    }
+    finally
+    {
+      CultureInfo.CurrentCulture = previousCulture;
+    }
+  }
+
+  [Fact]
+  public void Timestamp_treats_unspecified_values_as_utc_and_renders_singapore_offset()
+  {
+    var utc = new DateTime(2024, 2, 1, 2, 3, 4, DateTimeKind.Utc);
+    var unspecified = DateTime.SpecifyKind(utc, DateTimeKind.Unspecified);
+
+    WithdrawalCsv.Timestamp(utc).Should().Be("2024-02-01T10:03:04+08:00");
+    WithdrawalCsv.Timestamp(unspecified).Should().Be("2024-02-01T10:03:04+08:00");
+    WithdrawalCsv.Timestamp(utc.ToLocalTime()).Should().Be("2024-02-01T10:03:04+08:00");
+    WithdrawalCsv.Timestamp((DateTime?)null).Should().BeEmpty();
+  }
+
+  [Fact]
+  public void File_name_has_stable_bound_fallbacks()
+  {
+    WithdrawalCsv.FileName("2024-01-01", "2024-01-31")
+      .Should()
+      .Be("withdrawals-2024-01-01_2024-01-31.csv");
+    WithdrawalCsv.FileName("2024-01-01", null)
+      .Should()
+      .Be("withdrawals-2024-01-01_latest.csv");
+    WithdrawalCsv.FileName(null, null).Should().Be("withdrawals-earliest_latest.csv");
+  }
+
+  private static Withdrawal MakeWithdrawal(
+    WithdrawalMethod method = WithdrawalMethod.PayNow,
+    decimal amount = 100m,
+    WithdrawalPayout? payout = null,
+    WithdrawStatus status = WithdrawStatus.Completed,
+    WithdrawalComplete? complete = null,
+    string? payNowNumber = "91234567",
+    IReadOnlyList<RefundSpec>? refunds = null
+  )
+  {
+    var withdrawalId = Guid.NewGuid();
+    return new Withdrawal
+    {
+      Principal = new WithdrawalPrincipal
+      {
+        Id = withdrawalId,
+        CreatedAt = new DateTime(2024, 1, 1, 1, 2, 3, DateTimeKind.Utc),
+        Status = new WithdrawalStatus { Status = status },
+        Record = new WithdrawalRecord
+        {
+          Amount = amount,
+          Method = method,
+          PayNowNumber = payNowNumber,
+        },
+        Complete = complete,
+        Payout = payout,
+      },
+      Wallet = new WalletPrincipal
+      {
+        Id = Guid.NewGuid(),
+        UserId = "user-123",
+        Record = new WalletRecord
+        {
+          Usable = 0m,
+          WithdrawReserve = 0m,
+          BookingReserve = 0m,
+        },
+      },
+      User = new UserPrincipal
+      {
+        Id = "user-123",
+        Record = new UserRecord { Username = "accountant", Email = "user@example.test" },
+      },
+      Completer = null,
+      Refunds = (refunds ?? []).Select(
+        (refund, index) => new WithdrawalRefundFragment
+        {
+          Id = Guid.NewGuid(),
+          WithdrawalId = withdrawalId,
+          PaymentId = Guid.NewGuid(),
+          PaymentIntentId = refund.PaymentIntentId,
+          AirwallexRefundId = refund.AirwallexRefundId,
+          RequestId = $"{withdrawalId}-2-{index}",
+          Amount = refund.Amount,
+          Status = refund.Status,
+          CreatedAt = new DateTime(2024, 1, 1, 1, 2, 3, DateTimeKind.Utc).AddMinutes(index),
+          SettledAt = refund.SettledAt,
+        }
+      ).ToArray(),
+    };
+  }
+
+  private static WithdrawalPayout Payout(decimal fee) =>
+    new()
+    {
+      ConfirmationNumber = "payout-confirmation",
+      Fee = fee,
+      Attempt = 2,
+      ReconcileAttempts = 1,
+    };
+
+  private static WithdrawalComplete Complete(string note, string? receipt = null) =>
+    new()
+    {
+      CompletedAt = new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc),
+      CompleterId = "admin-123",
+      Note = note,
+      Receipt = receipt,
+    };
+
+  private sealed record RefundSpec(
+    string PaymentIntentId,
+    string? AirwallexRefundId,
+    decimal Amount,
+    RefundFragmentStatus Status,
+    DateTime? SettledAt
+  );
+}

--- a/UnitTest/Withdrawals/WithdrawalExporterTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalExporterTests.cs
@@ -1,0 +1,647 @@
+using System.Reflection;
+using System.Text;
+using App.Modules.Withdrawals.API.V1;
+using App.StartUp.Options;
+using App.StartUp.Registry;
+using App.StartUp.Services;
+using CSharp_Result;
+using Domain.User;
+using Domain.Wallet;
+using Domain.Withdrawal;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace UnitTest.Withdrawals;
+
+public class WithdrawalExporterTests
+{
+  [Fact]
+  public void Positive_max_is_accepted_by_both_withdrawal_query_validators()
+  {
+    var search = new SearchWithdrawalQuery(
+      null,
+      null,
+      null,
+      null,
+      100m,
+      null,
+      null,
+      null,
+      null,
+      null
+    );
+    var export = new ExportWithdrawalQuery(null, null, null, null, 100m, null, null, null);
+
+    new SearchWithdrawalQueryValidator().Validate(search).IsValid.Should().BeTrue();
+    new ExportWithdrawalQueryValidator().Validate(export).IsValid.Should().BeTrue();
+  }
+
+  [Fact]
+  public async Task Prepare_and_write_page_through_every_matching_withdrawal_without_losing_filters()
+  {
+    var withdrawals = Enumerable.Range(0, 205).Select(index => MakeWithdrawal(index)).ToArray();
+    var repository = new FakeExportRepository(withdrawals);
+    var exporter = new WithdrawalExporter(repository, new FakeStorage());
+    var search = new WithdrawalSearch
+    {
+      Id = null,
+      UserId = "accountant-user",
+      CompleterId = "admin-user",
+      Min = 12.34m,
+      Max = 567.89m,
+      Status = WithdrawStatus.Completed,
+      Before = new DateOnly(2024, 12, 31),
+      After = new DateOnly(2024, 1, 1),
+      Limit = 1,
+      Skip = 99,
+    };
+
+    var prepared = await exporter.Prepare(search);
+    prepared.IsSuccess().Should().BeTrue();
+    using var writer = new StringWriter();
+    var written = await exporter.Write(prepared.SuccessOrDefault(), writer);
+
+    written.IsSuccess().Should().BeTrue();
+    var records = writer
+      .ToString()
+      .Split(WithdrawalCsv.LineEnding, StringSplitOptions.RemoveEmptyEntries);
+    var ids = records.Skip(1).Select(record => record.Split(',')[0]).ToArray();
+
+    records.Should().HaveCount(206, "the header plus every one of the 205 matching withdrawals");
+    ids.Should().HaveCount(205).And.OnlyHaveUniqueItems();
+    ids.Should().Equal(withdrawals.Select(w => w.Principal.Id.ToString()));
+    repository.IssuedSearches.Should().HaveCount(3);
+    repository.IssuedSearches[0].Cursor.Should().BeNull();
+    repository.IssuedSearches[1].Cursor.Should().Be(CursorFor(withdrawals[99]));
+    repository.IssuedSearches[2].Cursor.Should().Be(CursorFor(withdrawals[199]));
+    repository.IssuedSearches.Should().OnlyContain(x => x.Limit == WithdrawalExporter.PageSize);
+    repository.IssuedSearches.Should().OnlyContain(
+      x =>
+        x.Search.UserId == search.UserId
+        && x.Search.CompleterId == search.CompleterId
+        && x.Search.Min == search.Min
+        && x.Search.Max == search.Max
+        && x.Search.Status == search.Status
+        && x.Search.Before == search.Before
+        && x.Search.After == search.After
+    );
+  }
+
+  [Fact]
+  public async Task Write_emits_one_bom_exact_header_and_crlf_terminated_records()
+  {
+    var repository = new FakeExportRepository(
+      Enumerable.Range(0, 205).Select(index => MakeWithdrawal(index))
+    );
+    var exporter = new WithdrawalExporter(repository, new FakeStorage());
+    var prepared = await exporter.Prepare(new WithdrawalSearch());
+    using var writer = new StringWriter();
+
+    var written = await exporter.Write(prepared.SuccessOrDefault(), writer);
+    var csv = writer.ToString();
+    var records = csv.Split(WithdrawalCsv.LineEnding, StringSplitOptions.RemoveEmptyEntries);
+
+    written.IsSuccess().Should().BeTrue();
+    csv.Should().StartWith("\uFEFF" + WithdrawalCsv.HeaderLine + WithdrawalCsv.LineEnding);
+    csv.Count(c => c == '\uFEFF').Should().Be(1);
+    csv.Replace(WithdrawalCsv.LineEnding, "").Should().NotContain("\n").And.NotContain("\r");
+    records.Should().HaveCount(206);
+    records[0].Should().Be("\uFEFF" + WithdrawalCsv.HeaderLine);
+  }
+
+  [Fact]
+  public async Task Prepare_presigns_first_page_receipts_and_write_emits_the_urls()
+  {
+    var withdrawal = MakeWithdrawal(1, receipt: "receipts/withdrawal-1.pdf");
+    var storage = new FakeStorage();
+    var exporter = new WithdrawalExporter(new FakeExportRepository([withdrawal]), storage);
+
+    var prepared = await exporter.Prepare(new WithdrawalSearch());
+    using var writer = new StringWriter();
+    var written = await exporter.Write(prepared.SuccessOrDefault(), writer);
+
+    prepared.IsSuccess().Should().BeTrue();
+    storage.RequestedKeys.Should().Equal("receipts/withdrawal-1.pdf");
+    storage.RequestedExpiries.Should().OnlyContain(
+      expiry => expiry == TimeSpan.FromDays(7),
+      "the export presigns receipts for the 7-day S3/MinIO maximum, not the interactive 1-hour link"
+    );
+    written.IsSuccess().Should().BeTrue();
+    writer.ToString().Split(WithdrawalCsv.LineEnding, StringSplitOptions.RemoveEmptyEntries)[1]
+      .Split(',')[16]
+      .Should()
+      .Be("https://storage.test/receipts/withdrawal-1.pdf");
+  }
+
+  [Fact]
+  public async Task Export_renders_range_start_boundary_timestamps_in_singapore_time()
+  {
+    var createdAt = new DateTime(2023, 12, 31, 16, 0, 0, DateTimeKind.Utc);
+    var completedAt = new DateTime(2023, 12, 31, 16, 30, 0, DateTimeKind.Utc);
+    var withdrawal = MakeWithdrawal(
+      1,
+      receipt: "receipts/boundary.pdf",
+      createdAt: createdAt,
+      completedAt: completedAt
+    );
+    var repository = new FakeExportRepository([withdrawal]);
+    var exporter = new WithdrawalExporter(repository, new FakeStorage());
+    var search = new WithdrawalSearch { After = new DateOnly(2024, 1, 1) };
+
+    var prepared = await exporter.Prepare(search);
+    using var writer = new StringWriter();
+    var written = await exporter.Write(prepared.SuccessOrDefault(), writer);
+    var fields = writer
+      .ToString()
+      .Split(WithdrawalCsv.LineEnding, StringSplitOptions.RemoveEmptyEntries)[1]
+      .Split(',');
+
+    written.IsSuccess().Should().BeTrue();
+    repository.IssuedSearches[0].Search.After.Should().Be(new DateOnly(2024, 1, 1));
+    fields[1].Should().Be("2024-01-01T00:00:00+08:00");
+    fields[2].Should().Be("2024-01-01T00:30:00+08:00");
+  }
+
+  [Fact]
+  public async Task Export_renders_the_final_second_of_the_range_start_day_in_singapore_time()
+  {
+    var withdrawal = MakeWithdrawal(
+      1,
+      createdAt: new DateTime(2024, 1, 1, 15, 59, 59, DateTimeKind.Utc)
+    );
+    var repository = new FakeExportRepository([withdrawal]);
+    var exporter = new WithdrawalExporter(repository, new FakeStorage());
+    var search = new WithdrawalSearch { After = new DateOnly(2024, 1, 1) };
+
+    var prepared = await exporter.Prepare(search);
+    using var writer = new StringWriter();
+    var written = await exporter.Write(prepared.SuccessOrDefault(), writer);
+    var fields = writer
+      .ToString()
+      .Split(WithdrawalCsv.LineEnding, StringSplitOptions.RemoveEmptyEntries)[1]
+      .Split(',');
+
+    written.IsSuccess().Should().BeTrue();
+    repository.IssuedSearches[0].Search.After.Should().Be(new DateOnly(2024, 1, 1));
+    fields[1].Should().Be("2024-01-01T23:59:59+08:00");
+  }
+
+  [Fact]
+  public async Task Repository_failure_after_a_written_page_propagates_instead_of_reporting_clean_success()
+  {
+    var withdrawals = Enumerable.Range(0, 200).Select(index => MakeWithdrawal(index)).ToArray();
+    var repository = new FakeExportRepository(withdrawals)
+    {
+      FailAtCursor = CursorFor(withdrawals[99]),
+    };
+    var exporter = new WithdrawalExporter(repository, new FakeStorage());
+    var prepared = await exporter.Prepare(new WithdrawalSearch());
+    using var writer = new StringWriter();
+
+    var written = await exporter.Write(prepared.SuccessOrDefault(), writer);
+
+    written.IsFailure().Should().BeTrue();
+    writer
+      .ToString()
+      .Split(WithdrawalCsv.LineEnding, StringSplitOptions.RemoveEmptyEntries)
+      .Should()
+      .HaveCount(101, "the controller must abort this partial response instead of presenting success");
+  }
+
+  [Fact]
+  public async Task Write_propagates_cancellation_between_full_pages_instead_of_reporting_success()
+  {
+    var withdrawals = Enumerable.Range(0, 205).Select(index => MakeWithdrawal(index)).ToArray();
+    var repository = new FakeExportRepository(withdrawals);
+    var exporter = new WithdrawalExporter(repository, new FakeStorage());
+    var prepared = await exporter.Prepare(new WithdrawalSearch());
+    using var cancellation = new CancellationTokenSource();
+    using var writer = new CancellingStringWriter(cancellation, lineEndingLimit: 101);
+
+    var write = async () =>
+      await exporter.Write(prepared.SuccessOrDefault(), writer, cancellation.Token);
+
+    await write.Should().ThrowAsync<OperationCanceledException>();
+    writer
+      .ToString()
+      .Split(WithdrawalCsv.LineEnding, StringSplitOptions.RemoveEmptyEntries)
+      .Should()
+      .HaveCount(101, "the header and first page were written before cancellation");
+    repository.IssuedSearches.Should().ContainSingle("the next page must not be fetched");
+  }
+
+  [Fact]
+  public async Task Keyset_paging_does_not_skip_rows_when_a_written_row_is_removed_between_pages()
+  {
+    var withdrawals = Enumerable.Range(0, 205).Select(index => MakeWithdrawal(index)).ToArray();
+    var repository = new FakeExportRepository(withdrawals);
+    repository.AfterFirstPage = fake => fake.Remove(withdrawals[50].Principal.Id);
+    var exporter = new WithdrawalExporter(repository, new FakeStorage());
+
+    var prepared = await exporter.Prepare(new WithdrawalSearch());
+    using var writer = new StringWriter();
+    var written = await exporter.Write(prepared.SuccessOrDefault(), writer);
+    var ids = writer
+      .ToString()
+      .Split(WithdrawalCsv.LineEnding, StringSplitOptions.RemoveEmptyEntries)
+      .Skip(1)
+      .Select(record => record.Split(',')[0]);
+
+    written.IsSuccess().Should().BeTrue();
+    ids.Should().Equal(withdrawals.Select(x => x.Principal.Id.ToString()));
+  }
+
+  [Fact]
+  public async Task Keyset_paging_resumes_a_same_timestamp_group_in_postgres_uuid_order_across_the_page_boundary()
+  {
+    // A 105-row result whose final 10 rows share one CreatedAt, straddling the
+    // 100-row page boundary: 95 earlier-timestamped fillers open page 1, then
+    // the first 5 of the tied group finish it. The cursor handed to page 2
+    // therefore carries that shared timestamp AND a UUID tiebreak, so page 2
+    // must resume mid-group without dropping or repeating a row. The tie is
+    // broken by PostgreSQL's unsigned big-endian byte order, not the default
+    // mixed-endian Guid.ToByteArray(); these 10 ids are chosen so those two
+    // orders genuinely disagree, so a fake comparing the wrong bytes would sort
+    // the group differently and fail this test.
+    var sharedTimestamp = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMinutes(1000);
+    var tiedIdsInPostgresOrder = new[]
+    {
+      "00000000-0000-0000-0000-000000000001",
+      "00000000-0000-0000-0000-010000000000",
+      "00000000-0000-0000-0100-000000000000",
+      "00000000-0000-0001-0000-000000000000",
+      "00000000-0001-0000-0000-000000000000",
+      "00000000-0100-0000-0000-000000000000",
+      "00000001-0000-0000-0000-000000000000",
+      "00000100-0000-0000-0000-000000000000",
+      "00010000-0000-0000-0000-000000000000",
+      "01000000-0000-0000-0000-000000000000",
+    }.Select(Guid.Parse).ToArray();
+
+    // Fillers use indices 100..194 so their ids never collide with the tied
+    // group and their default createdAt (base + index minutes) stays strictly
+    // before the shared timestamp.
+    var fillers = Enumerable.Range(100, 95).Select(index => MakeWithdrawal(index)).ToArray();
+    // Insert the tied group scrambled so the fixture proves the fake sorts them
+    // rather than echoing input order.
+    var scrambledTied = new[] { 4, 9, 0, 7, 2, 5, 1, 8, 3, 6 }
+      .Select(i => WithId(MakeWithdrawal(0), tiedIdsInPostgresOrder[i], sharedTimestamp))
+      .ToArray();
+    var repository = new FakeExportRepository(fillers.Concat(scrambledTied));
+    var exporter = new WithdrawalExporter(repository, new FakeStorage());
+
+    var prepared = await exporter.Prepare(new WithdrawalSearch());
+    using var writer = new StringWriter();
+    var written = await exporter.Write(prepared.SuccessOrDefault(), writer);
+
+    written.IsSuccess().Should().BeTrue();
+    var ids = writer
+      .ToString()
+      .Split(WithdrawalCsv.LineEnding, StringSplitOptions.RemoveEmptyEntries)
+      .Skip(1)
+      .Select(record => record.Split(',')[0])
+      .ToArray();
+    var expected = fillers
+      .Select(w => w.Principal.Id)
+      .Concat(tiedIdsInPostgresOrder)
+      .Select(id => id.ToString())
+      .ToArray();
+
+    ids.Should().HaveCount(105).And.OnlyHaveUniqueItems();
+    ids.Should().Equal(
+      expected,
+      "the tied group resumes across the page boundary in PostgreSQL big-endian UUID order"
+    );
+    // The boundary really fell inside the tied group: page 2's cursor carries
+    // the shared timestamp and the 5th tied id, proving the same-CreatedAt
+    // keyset branch ran (not a timestamp-only cursor).
+    repository.IssuedSearches.Should().HaveCount(2);
+    repository.IssuedSearches[1].Cursor!.CreatedAt.Should().Be(sharedTimestamp);
+    repository.IssuedSearches[1].Cursor!.Id.Should().Be(tiedIdsInPostgresOrder[4]);
+  }
+
+  [Fact]
+  public async Task Exactly_full_pages_request_a_final_empty_cursor_page()
+  {
+    var withdrawals = Enumerable.Range(0, 200).Select(index => MakeWithdrawal(index)).ToArray();
+    var repository = new FakeExportRepository(withdrawals);
+    var exporter = new WithdrawalExporter(repository, new FakeStorage());
+
+    var prepared = await exporter.Prepare(new WithdrawalSearch());
+    using var writer = new StringWriter();
+    var written = await exporter.Write(prepared.SuccessOrDefault(), writer);
+
+    written.IsSuccess().Should().BeTrue();
+    repository.IssuedSearches.Should().HaveCount(3);
+    repository.IssuedSearches[0].Cursor.Should().BeNull();
+    repository.IssuedSearches[1].Cursor.Should().Be(CursorFor(withdrawals[99]));
+    repository.IssuedSearches[2].Cursor.Should().Be(CursorFor(withdrawals[199]));
+    writer
+      .ToString()
+      .Split(WithdrawalCsv.LineEnding, StringSplitOptions.RemoveEmptyEntries)
+      .Should()
+      .HaveCount(201);
+  }
+
+  [Fact]
+  public async Task Storage_failure_during_prepare_propagates_before_any_output_is_started()
+  {
+    var storage = new FakeStorage { FailGet = true };
+    var exporter = new WithdrawalExporter(
+      new FakeExportRepository([MakeWithdrawal(1, receipt: "receipts/fails.pdf")]),
+      storage
+    );
+
+    var prepared = await exporter.Prepare(new WithdrawalSearch());
+
+    prepared.IsFailure().Should().BeTrue();
+  }
+
+  [Fact]
+  public void Export_endpoint_is_guarded_by_the_admin_only_policy()
+  {
+    var method = typeof(WithdrawalController).GetMethod(nameof(WithdrawalController.Export))!;
+    var authorize = method.GetCustomAttributes<AuthorizeAttribute>().Single();
+
+    authorize.Policy.Should().Be(AuthPolicies.OnlyAdmin);
+  }
+
+  [Fact]
+  public async Task Export_response_exposes_the_attachment_filename_to_cross_origin_clients()
+  {
+    await using var responseBody = new MemoryStream();
+    var httpContext = new DefaultHttpContext();
+    httpContext.Response.Body = responseBody;
+    var controller = Controller(
+      httpContext,
+      new WithdrawalExporter(new FakeExportRepository([]), new FakeStorage()),
+      new ExportWithdrawalQueryValidator()
+    );
+
+    var result = await controller.Export(
+      new ExportWithdrawalQuery(null, null, null, null, null, null, null, null)
+    );
+
+    result.Should().BeOfType<EmptyResult>();
+    controller.Response.ContentType.Should().Be("text/csv; charset=utf-8");
+    controller
+      .Response.Headers.ContentDisposition.ToString()
+      .Should()
+      .Be("attachment; filename=\"withdrawals-earliest_latest.csv\"");
+    controller
+      .Response.Headers["Access-Control-Expose-Headers"]
+      .ToString()
+      .Should()
+      .Be("Content-Disposition");
+    controller.Response.Headers.CacheControl.ToString().Should().Be("no-store");
+    responseBody.ToArray().Take(3).Should().Equal(new byte[] { 0xef, 0xbb, 0xbf });
+  }
+
+  [Theory]
+  [InlineData("Cancelled", null, "Status must be one of")]
+  [InlineData(null, "2026-12-31", "DateOnly must be in the format of dd-MM-yyyy")]
+  public async Task Invalid_export_query_can_be_written_as_readable_400_problem_details(
+    string? status,
+    string? before,
+    string expectedMessage
+  )
+  {
+    await using var serviceProvider = new ServiceCollection()
+      .AddLogging()
+      .AddProblemDetailsService(
+        new ErrorPortalOption { Enabled = false },
+        new AppOption()
+      )
+      .BuildServiceProvider();
+    await using var responseBody = new MemoryStream();
+    var httpContext = new DefaultHttpContext { RequestServices = serviceProvider };
+    httpContext.Request.Headers.Accept =
+      "text/csv, application/problem+json, application/json";
+    httpContext.Response.Body = responseBody;
+    var controller = Controller(httpContext, null!, new ExportWithdrawalQueryValidator());
+
+    var result = await controller.Export(
+      new ExportWithdrawalQuery(null, null, null, null, null, status, before, null)
+    );
+
+    var statusResult = result.Should().BeOfType<StatusCodeResult>().Which;
+    statusResult.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    httpContext.Response.StatusCode = statusResult.StatusCode;
+    var written = await serviceProvider
+      .GetRequiredService<IProblemDetailsService>()
+      .TryWriteAsync(
+        new ProblemDetailsContext
+        {
+          HttpContext = httpContext,
+          ProblemDetails = new ProblemDetails { Status = StatusCodes.Status400BadRequest },
+        }
+      );
+
+    written.Should().BeTrue();
+    httpContext.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    httpContext.Response.ContentType.Should().StartWith("application/problem+json");
+    Encoding.UTF8.GetString(responseBody.ToArray())
+      .Should()
+      .Contain("Validation Error")
+      .And.Contain(expectedMessage);
+  }
+
+  private static WithdrawalController Controller(
+    DefaultHttpContext httpContext,
+    IWithdrawalExporter exporter,
+    ExportWithdrawalQueryValidator exportValidator
+  ) =>
+    new(
+      null!,
+      null!,
+      null!,
+      null!,
+      null!,
+      exportValidator,
+      null!,
+      null!,
+      exporter,
+      null!,
+      null!,
+      null!
+    )
+    {
+      ControllerContext = new ControllerContext { HttpContext = httpContext },
+    };
+
+  private static Withdrawal MakeWithdrawal(
+    int index,
+    string? receipt = null,
+    DateTime? createdAt = null,
+    DateTime? completedAt = null
+  )
+  {
+    var id = Guid.Parse($"00000000-0000-0000-0000-{index + 1:000000000000}");
+    return new Withdrawal
+    {
+      Principal = new WithdrawalPrincipal
+      {
+        Id = id,
+        CreatedAt = createdAt
+          ?? new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMinutes(index),
+        Status = new WithdrawalStatus { Status = WithdrawStatus.Completed },
+        Record = new WithdrawalRecord
+        {
+          Amount = 100m,
+          Method = WithdrawalMethod.PayNow,
+          PayNowNumber = "91234567",
+        },
+        Complete = receipt is null
+          ? null
+          : new WithdrawalComplete
+          {
+            CompletedAt = completedAt
+              ?? new DateTime(2024, 1, 2, 0, 0, 0, DateTimeKind.Utc),
+            CompleterId = "admin-user",
+            Note = "completed",
+            Receipt = receipt,
+          },
+        Payout = new WithdrawalPayout
+        {
+          ConfirmationNumber = "confirmation",
+          Fee = 1m,
+          Attempt = 1,
+          ReconcileAttempts = 0,
+        },
+      },
+      Wallet = new WalletPrincipal
+      {
+        Id = Guid.NewGuid(),
+        UserId = "accountant-user",
+        Record = new WalletRecord { Usable = 0m, WithdrawReserve = 0m, BookingReserve = 0m },
+      },
+      User = new UserPrincipal
+      {
+        Id = "accountant-user",
+        Record = new UserRecord { Username = "accountant", Email = "accountant@example.test" },
+      },
+      Completer = null,
+    };
+  }
+
+  private static Withdrawal WithId(Withdrawal withdrawal, Guid id, DateTime createdAt) =>
+    withdrawal with
+    {
+      Principal = withdrawal.Principal with { Id = id, CreatedAt = createdAt },
+    };
+
+  private static WithdrawalExportCursor CursorFor(Withdrawal withdrawal) =>
+    new(withdrawal.Principal.CreatedAt, withdrawal.Principal.Id);
+
+  private sealed class FakeExportRepository(IEnumerable<Withdrawal> withdrawals)
+    : IWithdrawalExportRepository
+  {
+    private readonly List<Withdrawal> withdrawals = withdrawals.ToList();
+
+    public List<(WithdrawalSearch Search, int Limit, WithdrawalExportCursor? Cursor)> IssuedSearches { get; } =
+      [];
+
+    public WithdrawalExportCursor? FailAtCursor { get; init; }
+
+    public Action<FakeExportRepository>? AfterFirstPage { get; set; }
+
+    public void Remove(Guid id) => this.withdrawals.RemoveAll(x => x.Principal.Id == id);
+
+    // PostgreSQL orders `uuid` by an unsigned memcmp of the 16 canonical
+    // (RFC 4122, big-endian) bytes, and Npgsql translates both the keyset
+    // cursor predicate and `ORDER BY "Id"` to that order. The fake reproduces
+    // it exactly so the tiebreak test reflects production. Empirically this
+    // coincides with Guid.CompareTo across 2M random pairs (verified) — the
+    // trap is the DEFAULT Guid.ToByteArray(), which is mixed-endian and yields
+    // a genuinely different order; using the explicit big-endian bytes keeps
+    // the fake pinned to Postgres semantics regardless of Guid internals.
+    private static readonly IComparer<Guid> PostgresUuidOrder = Comparer<Guid>.Create(
+      PostgresUuidCompare
+    );
+
+    private static int PostgresUuidCompare(Guid a, Guid b) =>
+      a.ToByteArray(bigEndian: true).AsSpan().SequenceCompareTo(b.ToByteArray(bigEndian: true));
+
+    public Task<Result<IReadOnlyList<Withdrawal>>> SearchExport(
+      WithdrawalSearch search,
+      int limit,
+      WithdrawalExportCursor? cursor = null,
+      CancellationToken cancellationToken = default
+    )
+    {
+      this.IssuedSearches.Add((search, limit, cursor));
+      cancellationToken.ThrowIfCancellationRequested();
+      if (limit > WithdrawalExporter.PageSize)
+      {
+        return Task.FromResult(
+          (Result<IReadOnlyList<Withdrawal>>)new InvalidOperationException("page exceeds 100 rows")
+        );
+      }
+
+      if (this.FailAtCursor is not null && cursor == this.FailAtCursor)
+      {
+        return Task.FromResult(
+          (Result<IReadOnlyList<Withdrawal>>)new InvalidOperationException("repository unavailable")
+        );
+      }
+
+      var page = this.withdrawals
+        .Where(x =>
+          cursor is null
+          || x.Principal.CreatedAt > cursor.CreatedAt
+          || (
+            x.Principal.CreatedAt == cursor.CreatedAt
+            && PostgresUuidCompare(x.Principal.Id, cursor.Id) > 0
+          )
+        )
+        .OrderBy(x => x.Principal.CreatedAt)
+        .ThenBy(x => x.Principal.Id, PostgresUuidOrder)
+        .Take(limit)
+        .ToArray();
+      if (this.IssuedSearches.Count == 1)
+        this.AfterFirstPage?.Invoke(this);
+      return Task.FromResult((Result<IReadOnlyList<Withdrawal>>)page);
+    }
+  }
+
+  private sealed class FakeStorage : IWithdrawalStorage
+  {
+    public List<string> RequestedKeys { get; } = [];
+
+    public List<TimeSpan> RequestedExpiries { get; } = [];
+
+    public bool FailGet { get; init; }
+
+    public Task<Result<string>> Save(Stream stream) => Task.FromResult((Result<string>)"unused");
+
+    public Task<Result<string>> Get(string key) => this.Get(key, TimeSpan.FromHours(1));
+
+    public Task<Result<string>> Get(string key, TimeSpan expiry)
+    {
+      this.RequestedKeys.Add(key);
+      this.RequestedExpiries.Add(expiry);
+      return this.FailGet
+        ? Task.FromResult((Result<string>)new InvalidOperationException("storage unavailable"))
+        : Task.FromResult((Result<string>)$"https://storage.test/{key}");
+    }
+  }
+
+  private sealed class CancellingStringWriter(
+    CancellationTokenSource cancellation,
+    int lineEndingLimit
+  ) : StringWriter
+  {
+    private int lineEndings;
+
+    public override async Task WriteAsync(string? value)
+    {
+      await base.WriteAsync(value);
+      if (value == WithdrawalCsv.LineEnding && ++this.lineEndings == lineEndingLimit)
+        await cancellation.CancelAsync();
+    }
+  }
+
+}

--- a/UnitTest/Withdrawals/WithdrawalQueryMapperTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalQueryMapperTests.cs
@@ -1,0 +1,104 @@
+using App.Modules.Withdrawals.API.V1;
+using Domain.Withdrawal;
+using FluentAssertions;
+
+namespace UnitTest.Withdrawals;
+
+public class WithdrawalQueryMapperTests
+{
+  public static IEnumerable<object?[]> ValidStatuses() =>
+    Enum.GetNames<WithdrawStatus>()
+      .Select(status => new object?[] { status })
+      .Append(new object?[] { null });
+
+  [Fact]
+  public void Export_query_maps_all_filters_and_uses_safe_domain_pagination_defaults()
+  {
+    var id = Guid.Parse("4d63ea4e-d9a0-43f1-bfc0-234319569a20");
+    var query = new ExportWithdrawalQuery(
+      id,
+      "user-123",
+      "admin-456",
+      12.34m,
+      56.78m,
+      "Completed",
+      "31-12-2025",
+      "01-01-2025"
+    );
+
+    var search = query.ToDomain();
+
+    search.Id.Should().Be(id);
+    search.UserId.Should().Be("user-123");
+    search.CompleterId.Should().Be("admin-456");
+    search.Min.Should().Be(12.34m);
+    search.Max.Should().Be(56.78m);
+    search.Status.Should().Be(WithdrawStatus.Completed);
+    search.Before.Should().Be(new DateOnly(2025, 12, 31));
+    search.After.Should().Be(new DateOnly(2025, 1, 1));
+    search.Limit.Should().Be(20);
+    search.Skip.Should().Be(0);
+  }
+
+  [Fact]
+  public void Search_query_maps_all_filters_and_explicit_pagination()
+  {
+    var id = Guid.Parse("fd05cd1b-aeef-4e10-aee3-4703ec1059c9");
+    var query = new SearchWithdrawalQuery(
+      id,
+      "user-123",
+      "admin-456",
+      12.34m,
+      56.78m,
+      "RequireManualIntervention",
+      "31-12-2025",
+      "01-01-2025",
+      50,
+      10
+    );
+
+    var search = query.ToDomain();
+
+    search.Id.Should().Be(id);
+    search.UserId.Should().Be("user-123");
+    search.CompleterId.Should().Be("admin-456");
+    search.Min.Should().Be(12.34m);
+    search.Max.Should().Be(56.78m);
+    search.Status.Should().Be(WithdrawStatus.RequireManualIntervention);
+    search.Before.Should().Be(new DateOnly(2025, 12, 31));
+    search.After.Should().Be(new DateOnly(2025, 1, 1));
+    search.Limit.Should().Be(50);
+    search.Skip.Should().Be(10);
+  }
+
+  [Fact]
+  public void Search_query_uses_pagination_defaults_when_values_are_omitted()
+  {
+    var search = new SearchWithdrawalQuery(null, null, null, null, null, null, null, null, null, null)
+      .ToDomain();
+
+    search.Limit.Should().Be(20);
+    search.Skip.Should().Be(0);
+  }
+
+  [Theory]
+  [MemberData(nameof(ValidStatuses))]
+  public void Both_query_validators_accept_every_known_status_and_null(string? status)
+  {
+    var search = new SearchWithdrawalQuery(null, null, null, null, null, status, null, null, null, null);
+    var export = new ExportWithdrawalQuery(null, null, null, null, null, status, null, null);
+
+    new SearchWithdrawalQueryValidator().Validate(search).IsValid.Should().BeTrue();
+    new ExportWithdrawalQueryValidator().Validate(export).IsValid.Should().BeTrue();
+  }
+
+  [Fact]
+  public void Both_query_validators_reject_an_unknown_status()
+  {
+    var search = new SearchWithdrawalQuery(null, null, null, null, null, "Bogus", null, null, null, null);
+    var export = new ExportWithdrawalQuery(null, null, null, null, null, "Bogus", null, null);
+
+    new SearchWithdrawalQueryValidator().Validate(search).IsValid.Should().BeFalse();
+    new ExportWithdrawalQueryValidator().Validate(export).IsValid.Should().BeFalse();
+  }
+}

--- a/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
@@ -870,6 +870,9 @@ public class WithdrawalServiceGuardTests
       Task.FromResult((Result<string>)"receipt-key");
 
     public Task<Result<string>> Get(string key) => Task.FromResult((Result<string>)"url");
+
+    public Task<Result<string>> Get(string key, TimeSpan expiry) =>
+      Task.FromResult((Result<string>)"url");
   }
 
   private sealed class FakePayoutGateway(GatewayMode mode) : IPayoutGateway

--- a/UnitTest/Withdrawals/WithdrawalSettingsPolicyTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalSettingsPolicyTests.cs
@@ -470,6 +470,9 @@ public class WithdrawalSettingsPolicyTests
     public Task<Result<string>> Save(Stream stream) => throw new NotImplementedException();
 
     public Task<Result<string>> Get(string key) => throw new NotImplementedException();
+
+    public Task<Result<string>> Get(string key, TimeSpan expiry) =>
+      throw new NotImplementedException();
   }
 
   private sealed class UnusedPayoutGateway : IPayoutGateway

--- a/UnitTest/Withdrawals/WithdrawalStorageTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalStorageTests.cs
@@ -1,0 +1,103 @@
+using App.Modules.Common;
+using App.Modules.Withdrawals.Data;
+using CSharp_Result;
+using Domain;
+using FluentAssertions;
+
+namespace UnitTest.Withdrawals;
+
+public class WithdrawalStorageTests
+{
+  [Theory]
+  [InlineData(-1)]
+  [InlineData(0)]
+  [InlineData(0.5)]
+  [InlineData(604800.001)]
+  public async Task Explicit_expiry_rejects_values_outside_the_minio_presign_range(double seconds)
+  {
+    var file = new FakeFileRepository();
+    var storage = new WithdrawalStorage(file);
+
+    var result = await storage.Get("receipt-key", TimeSpan.FromSeconds(seconds));
+
+    result.IsFailure().Should().BeTrue();
+    result.FailureOrDefault().Should().BeOfType<ArgumentOutOfRangeException>();
+    file.SignedLinkRequests.Should().BeEmpty("invalid expiry must not reach the MinIO client");
+  }
+
+  [Theory]
+  [InlineData(1, 1)]
+  [InlineData(604800, 604800)]
+  public async Task Explicit_expiry_accepts_the_inclusive_minio_boundaries(
+    double seconds,
+    int expectedSeconds
+  )
+  {
+    var file = new FakeFileRepository();
+    var storage = new WithdrawalStorage(file);
+
+    var result = await storage.Get("receipt-key", TimeSpan.FromSeconds(seconds));
+
+    result.IsSuccess().Should().BeTrue();
+    result.SuccessOrDefault().Should().Be("signed-url");
+    var request = file.SignedLinkRequests.Should().ContainSingle().Which;
+    request.Key.Should().Be("receipt-key");
+    request.Seconds.Should().Be(expectedSeconds);
+  }
+
+  [Fact]
+  public async Task Interactive_link_keeps_the_one_hour_expiry()
+  {
+    var file = new FakeFileRepository();
+    var storage = new WithdrawalStorage(file);
+
+    var result = await storage.Get("receipt-key");
+
+    result.IsSuccess().Should().BeTrue();
+    file.SignedLinkRequests.Should().ContainSingle().Which.Seconds.Should().Be(3600);
+  }
+
+  private sealed class FakeFileRepository : IFileRepository
+  {
+    public List<(string Store, string Key, int Seconds)> SignedLinkRequests { get; } = [];
+
+    public Task<Result<string>> SignedLink(string store, string key, int seconds)
+    {
+      this.SignedLinkRequests.Add((store, key, seconds));
+      return Task.FromResult((Result<string>)"signed-url");
+    }
+
+    public Task<Result<string>> Save(
+      string store,
+      string dir,
+      string name,
+      byte[] content,
+      bool appendExt
+    ) => throw new NotImplementedException();
+
+    public Task<Result<string>> Save(
+      string store,
+      string dir,
+      string name,
+      string content,
+      bool appendExt
+    ) => throw new NotImplementedException();
+
+    public Task<Result<string>> Save(
+      string store,
+      string dir,
+      string name,
+      Stream content,
+      bool appendExt
+    ) => throw new NotImplementedException();
+
+    public Task<Result<string>> Link(string store, string key) =>
+      throw new NotImplementedException();
+
+    public Task<Result<bool>> Exists(string store, string key) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Unit>> Remove(string store, string key) =>
+      throw new NotImplementedException();
+  }
+}


### PR DESCRIPTION
## Summary

- add an admin-only `GET /api/v1.0/Withdrawal/export` endpoint using the existing withdrawal filters without caller pagination
- keyset-page fully hydrated withdrawals in stable ascending `(CreatedAt, Id)` order, backed by a composite database index, and stream the complete result as UTF-8 RFC 4180 CSV
- export legacy completed withdrawals correctly as `fee = 0.00` and `net_amount = gross` when their pre-fee rows have no payout record; no-payment and unsettled statuses retain blank money cells
- keep the 7-day presigned `receipt_url` as a convenience while appending a durable `receipt_key` as column 23 for archived evidence
- emit stored payout fields and index-aligned card-refund evidence, with Asia/Singapore timestamps and spreadsheet-formula protection
- abort incomplete responses on repository or receipt-presigning failures, and expose `Content-Disposition` cross-origin so the frontend can use the server-selected filename

## Verification

- `dotnet test UnitTest/UnitTest.csproj --no-build --no-restore --filter 'FullyQualifiedName~Withdrawals'` — 206 passed
- `dotnet test UnitTest/UnitTest.csproj --no-build --no-restore` — 831 passed; 29 pre-existing timezone-data failures, all in `BookingServicePrioritizeTests`
- `dotnet build App/App.csproj --no-restore -v:minimal` — 0 errors
- `dotnet ef migrations has-pending-model-changes --project ./App --no-build` — no pending model changes
- `pre-commit run treefmt --all-files` — passed
- `git diff --check` — passed

## Export contract

```text
withdrawal_id,created_at,completed_at,status,method,user_id,user_email,gross_amount,fee,net_amount,paynow_number,airwallex_confirmation,payout_attempt,reconcile_attempts,completer_id,completion_note,receipt_url,refund_payment_intent_ids,refund_airwallex_ids,refund_amounts,refund_statuses,refund_settled_ats,receipt_key
```

## Notes

- `receipt_url` uses the MinIO/S3 7-day presign maximum; expiry inputs are bounded to the supported 1-second–7-day range, while `receipt_key` is the permanent object reference that can be re-signed later.
- Each export page and its refund evidence now load in one SQL statement; the `(CreatedAt, Id)` migration keeps repeated keyset pages index-served.
- Formula-like field values are prefixed with a literal apostrophe for Excel/Sheets safety.
- Timestamps are emitted as ISO 8601 Asia/Singapore values with an explicit `+08:00` offset, matching the `After`/`Before` calendar-day boundaries.
- The shared list/export validator accepts non-negative `Max`; invalid list statuses now return a validation error instead of reaching the mapper and producing a 500.
- The same-timestamp page-boundary regression pins canonical PostgreSQL UUID ordering. Empirical verification found `.NET Guid.CompareTo` agrees with that order; the mixed-endian default `Guid.ToByteArray()` is the actual ordering hazard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin-only withdrawal CSV export endpoint with filtering by ID, user/completer, amount range, status, and date window.
  * CSV exports now include a new `receipt_key` column (alongside expiring receipt download links).
  * Large exports stream as RFC-compliant CSV using cursor-based paging.
* **Bug Fixes**
  * Improved export query validation with shared filter rules, stricter status checks, and corrected fee/net behavior for legacy “completed without payout” cases.
  * Export streaming is cancellation-safe and returns complete/consistent CSV results.
* **Chores**
  * Added a database index on `(CreatedAt, Id)` to optimize export pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->