### PR TITLE
fix: remove argocd sync hook from api deployment

### DIFF
--- a/infra/api_chart/README.md
+++ b/infra/api_chart/README.md
@@ -33,6 +33,9 @@ A Chart to deploy .NET Microservice
 | readinessProbe | object | `{}` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
+| rollingUpdate | object | `{"maxSurge":1,"maxUnavailable":0}` | Rolling update strategy. Defaults to surge-not-shrink so a sync never drops below the desired replica count. |
+| rollingUpdate.maxSurge | int | `1` | Max pods that may be created above the desired count during a rollout |
+| rollingUpdate.maxUnavailable | int | `0` | Max pods that may be unavailable during a rollout |
 | securityContext | object | `{}` |  |
 | service.containerPort | int | `9000` |  |
 | service.port | int | `80` |  |

--- a/infra/api_chart/templates/deployment.yaml
+++ b/infra/api_chart/templates/deployment.yaml
@@ -8,11 +8,12 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- $rollingUpdate := .Values.rollingUpdate | default dict }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: {{ .Values.rollingUpdate.maxUnavailable | default 0 }}
-      maxSurge: {{ .Values.rollingUpdate.maxSurge | default 1 }}
+      maxUnavailable: {{ dig "maxUnavailable" 0 $rollingUpdate }}
+      maxSurge: {{ dig "maxSurge" 1 $rollingUpdate }}
   selector:
     matchLabels:
       {{- include "dotnet-chart.selectorLabels" . | nindent 6 }}

--- a/infra/api_chart/templates/deployment.yaml
+++ b/infra/api_chart/templates/deployment.yaml
@@ -8,6 +8,11 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: {{ .Values.rollingUpdate.maxUnavailable | default 0 }}
+      maxSurge: {{ .Values.rollingUpdate.maxSurge | default 1 }}
   selector:
     matchLabels:
       {{- include "dotnet-chart.selectorLabels" . | nindent 6 }}

--- a/infra/api_chart/values.yaml
+++ b/infra/api_chart/values.yaml
@@ -6,6 +6,14 @@ serviceTree:
 
 replicaCount: 1
 
+# -- Rolling update strategy. Defaults to surge-not-shrink so a sync never
+# drops below the desired replica count.
+rollingUpdate:
+  # -- Max pods that may be unavailable during a rollout
+  maxUnavailable: 0
+  # -- Max pods that may be created above the desired count during a rollout
+  maxSurge: 1
+
 aspNetEnv: Development
 
 appSettings:

--- a/infra/root_chart/README.md
+++ b/infra/root_chart/README.md
@@ -21,7 +21,6 @@ Root Chart to a single Service
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | api.affinity | object | `{}` |  |
-| api.annotations."argocd.argoproj.io/hook" | string | `"Sync"` |  |
 | api.annotations."argocd.argoproj.io/sync-wave" | string | `"4"` |  |
 | api.annotations.drop_log | string | `"true"` |  |
 | api.appSettings.App.Mode | string | `"Server"` |  |
@@ -41,16 +40,24 @@ Root Chart to a single Service
 | api.ingress.tls[0].hosts[0] | string | `"api.zinc.nitroso.lapras.lvh.me"` |  |
 | api.ingress.tls[0].issuerRef | string | `"sample"` |  |
 | api.ingress.tls[0].secretName | string | `"sample"` |  |
+| api.livenessProbe.failureThreshold | int | `3` |  |
 | api.livenessProbe.httpGet.path | string | `"/"` |  |
 | api.livenessProbe.httpGet.port | string | `"http"` |  |
-| api.livenessProbe.periodSeconds | int | `30` |  |
+| api.livenessProbe.initialDelaySeconds | int | `5` |  |
+| api.livenessProbe.periodSeconds | int | `5` |  |
+| api.livenessProbe.successThreshold | int | `1` |  |
+| api.livenessProbe.timeoutSeconds | int | `5` |  |
 | api.nameOverride | string | `"zinc-api"` |  |
 | api.nodeSelector | object | `{}` |  |
 | api.podAnnotations | object | `{}` |  |
 | api.podSecurityContext | object | `{}` |  |
+| api.readinessProbe.failureThreshold | int | `3` |  |
 | api.readinessProbe.httpGet.path | string | `"/"` |  |
 | api.readinessProbe.httpGet.port | string | `"http"` |  |
-| api.readinessProbe.periodSeconds | int | `30` |  |
+| api.readinessProbe.initialDelaySeconds | int | `5` |  |
+| api.readinessProbe.periodSeconds | int | `5` |  |
+| api.readinessProbe.successThreshold | int | `1` |  |
+| api.readinessProbe.timeoutSeconds | int | `5` |  |
 | api.replicaCount | int | `1` |  |
 | api.resources.limits.cpu | string | `"1"` |  |
 | api.resources.limits.memory | string | `"1Gi"` |  |

--- a/infra/root_chart/values.yaml
+++ b/infra/root_chart/values.yaml
@@ -32,7 +32,6 @@ api:
   enabled: true
   annotations:
     argocd.argoproj.io/sync-wave: '4'
-    argocd.argoproj.io/hook: Sync
     drop_log: 'true'
   nameOverride: 'zinc-api'
 
@@ -97,14 +96,25 @@ api:
       memory: 128Mi
 
   autoscaling: {}
+  # NOTE: `/` is served by Swagger UI, not a dedicated health endpoint. It only
+  # proves the host is listening, not that Postgres/Redis/MinIO are reachable.
+  # A real readiness endpoint is tracked as follow-up.
   readinessProbe:
-    periodSeconds: 30
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 3
     httpGet:
       path: /
       port: http
 
   livenessProbe:
-    periodSeconds: 30
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 3
     httpGet:
       path: /
       port: http


### PR DESCRIPTION
## The bug

`infra/root_chart/values.yaml` carried this on the **`api:`** block:

```yaml
api:
  annotations:
    argocd.argoproj.io/sync-wave: '4'
    argocd.argoproj.io/hook: Sync      # <-- the bug
```

Those annotations render onto the **Deployment's** metadata via
`dotnet-chart.annotations` (`api_chart/templates/_helpers.tpl:61` →
`deployment.yaml:6`).

ArgoCD's default `hook-delete-policy` is `BeforeHookCreation` — "any existing
hook resource is deleted before the new one is created". So **every sync deleted
the `zinc-api` Deployment, all 3 raichu replicas, then recreated it**,
guaranteeing a zero-pod window on every single release.

Observed as nginx **503 on raichu (prod) for ~2 min, 2026-08-05 04:11–04:13 UTC**.

Introduced in `33c4283` "fix: missing sync hook" (2023-12-27), which correctly
added the hook to the migration **Job** and incorrectly also to the api
**Deployment**.

**Control case:** `nitroso.tin` carries `sync-wave: '4'` on 14 workloads with
**no hook**, and does not do this. This PR copies tin's shape.

## Changes

1. **Remove `argocd.argoproj.io/hook: Sync` from the `api` block.** This is the
   actual fix. `sync-wave: '4'` is kept so the api still orders after the
   migration. **The `migration:` block's hook is deliberately untouched** — on a
   Job the hook is correct and required.
2. **Add an explicit rollout strategy** to `api_chart/templates/deployment.yaml`.
   There was no `strategy:` block, so k8s defaulted to `maxUnavailable: 25%`.
   Now defaults to surge-not-shrink (`maxUnavailable: 0`, `maxSurge: 1`), with
   values templated via a new `rollingUpdate` key.
3. **Tighten the readiness/liveness probes.** The effective raichu probe was only
   `periodSeconds: 30` + `httpGet /` — no `initialDelaySeconds`, `timeoutSeconds`
   or `failureThreshold`. Brought toward the values the repo already documents in
   `api_chart/values.example.yaml`.

## Verification

`helm template` of the root chart with `-f infra/root_chart/values.raichu.yaml`:

**(a) The Deployment no longer has the hook** — `sync-wave` retained:

```yaml
kind: Deployment
metadata:
  name: zinc-api
  annotations:
    helm.sh/chart: api-0.1.0
    ...
    "argocd.argoproj.io/sync-wave": "4"
    "drop_log": "true"
```

**(b) The migration Job still does** — every remaining hook in the rendered
output, mapped to its owning resource:

```
ConfigMap / zinc-migration-config ->  "argocd.argoproj.io/hook": "Sync"
Job       / zinc-migration       ->  "argocd.argoproj.io/hook": "Sync"
Job       / zinc-migration       ->  "argocd.argoproj.io/hook": "Sync"   (pod template)
```

**(c) The strategy block is present:**

```yaml
spec:
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 0
      maxSurge: 1
```

**Sync-wave ordering is unaffected** by removing the hook — secrets (1–2) still
precede the migration Job (3), which still precedes the api (4).

Probes render as expected:

```yaml
readinessProbe:
  failureThreshold: 3
  httpGet: {path: /, port: http}
  initialDelaySeconds: 5
  periodSeconds: 5
  successThreshold: 1
  timeoutSeconds: 5
```

All five landscapes (`pichu`/`pikachu`/`raichu`/`lapras`/`tauros`) render
successfully; `helm lint` passes with 0 failures. `helm-docs` regenerates both
READMEs with **zero diff**, so the docs match generated output exactly.

**Local build/test:** `dotnet build` — 0 errors. `dotnet test` — **874/874
passing** (+1 IntTest), matching the baseline on `main`. This PR touches only
YAML/templates, so that is expected.

## Review follow-up (`cef442a`)

CodeRabbit caught a real latent bug in the first commit: Helm's `default`
treats numeric `0` as empty, so an explicit `maxSurge: 0` override silently
rendered as `1`. Reproduced, then fixed with `dig`, which distinguishes "key
absent" from "key set to zero":

```yaml
{{- $rollingUpdate := .Values.rollingUpdate | default dict }}
strategy:
  type: RollingUpdate
  rollingUpdate:
    maxUnavailable: {{ dig "maxUnavailable" 0 $rollingUpdate }}
    maxSurge: {{ dig "maxSurge" 1 $rollingUpdate }}
```

Verified: explicit `0` now survives, defaults still resolve to `0`/`1`, and an
absent `rollingUpdate` key falls back without a nil-deref. This was latent, not
active — no landscape sets `maxSurge: 0`, and the shipped raichu render is
unchanged.

## Follow-up (deliberately not in this PR)

`/` is served by **Swagger UI**, not a health endpoint. It proves the host is
listening, not that Postgres/Redis/MinIO are reachable — so a pod can pass
readiness while its dependencies are down. A real health endpoint is worth doing
separately; it is noted in a comment in `values.yaml`.

## Deploy note

Merging this **does not deploy anything** — it only triggers semantic-release to
publish a new chart. The actual deploy is a version pin bump in
`AtomiCloud/sulfoxide.radon`, which is a separate PR held for the human to time,
since this rollout is itself the thing that causes the outage.

**Live confirmation still requires watching the next sync** — I have no cluster
access from this box. What is verified here is that the chart no longer renders
the hook, which is the mechanism.
