### PR TITLE
feat(withdrawals): reconcile historic paynow card refunds

### DIFF
--- a/App/Modules/DomainServices.cs
+++ b/App/Modules/DomainServices.cs
@@ -150,6 +150,11 @@ public static class DomainServices
 
     s.AddHostedService<RefundArnBackfillWorker>();
 
+    // Admin-triggered historic-refund reconciliation. Deliberately NOT a
+    // hosted service: the matching is inferential, so a human reads the
+    // ambiguous bucket before the apply phase writes anything.
+    s.AddScoped<RefundReconciliationRunner>();
+
     s.AddScoped<IWithdrawalSettingsRepository, WithdrawalSettingsRepository>()
       .AutoTrace<IWithdrawalSettingsRepository>();
 

--- a/App/Modules/Payments/Airwallex/Client.cs
+++ b/App/Modules/Payments/Airwallex/Client.cs
@@ -185,6 +185,81 @@ public class AirWallexClient(
       });
   }
 
+  // Every refund the gateway created in [fromUtc, toUtc), following page_num
+  // until has_more is false. This is the comb side of the historic-refund
+  // reconciliation: refunds issued manually before the CardRefund method
+  // existed are addressable only this way, since zinc stored no refund id for
+  // them and the single-refund lookup needs one.
+  //
+  // NOTE the hard limit this inherits from the gateway: a refund is queryable
+  // for at most 2 YEARS since creation. A window older than that comes back
+  // empty and those refunds are unrecoverable, permanently — the caller must
+  // clamp rather than assume an empty page means "no refunds happened".
+  public Task<Result<AirwallexRefundRes[]>> ListRefunds(DateTime fromUtc, DateTime toUtc)
+  {
+    return authenticator
+      .GetToken()
+      .ThenAwait(async token =>
+      {
+        try
+        {
+          var from = Uri.EscapeDataString(fromUtc.ToString("yyyy-MM-ddTHH:mm:ssZ"));
+          var to = Uri.EscapeDataString(toUtc.ToString("yyyy-MM-ddTHH:mm:ssZ"));
+          var items = new List<AirwallexRefundRes>();
+          var page = 0;
+          while (true)
+          {
+            var request = new HttpRequestMessage
+            {
+              Method = HttpMethod.Get,
+              RequestUri = new Uri(
+                $"api/v1/pa/refunds?from_created_at={from}&to_created_at={to}"
+                  + $"&page_num={page}&page_size=100",
+                UriKind.Relative
+              ),
+              Headers = { Authorization = new AuthenticationHeaderValue("Bearer", token) },
+            };
+            using var response = await this.HttpClient.SendAsync(request);
+            var body = await response.Content.ReadAsStringAsync();
+            // a 404 is "no refunds in this window" — a normal empty answer
+            if ((int)response.StatusCode == 404)
+              return (Result<AirwallexRefundRes[]>)items.ToArray();
+            if (!response.IsSuccessStatusCode)
+            {
+              logger.LogError(
+                "Failed to list Airwallex refunds in [{From}, {To}), "
+                  + "Status: {Status}, Response: {Body}",
+                fromUtc,
+                toUtc,
+                (int)response.StatusCode,
+                body
+              );
+              return (Result<AirwallexRefundRes[]>)
+                new HttpRequestException(
+                  $"Airwallex refund listing failed ({(int)response.StatusCode}): {body}"
+                );
+            }
+
+            var list = body.ToObj<AirwallexRefundListRes>();
+            items.AddRange(list.Items ?? []);
+            if (!list.HasMore || list.Items is not { Length: > 0 })
+              return (Result<AirwallexRefundRes[]>)items.ToArray();
+            page++;
+          }
+        }
+        catch (Exception e)
+        {
+          logger.LogError(
+            e,
+            "Failed to list Airwallex refunds in [{From}, {To}) (transport error)",
+            fromUtc,
+            toUtc
+          );
+          return (Result<AirwallexRefundRes[]>)e;
+        }
+      });
+  }
+
   // Point-in-time intent lookup: the gateway keys a payment's financial
   // transactions by the payment ATTEMPT id, so fee capture resolves the
   // intent's latest_payment_attempt through this. Returns null (not an

--- a/App/Modules/Payments/Airwallex/ResModel.cs
+++ b/App/Modules/Payments/Airwallex/ResModel.cs
@@ -174,6 +174,34 @@ public record AirwallexRefundRes
   // the refund SETTLES, so a freshly-created refund legitimately has none.
   [JsonPropertyName("acquirer_reference_number")]
   public string? AcquirerReferenceNumber { get; set; }
+
+  // When the refund was created at the gateway. Only the LIST endpoint is
+  // filtered on it, and the reconciliation matcher scores a candidate
+  // withdrawal by how close its timestamps sit to this — so it is read, not
+  // merely carried. Nullable: the single-refund lookup paths never needed it
+  // and their fakes do not set it.
+  [JsonPropertyName("created_at")]
+  public DateTime? CreatedAt { get; set; }
+
+  // Last state change. For a SETTLED refund this is the closest thing the list
+  // endpoint offers to a settlement time — the single-refund object carries no
+  // settled_at at all.
+  [JsonPropertyName("updated_at")]
+  public DateTime? UpdatedAt { get; set; }
+
+  [JsonPropertyName("currency")]
+  public string? Currency { get; set; }
+}
+
+// One page of the refunds listing. Same envelope as the financial-transaction
+// listing: has_more drives the page_num walk.
+public record AirwallexRefundListRes
+{
+  [JsonPropertyName("has_more")]
+  public bool HasMore { get; set; }
+
+  [JsonPropertyName("items")]
+  public AirwallexRefundRes[]? Items { get; set; }
 }
 
 // Shared status classification for refund objects (webhook adapter and

--- a/App/Modules/Withdrawals/API/V1/WithdrawalController.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalController.cs
@@ -138,6 +138,73 @@ public class WithdrawalController(
     return new EmptyResult();
   }
 
+  // Owner-only historic-refund comb, phase 1: READ-ONLY. Lists every Airwallex
+  // refund created in the window and reports which withdrawal each belongs to,
+  // in four buckets — matched, ambiguous, unowned, already attached. Writes
+  // NOTHING, so it is safe to run repeatedly while a human reads the ambiguous
+  // bucket (refunds issued manually before WithdrawalMethod.CardRefund existed
+  // sit on PayNow withdrawals with no evidence, and the gateway data alone
+  // cannot always name their owner).
+  //
+  // Same two gates as Export, for the same reason: this walks the whole
+  // withdrawal ledger of every affected user.
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpGet("reconcile-refunds")]
+  public async Task<ActionResult<RefundReconciliationRes>> ReconcileRefundsReport(
+    [FromQuery] ReconcileRefundsQuery query,
+    [FromServices] ReconcileRefundsQueryValidator validator,
+    [FromServices] RefundReconciliationRunner runner
+  )
+  {
+    var x = await this.GuardRoleIgnoreCaseAsync(AuthRoles.Owner)
+      .ThenAwait(_ => validator.ValidateAsyncResult(query, "Invalid ReconcileRefundsQuery"))
+      .ThenAwait(q =>
+      {
+        var (from, to) = ReconcileWindow(q);
+        return runner.Report(from, to, DateTime.UtcNow);
+      })
+      .Then(report => report.ToRes(), Errors.MapAll);
+    return this.ReturnResult(x);
+  }
+
+  // Phase 2: WRITES. Attaches a refund fragment for the confidently-matched
+  // bucket only — the ambiguous bucket is never applied, by construction. The
+  // match is re-derived from fresh gateway and database state inside the
+  // runner, so this cannot be steered toward an assignment phase 1 would not
+  // have offered. Idempotent: a refund that already has a fragment is skipped.
+  [Authorize(Policy = AuthPolicies.OnlyAdmin), HttpPost("reconcile-refunds")]
+  public async Task<ActionResult<RefundReconciliationApplyRes>> ReconcileRefundsApply(
+    [FromQuery] ReconcileRefundsQuery query,
+    [FromServices] ReconcileRefundsQueryValidator validator,
+    [FromServices] RefundReconciliationRunner runner
+  )
+  {
+    var x = await this.GuardRoleIgnoreCaseAsync(AuthRoles.Owner)
+      .ThenAwait(_ => validator.ValidateAsyncResult(query, "Invalid ReconcileRefundsQuery"))
+      .ThenAwait(q =>
+      {
+        var (from, to) = ReconcileWindow(q);
+        return runner.Apply(from, to, DateTime.UtcNow);
+      })
+      .Then(report => report.ToRes(), Errors.MapAll);
+    return this.ReturnResult(x);
+  }
+
+  // Inclusive calendar days in the export's business timezone, so a window
+  // asked for here covers the same rows the CSV would show for those dates.
+  // An absent bound opens that end: the runner clamps the start to the
+  // gateway's retention horizon and warns about what it had to drop.
+  private static (DateTime From, DateTime To) ReconcileWindow(ReconcileRefundsQuery query)
+  {
+    var sgt = TimeZoneInfo.FindSystemTimeZoneById("Asia/Singapore");
+    var from =
+      query.After?.ToDate().ToZonedDateTime(TimeOnly.MinValue, sgt)
+      ?? DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc);
+    var to =
+      query.Before?.ToDate().AddDays(1).ToZonedDateTime(TimeOnly.MinValue, sgt)
+      ?? DateTime.UtcNow;
+    return (from, to);
+  }
+
   [Authorize, HttpGet("{id:guid}")]
   public async Task<ActionResult<WithdrawalRes>> Get(Guid id, string? userId)
   {

--- a/App/Modules/Withdrawals/API/V1/WithdrawalCsv.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalCsv.cs
@@ -190,6 +190,20 @@ public static class WithdrawalCsv
     var payout = p.Payout;
     var fragments = w.Refunds;
     var isCardRefund = p.Record.Method == WithdrawalMethod.CardRefund;
+    // The six refund_* columns render EVIDENCE, so they are gated on whether
+    // evidence exists — never on the method. Gating them on CardRefund blanked
+    // every historic manual refund: those were issued before the CardRefund
+    // method existed, so they sit on Method = PayNow withdrawals, and the
+    // reconciliation backfill attaches their fragments to exactly those rows.
+    // A fragment on a PayNow withdrawal is not corrupt data, it is the money
+    // trail the tax export exists to produce.
+    //
+    // JoinFragments over an empty list already yields "", so a withdrawal with
+    // no evidence renders blank by construction and needs no guard at all.
+    // isCardRefund survives only on paynow_number below, which asks a
+    // genuinely different question: a card refund returns money to the cards
+    // that funded the wallet, so any PayNow number on such a row is stale
+    // legacy data that must not export.
     var hasPayment = payout is not null
       && p.Status.Status is not (WithdrawStatus.Pending or WithdrawStatus.Rejected or WithdrawStatus.Cancel);
     // Withdrawals completed before the payout columns existed (migration
@@ -227,21 +241,15 @@ public static class WithdrawalCsv
       CompleterId = p.Complete?.CompleterId ?? "",
       CompletionNote = p.Complete?.Note ?? "",
       ReceiptUrl = receiptUrl ?? "",
-      RefundPaymentIntentIds = isCardRefund
-        ? JoinFragments(fragments, f => f.PaymentIntentId)
-        : "",
-      RefundAirwallexIds = isCardRefund
-        ? JoinFragments(fragments, f => f.AirwallexRefundId)
-        : "",
-      RefundAmounts = isCardRefund ? JoinFragments(fragments, f => Amount(f.Amount)) : "",
-      RefundStatuses = isCardRefund ? JoinFragments(fragments, f => f.Status.ToRes()) : "",
-      RefundSettledAts = isCardRefund ? JoinFragments(fragments, f => Timestamp(f.SettledAt)) : "",
+      RefundPaymentIntentIds = JoinFragments(fragments, f => f.PaymentIntentId),
+      RefundAirwallexIds = JoinFragments(fragments, f => f.AirwallexRefundId),
+      RefundAmounts = JoinFragments(fragments, f => Amount(f.Amount)),
+      RefundStatuses = JoinFragments(fragments, f => f.Status.ToRes()),
+      RefundSettledAts = JoinFragments(fragments, f => Timestamp(f.SettledAt)),
       // permanent storage key; receipt_url next to it is a presigned link
       // that expires, so this is what survives in an archived CSV
       ReceiptKey = p.Complete?.Receipt ?? "",
-      RefundArns = isCardRefund
-        ? JoinFragments(fragments, f => f.AcquirerReferenceNumber)
-        : "",
+      RefundArns = JoinFragments(fragments, f => f.AcquirerReferenceNumber),
     };
   }
 

--- a/App/Modules/Withdrawals/API/V1/WithdrawalMapper.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalMapper.cs
@@ -79,6 +79,87 @@ public static class WithdrawalMapper
       w.Refunds.Select(x => x.ToRes())
     );
 
+  public static string ToRes(this RefundMatchVerdict verdict) =>
+    verdict switch
+    {
+      RefundMatchVerdict.Matched => "Matched",
+      RefundMatchVerdict.AlreadyAttached => "AlreadyAttached",
+      RefundMatchVerdict.NoPaymentIntent => "NoPaymentIntent",
+      RefundMatchVerdict.NoCandidateWithdrawal => "NoCandidateWithdrawal",
+      RefundMatchVerdict.Ambiguous => "Ambiguous",
+      _ => throw new ArgumentOutOfRangeException(nameof(verdict), verdict, null),
+    };
+
+  public static string ToRes(this PayoutOutcome outcome) =>
+    outcome switch
+    {
+      PayoutOutcome.Settled => "Settled",
+      PayoutOutcome.Failed => "Failed",
+      PayoutOutcome.InFlight => "InFlight",
+      PayoutOutcome.NotFound => "NotFound",
+      _ => throw new ArgumentOutOfRangeException(nameof(outcome), outcome, null),
+    };
+
+  public static RefundCandidateRes ToRes(this RefundCandidateScore score) =>
+    new(
+      score.WithdrawalId,
+      score.Amount,
+      score.Method.ToRes(),
+      score.Status.ToRes(),
+      score.CreatedAt,
+      score.CompletedAt,
+      score.AmountGap,
+      score.HoursApart
+    );
+
+  public static RefundMatchRes ToRes(this RefundMatch match) =>
+    new(
+      match.Refund.Id,
+      match.Refund.PaymentIntentId,
+      match.Refund.Amount,
+      match.Refund.Outcome.ToRes(),
+      match.Refund.CreatedAt,
+      match.Refund.AcquirerReferenceNumber,
+      match.Verdict.ToRes(),
+      match.WithdrawalId,
+      match.UserId,
+      match.Reason,
+      match.Candidates.Select(c => c.ToRes())
+    );
+
+  public static RefundReconciliationRes ToRes(this RefundReconciliationReport report) =>
+    new(
+      report.FromUtc,
+      report.ToUtc,
+      report.Scanned,
+      report.Matched.Select(m => m.ToRes()),
+      report.Ambiguous.Select(m => m.ToRes()),
+      report.Unowned.Select(m => m.ToRes()),
+      report.AlreadyAttached.Select(m => m.ToRes())
+    );
+
+  public static RefundAttachmentRes ToRes(this RefundAttachment attachment) =>
+    new(
+      attachment.FragmentId,
+      attachment.WithdrawalId,
+      attachment.AirwallexRefundId,
+      attachment.PaymentIntentId,
+      attachment.Amount,
+      attachment.AcquirerReferenceNumber
+    );
+
+  public static RefundReconciliationApplyRes ToRes(
+    this RefundReconciliationApplyReport report
+  ) =>
+    new(
+      report.FromUtc,
+      report.ToUtc,
+      report.Eligible,
+      report.Attached,
+      report.AlreadyAttached,
+      report.Attachments.Select(a => a.ToRes())
+    );
+
   public static string ToRes(this PayNowMode mode) =>
     mode switch
     {

--- a/App/Modules/Withdrawals/API/V1/WithdrawalModel.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalModel.cs
@@ -85,6 +85,74 @@ public record WithdrawalRes(
 // card refunds right now, and the window that pool was computed over
 public record RefundablePoolRes(decimal Pool, int WindowDays);
 
+// Historic-refund reconciliation window (owner-only). Dates are inclusive
+// calendar days in the export's business timezone, like the export query.
+// Bounded by the gateway's 2-year refund retention whatever is asked for.
+public record ReconcileRefundsQuery(string? After, string? Before);
+
+// One candidate withdrawal a historic refund might belong to, with the two
+// signals that ranked it. AmountGap 0 means the withdrawal has exactly this
+// refund's amount left to account for.
+public record RefundCandidateRes(
+  Guid WithdrawalId,
+  decimal Amount,
+  string Method,
+  string Status,
+  DateTime CreatedAt,
+  DateTime? CompletedAt,
+  decimal AmountGap,
+  double? HoursApart
+);
+
+// One gateway refund and what the reconciliation concluded. Candidates is the
+// shortlist to check by hand when Verdict is "Ambiguous".
+public record RefundMatchRes(
+  string AirwallexRefundId,
+  string PaymentIntentId,
+  decimal Amount,
+  string RefundStatus,
+  DateTime? RefundCreatedAt,
+  string? AcquirerReferenceNumber,
+  string Verdict,
+  Guid? WithdrawalId,
+  string? UserId,
+  string Reason,
+  IEnumerable<RefundCandidateRes> Candidates
+);
+
+// GET Withdrawal/reconcile-refunds: the read-only comb. Ambiguous is the
+// "unsure" list a human must resolve by hand; nothing is ever written for it.
+public record RefundReconciliationRes(
+  DateTime FromUtc,
+  DateTime ToUtc,
+  int Scanned,
+  IEnumerable<RefundMatchRes> Matched,
+  IEnumerable<RefundMatchRes> Ambiguous,
+  IEnumerable<RefundMatchRes> Unowned,
+  IEnumerable<RefundMatchRes> AlreadyAttached
+);
+
+// One fragment an apply pass created.
+public record RefundAttachmentRes(
+  Guid FragmentId,
+  Guid WithdrawalId,
+  string AirwallexRefundId,
+  string PaymentIntentId,
+  decimal Amount,
+  string? AcquirerReferenceNumber
+);
+
+// POST Withdrawal/reconcile-refunds: what the apply pass wrote. Only the
+// confidently-matched bucket is ever attached.
+public record RefundReconciliationApplyRes(
+  DateTime FromUtc,
+  DateTime ToUtc,
+  int Eligible,
+  int Attached,
+  int AlreadyAttached,
+  IEnumerable<RefundAttachmentRes> Attachments
+);
+
 // POST Withdrawal/settings: replace the withdrawal method policy and the tin
 // sweep switch. PayNowMode: "Enabled" | "Disabled" | "FallbackOnly" (PayNow
 // accepted only when the refundable pool cannot cover the amount).

--- a/App/Modules/Withdrawals/API/V1/WithdrawalValidator.cs
+++ b/App/Modules/Withdrawals/API/V1/WithdrawalValidator.cs
@@ -91,6 +91,15 @@ public class CreateWithdrawalReqValidator : AbstractValidator<CreateWithdrawalRe
   }
 }
 
+public class ReconcileRefundsQueryValidator : AbstractValidator<ReconcileRefundsQuery>
+{
+  public ReconcileRefundsQueryValidator()
+  {
+    this.RuleFor(x => x.After).NullableDateValid();
+    this.RuleFor(x => x.Before).NullableDateValid();
+  }
+}
+
 public class SetWithdrawalSettingsReqValidator : AbstractValidator<SetWithdrawalSettingsReq>
 {
   private static readonly string[] Modes = ["Enabled", "Disabled", "FallbackOnly"];

--- a/App/Modules/Withdrawals/Data/AirwallexRefundGateway.cs
+++ b/App/Modules/Withdrawals/Data/AirwallexRefundGateway.cs
@@ -22,6 +22,40 @@ public class AirwallexRefundGateway(AirWallexClient client) : IRefundGateway
       .Then(res => new RefundConfirmation { Id = res.Id }, Errors.MapNone);
   }
 
+  public Task<Result<List<GatewayRefund>>> ListRefunds(DateTime fromUtc, DateTime toUtc)
+  {
+    return client
+      .ListRefunds(fromUtc, toUtc)
+      .Then(
+        refunds =>
+          refunds
+            .Select(r => new GatewayRefund
+            {
+              Id = r.Id,
+              PaymentIntentId = r.PaymentIntentId,
+              Amount = r.Amount,
+              Outcome = Classify(r.Status),
+              // a blank ARN is the same fact as an absent one
+              AcquirerReferenceNumber = string.IsNullOrWhiteSpace(r.AcquirerReferenceNumber)
+                ? null
+                : r.AcquirerReferenceNumber,
+              CreatedAt = r.CreatedAt,
+              UpdatedAt = r.UpdatedAt,
+              RequestId = string.IsNullOrWhiteSpace(r.RequestId) ? null : r.RequestId,
+            })
+            .ToList(),
+        Errors.MapNone
+      );
+  }
+
+  private static PayoutOutcome Classify(string status)
+  {
+    var normalized = status.ToUpperInvariant();
+    return AirwallexRefundStatuses.Settled.Contains(normalized) ? PayoutOutcome.Settled
+      : AirwallexRefundStatuses.Failed.Contains(normalized) ? PayoutOutcome.Failed
+      : PayoutOutcome.InFlight;
+  }
+
   public Task<Result<RefundStatus>> GetRefundStatus(string refundId)
   {
     return client
@@ -36,13 +70,9 @@ public class AirwallexRefundGateway(AirWallexClient client) : IRefundGateway
               ConfirmationNumber = null,
               AcquirerReferenceNumber = null,
             };
-          var status = refund.Status.ToUpperInvariant();
-          var outcome = AirwallexRefundStatuses.Settled.Contains(status) ? PayoutOutcome.Settled
-            : AirwallexRefundStatuses.Failed.Contains(status) ? PayoutOutcome.Failed
-            : PayoutOutcome.InFlight;
           return new RefundStatus
           {
-            Outcome = outcome,
+            Outcome = Classify(refund.Status),
             ConfirmationNumber = refund.Id,
             // a blank ARN is the same fact as an absent one: the network has
             // not issued a reference, and only null leaves a stored value alone

--- a/App/Modules/Withdrawals/Data/WithdrawalRefundRepository.cs
+++ b/App/Modules/Withdrawals/Data/WithdrawalRefundRepository.cs
@@ -141,6 +141,117 @@ public class WithdrawalRefundRepository(
     }
   }
 
+  public async Task<Result<List<WithdrawalRefundFragment>>> ListByAirwallexRefundIds(
+    IEnumerable<string> refundIds
+  )
+  {
+    try
+    {
+      var ids = refundIds.Distinct(StringComparer.Ordinal).ToArray();
+      if (ids.Length == 0)
+        return new List<WithdrawalRefundFragment>();
+      var rows = await db
+        .WithdrawalRefunds.Where(x =>
+          x.AirwallexRefundId != null && ids.Contains(x.AirwallexRefundId)
+        )
+        .ToArrayAsync();
+      return rows.Select(x => x.ToDomain()).ToList();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed listing refund fragments by gateway refund id");
+      return e;
+    }
+  }
+
+  public async Task<Result<List<PaymentIntentOwner>>> ListPaymentIntentOwners(
+    IEnumerable<string> paymentIntentIds
+  )
+  {
+    try
+    {
+      var ids = paymentIntentIds.Distinct(StringComparer.Ordinal).ToArray();
+      if (ids.Length == 0)
+        return new List<PaymentIntentOwner>();
+      var rows = await db
+        .Payments.Where(x => x.Gateway == Gateway && ids.Contains(x.ExternalReference))
+        .Select(x => new
+        {
+          x.Id,
+          x.ExternalReference,
+          x.WalletId,
+          x.Wallet.UserId,
+        })
+        .ToArrayAsync();
+      return rows
+        .Select(x => new PaymentIntentOwner
+        {
+          PaymentId = x.Id,
+          PaymentIntentId = x.ExternalReference,
+          WalletId = x.WalletId,
+          UserId = x.UserId,
+        })
+        .ToList();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed resolving payment intent owners");
+      return e;
+    }
+  }
+
+  public async Task<Result<List<WithdrawalCandidate>>> ListCandidatesByWallets(
+    IEnumerable<Guid> walletIds
+  )
+  {
+    try
+    {
+      var ids = walletIds.Distinct().ToArray();
+      if (ids.Length == 0)
+        return new List<WithdrawalCandidate>();
+      var rows = await db
+        .Withdrawals.Where(x => ids.Contains(x.WalletId))
+        .Select(x => new
+        {
+          x.Id,
+          x.WalletId,
+          x.Wallet.UserId,
+          x.Method,
+          x.Status,
+          x.Amount,
+          x.Fee,
+          x.CreatedAt,
+          x.CompletedAt,
+          // non-Failed only, matching SumActiveRefundsByPayment: a failed
+          // fragment released its claim, so it explains none of the amount
+          Attached = x
+            .Refunds.Where(r => r.Status != (byte)RefundFragmentStatus.Failed)
+            .Sum(r => (decimal?)r.Amount),
+        })
+        .ToArrayAsync();
+      return rows
+        .Select(x => new WithdrawalCandidate
+        {
+          Id = x.Id,
+          WalletId = x.WalletId,
+          UserId = x.UserId,
+          Method = (WithdrawalMethod)x.Method,
+          Status = (WithdrawStatus)x.Status,
+          Amount = x.Amount,
+          Fee = x.Fee,
+          CreatedAt = x.CreatedAt,
+          CompletedAt = x.CompletedAt,
+          AttachedRefundTotal = x.Attached ?? 0m,
+        })
+        .ToList();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed listing withdrawal candidates by wallet");
+      return e;
+    }
+  }
+
   public async Task<Result<List<WithdrawalRefundFragment>>> ListSettledMissingArn(
     DateTime createdOnOrAfter,
     IEnumerable<Guid> excludeIds,

--- a/Domain/Withdrawal/IRefundGateway.cs
+++ b/Domain/Withdrawal/IRefundGateway.cs
@@ -40,6 +40,41 @@ public record RefundStatus
   public required string? AcquirerReferenceNumber { get; init; }
 }
 
+// A refund as the GATEWAY knows it, listed by creation window rather than
+// looked up by id. This is the only handle on refunds issued manually before
+// the CardRefund method existed: zinc stored no refund id for those, so
+// GetRefundStatus cannot reach them and the reconciliation has to comb.
+public record GatewayRefund
+{
+  public required string Id { get; init; }
+
+  // the payment intent the money returned to — the link back to a zinc
+  // payment, and from there to the owning wallet and user
+  public required string PaymentIntentId { get; init; }
+
+  public required decimal Amount { get; init; }
+
+  public required PayoutOutcome Outcome { get; init; }
+
+  public required string? AcquirerReferenceNumber { get; init; }
+
+  // null when the gateway did not report one; a candidate withdrawal then
+  // cannot be scored on time proximity and stays ambiguous rather than being
+  // guessed at
+  public required DateTime? CreatedAt { get; init; }
+
+  // Last state change at the gateway. For a settled refund this is the nearest
+  // available settlement time — the gateway publishes no settled_at — so it is
+  // what an attached fragment records as SettledAt.
+  public required DateTime? UpdatedAt { get; init; }
+
+  // The merchant-supplied idempotency key. zinc-issued refunds carry the
+  // "{withdrawalId}-{attempt}-{index}" fragment RequestId here, which names
+  // the owning withdrawal outright — a manually-issued refund does not, which
+  // is exactly why the rest of the matching exists.
+  public required string? RequestId { get; init; }
+}
+
 public interface IRefundGateway
 {
   Task<Result<RefundConfirmation>> CreateRefund(RefundRequest request);
@@ -47,4 +82,10 @@ public interface IRefundGateway
   // Point-in-time gateway view of a refund, used by the reconciliation sweep
   // and the ARN backfill (refunds are only addressable by their gateway id)
   Task<Result<RefundStatus>> GetRefundStatus(string refundId);
+
+  // Every refund the gateway created in [fromUtc, toUtc). Used by the
+  // historic-refund reconciliation, which has no refund ids to look up.
+  // Bounded by the gateway's 2-year retention: an older window answers empty,
+  // and those refunds can never be recovered.
+  Task<Result<List<GatewayRefund>>> ListRefunds(DateTime fromUtc, DateTime toUtc);
 }

--- a/Domain/Withdrawal/Model.cs
+++ b/Domain/Withdrawal/Model.cs
@@ -188,6 +188,51 @@ public record FundingPayment
   public required decimal CapturedAmount { get; init; }
 }
 
+// Who a gateway payment intent belongs to, resolved from the payment row the
+// intent id denormalizes. The reconciliation's first narrowing step: a refund
+// against this intent can only ever be owned by a withdrawal of THIS wallet.
+public record PaymentIntentOwner
+{
+  public required Guid PaymentId { get; init; }
+
+  public required string PaymentIntentId { get; init; }
+
+  public required Guid WalletId { get; init; }
+
+  public required string UserId { get; init; }
+}
+
+// A withdrawal considered as the possible owner of a historic gateway refund.
+// Flattened on purpose: the matcher is a pure function over these, so it needs
+// the wallet and the timestamps beside the record, not a full aggregate.
+public record WithdrawalCandidate
+{
+  public required Guid Id { get; init; }
+
+  public required Guid WalletId { get; init; }
+
+  public required string UserId { get; init; }
+
+  public required WithdrawalMethod Method { get; init; }
+
+  public required WithdrawStatus Status { get; init; }
+
+  public required decimal Amount { get; init; }
+
+  // approval-time fee snapshot; the refunded net is Amount - Fee, so a
+  // withdrawal whose payout row predates the fee feature (null) is scored on
+  // its gross instead
+  public required decimal? Fee { get; init; }
+
+  public required DateTime CreatedAt { get; init; }
+
+  public required DateTime? CompletedAt { get; init; }
+
+  // fragments already attached, so an amount-coverage score never double-counts
+  // evidence a previous reconciliation run wrote
+  public required decimal AttachedRefundTotal { get; init; }
+}
+
 // A funding payment still inside the refund window, and how much of its
 // captured amount remains refundable (captured minus non-failed fragments)
 public record RefundablePayment

--- a/Domain/Withdrawal/RefundReconciliation.cs
+++ b/Domain/Withdrawal/RefundReconciliation.cs
@@ -1,0 +1,336 @@
+namespace Domain.Withdrawal;
+
+// Why a gateway refund could not be assigned to exactly one withdrawal, or
+// why it was. Carried on every row of the report so the human reading the
+// "unsure" list knows what to check rather than just that we gave up.
+public enum RefundMatchVerdict
+{
+  // exactly one candidate withdrawal survived every filter
+  Matched = 0,
+
+  // zinc already has a fragment for this gateway refund id — nothing to do,
+  // and reported so a re-run visibly accounts for every refund in the window
+  AlreadyAttached = 1,
+
+  // no zinc payment row carries this payment intent, so no withdrawal of ours
+  // can own the refund (a refund against a booking payment, another product,
+  // or an intent that predates zinc's payment records)
+  NoPaymentIntent = 2,
+
+  // the intent resolves to a wallet, but that wallet has no withdrawal the
+  // refund could belong to
+  NoCandidateWithdrawal = 3,
+
+  // more than one candidate survived and the gateway data cannot separate
+  // them — THE case the human asked to see listed
+  Ambiguous = 4,
+}
+
+// One gateway refund, and what the reconciliation concluded about it.
+public record RefundMatch
+{
+  public required GatewayRefund Refund { get; init; }
+
+  public required RefundMatchVerdict Verdict { get; init; }
+
+  // set only for Matched (and AlreadyAttached, where it names the withdrawal
+  // the existing fragment already belongs to)
+  public required Guid? WithdrawalId { get; init; }
+
+  // the wallet the refund's payment intent resolved to, when it resolved
+  public required string? UserId { get; init; }
+
+  // Every withdrawal that survived the filters, best-scoring first. For
+  // Ambiguous rows this IS the human's shortlist; for Matched it has exactly
+  // one entry.
+  public required IReadOnlyList<RefundCandidateScore> Candidates { get; init; }
+
+  // one-line human-readable account of the verdict
+  public required string Reason { get; init; }
+}
+
+// A candidate withdrawal and how well it fits the refund.
+public record RefundCandidateScore
+{
+  public required Guid WithdrawalId { get; init; }
+
+  public required decimal Amount { get; init; }
+
+  public required WithdrawalMethod Method { get; init; }
+
+  public required WithdrawStatus Status { get; init; }
+
+  public required DateTime CreatedAt { get; init; }
+
+  public required DateTime? CompletedAt { get; init; }
+
+  // |refund amount - the withdrawal's still-unevidenced amount|. Zero means
+  // the refund exactly accounts for what the withdrawal has left to explain.
+  public required decimal AmountGap { get; init; }
+
+  // hours between the refund's creation and the withdrawal's reference time
+  // (completed, else created); null when the gateway reported no created_at
+  public required double? HoursApart { get; init; }
+}
+
+// The whole dry run: every refund in the window, bucketed.
+public record RefundReconciliationReport
+{
+  public required DateTime FromUtc { get; init; }
+
+  public required DateTime ToUtc { get; init; }
+
+  // refunds the gateway reported in the window
+  public required int Scanned { get; init; }
+
+  public required IReadOnlyList<RefundMatch> Matched { get; init; }
+
+  public required IReadOnlyList<RefundMatch> Ambiguous { get; init; }
+
+  public required IReadOnlyList<RefundMatch> Unowned { get; init; }
+
+  public required IReadOnlyList<RefundMatch> AlreadyAttached { get; init; }
+}
+
+// Pure matcher for historic gateway refunds -> owning withdrawals.
+//
+// The problem: WithdrawalMethod.CardRefund did not always exist. Refunds
+// issued manually before it did left NO fragment behind, so the only record
+// that a withdrawal was paid by card refund is the refund sitting at the
+// gateway. Those withdrawals are stored as Method = PayNow.
+//
+// What the gateway gives us per refund is the payment intent, an amount, and a
+// creation time. What it never gives us is the withdrawal id. So ownership is
+// INFERRED, and the whole design point is that a weak inference is reported as
+// unsure rather than written:
+//
+//  1. The intent resolves through zinc's payment rows to exactly one wallet.
+//     A refund can then only belong to a withdrawal of that wallet — this is
+//     the one hard, non-heuristic constraint, and it does the heavy lifting.
+//  2. Within that wallet, only withdrawals that could have been paid out by a
+//     refund survive: Completed (money left) and, so a half-finished manual
+//     job is still visible, RequireManualIntervention.
+//  3. A refund cannot predate the withdrawal that caused it, so candidates
+//     created after the refund are dropped (with a small clock-skew grace).
+//  4. What is left is scored on amount coverage first and time proximity
+//     second. A single survivor whose amount fits within the tolerance is
+//     Matched. Anything else is Ambiguous, with the shortlist attached.
+//
+// Deliberately NOT done: picking the closest candidate when several fit. A
+// user with two PayNow withdrawals of the same amount in the same week is
+// genuinely undecidable from gateway data, and quietly choosing one would
+// write a false money trail into a tax export. That is strictly worse than a
+// blank cell, which at least reads as "unknown".
+public static class RefundReconciler
+{
+  // Airwallex keeps a refund queryable for at most 2 years since creation.
+  // Same haircut as RefundArnBackfillRunner.RetentionWindow, and the same
+  // reason: stay off a cliff edge we cannot observe.
+  public static readonly TimeSpan RetentionWindow = RefundArnBackfillRunner.RetentionWindow;
+
+  // How far a refund's amount may sit from a candidate's unexplained amount
+  // and still count as covering it. A cent of rounding is plausible in
+  // hand-entered historic refunds; a dollar is a different withdrawal.
+  public const decimal AmountTolerance = 0.01m;
+
+  // A refund settles after the withdrawal that caused it, never meaningfully
+  // before. The grace absorbs clock skew and the manual case where an admin
+  // issued the refund minutes before recording the withdrawal.
+  public static readonly TimeSpan CreationGrace = TimeSpan.FromDays(1);
+
+  // Statuses a historic card refund could have paid out. Pending/Rejected/
+  // Cancel never moved money, so a refund cannot belong to them.
+  private static readonly WithdrawStatus[] PayableStatuses =
+  [
+    WithdrawStatus.Completed,
+    WithdrawStatus.RequireManualIntervention,
+  ];
+
+  public static RefundReconciliationReport Reconcile(
+    DateTime fromUtc,
+    DateTime toUtc,
+    IReadOnlyList<GatewayRefund> refunds,
+    IReadOnlyList<WithdrawalRefundFragment> existingFragments,
+    IReadOnlyList<PaymentIntentOwner> intentOwners,
+    IReadOnlyList<WithdrawalCandidate> candidates
+  )
+  {
+    var attachedByRefundId = existingFragments
+      .Where(f => f.AirwallexRefundId != null)
+      .GroupBy(f => f.AirwallexRefundId!, StringComparer.Ordinal)
+      .ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
+
+    var ownerByIntent = intentOwners
+      .GroupBy(o => o.PaymentIntentId, StringComparer.Ordinal)
+      .ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
+
+    var candidatesByWallet = candidates
+      .GroupBy(c => c.WalletId)
+      .ToDictionary(g => g.Key, g => (IReadOnlyList<WithdrawalCandidate>)g.ToList());
+
+    // Fragments this run has already assigned, so two refunds in the same
+    // window cannot both claim the same withdrawal's one unexplained amount.
+    // Without this a wallet with two same-amount refunds would match both to
+    // the same withdrawal and the apply phase would over-attach.
+    var claimed = new Dictionary<Guid, decimal>();
+
+    var results = new List<RefundMatch>();
+    foreach (var refund in refunds.OrderBy(r => r.CreatedAt ?? DateTime.MaxValue))
+      results.Add(MatchOne(refund, attachedByRefundId, ownerByIntent, candidatesByWallet, claimed));
+
+    return new RefundReconciliationReport
+    {
+      FromUtc = fromUtc,
+      ToUtc = toUtc,
+      Scanned = refunds.Count,
+      Matched = results.Where(r => r.Verdict == RefundMatchVerdict.Matched).ToList(),
+      Ambiguous = results.Where(r => r.Verdict == RefundMatchVerdict.Ambiguous).ToList(),
+      Unowned = results
+        .Where(r =>
+          r.Verdict
+            is RefundMatchVerdict.NoPaymentIntent
+              or RefundMatchVerdict.NoCandidateWithdrawal
+        )
+        .ToList(),
+      AlreadyAttached = results
+        .Where(r => r.Verdict == RefundMatchVerdict.AlreadyAttached)
+        .ToList(),
+    };
+  }
+
+  private static RefundMatch MatchOne(
+    GatewayRefund refund,
+    Dictionary<string, WithdrawalRefundFragment> attachedByRefundId,
+    Dictionary<string, PaymentIntentOwner> ownerByIntent,
+    Dictionary<Guid, IReadOnlyList<WithdrawalCandidate>> candidatesByWallet,
+    Dictionary<Guid, decimal> claimed
+  )
+  {
+    // 0. Idempotency, before anything else: zinc already has evidence for this
+    // refund, so a second fragment would double-count it in the refundable
+    // pool and duplicate the cell in the export.
+    if (attachedByRefundId.TryGetValue(refund.Id, out var existing))
+      return Unresolved(
+        refund,
+        RefundMatchVerdict.AlreadyAttached,
+        $"already evidenced by fragment '{existing.Id}' on withdrawal '{existing.WithdrawalId}'",
+        withdrawalId: existing.WithdrawalId
+      );
+
+    // 1. The hard constraint: the intent must resolve to a wallet we know.
+    if (!ownerByIntent.TryGetValue(refund.PaymentIntentId, out var owner))
+      return Unresolved(
+        refund,
+        RefundMatchVerdict.NoPaymentIntent,
+        $"no zinc payment carries intent '{refund.PaymentIntentId}', so no withdrawal can own it"
+      );
+
+    var wallet = candidatesByWallet.GetValueOrDefault(owner.WalletId, []);
+
+    // 2/3. Only withdrawals that moved money, and that the refund cannot
+    // predate.
+    var eligible = wallet
+      .Where(c => PayableStatuses.Contains(c.Status))
+      .Where(c => refund.CreatedAt is null || c.CreatedAt <= refund.CreatedAt.Value + CreationGrace)
+      .ToList();
+
+    if (eligible.Count == 0)
+      return Unresolved(
+        refund,
+        RefundMatchVerdict.NoCandidateWithdrawal,
+        $"user '{owner.UserId}' has no completed withdrawal this refund could belong to",
+        userId: owner.UserId
+      );
+
+    // 4. Score what is left. Unexplained = the net payout minus evidence
+    // already attached (by an earlier run, or by an earlier refund in THIS
+    // run) — so a partially-reconciled withdrawal is scored on what it still
+    // has to account for, not on its full amount.
+    var scored = eligible
+      .Select(c =>
+      {
+        var net = c.Amount - (c.Fee ?? 0m);
+        var unexplained = net - c.AttachedRefundTotal - claimed.GetValueOrDefault(c.Id);
+        var reference = c.CompletedAt ?? c.CreatedAt;
+        return new RefundCandidateScore
+        {
+          WithdrawalId = c.Id,
+          Amount = c.Amount,
+          Method = c.Method,
+          Status = c.Status,
+          CreatedAt = c.CreatedAt,
+          CompletedAt = c.CompletedAt,
+          AmountGap = Math.Abs(unexplained - refund.Amount),
+          HoursApart = refund.CreatedAt is null
+            ? null
+            : Math.Abs((refund.CreatedAt.Value - reference).TotalHours),
+        };
+      })
+      .OrderBy(s => s.AmountGap)
+      .ThenBy(s => s.HoursApart ?? double.MaxValue)
+      .ToList();
+
+    var fitting = scored.Where(s => s.AmountGap <= AmountTolerance).ToList();
+
+    if (fitting.Count == 0)
+      return new RefundMatch
+      {
+        Refund = refund,
+        Verdict = RefundMatchVerdict.Ambiguous,
+        WithdrawalId = null,
+        UserId = owner.UserId,
+        Candidates = scored,
+        Reason =
+          $"no withdrawal of user '{owner.UserId}' has SGD {refund.Amount:0.00} left to account "
+          + $"for (closest is off by SGD {scored[0].AmountGap:0.00}) — a partial refund, a fee "
+          + "difference, or evidence already recorded elsewhere",
+      };
+
+    if (fitting.Count > 1)
+      return new RefundMatch
+      {
+        Refund = refund,
+        Verdict = RefundMatchVerdict.Ambiguous,
+        WithdrawalId = null,
+        UserId = owner.UserId,
+        Candidates = fitting,
+        Reason =
+          $"{fitting.Count} withdrawals of user '{owner.UserId}' each account for SGD "
+          + $"{refund.Amount:0.00} exactly — the gateway data cannot separate them",
+      };
+
+    var winner = fitting[0];
+    claimed[winner.WithdrawalId] =
+      claimed.GetValueOrDefault(winner.WithdrawalId) + refund.Amount;
+
+    return new RefundMatch
+    {
+      Refund = refund,
+      Verdict = RefundMatchVerdict.Matched,
+      WithdrawalId = winner.WithdrawalId,
+      UserId = owner.UserId,
+      Candidates = fitting,
+      Reason =
+        $"the only withdrawal of user '{owner.UserId}' with SGD {refund.Amount:0.00} left to "
+        + $"account for"
+        + (winner.HoursApart is null ? "" : $", {winner.HoursApart:0.0}h from the refund"),
+    };
+  }
+
+  private static RefundMatch Unresolved(
+    GatewayRefund refund,
+    RefundMatchVerdict verdict,
+    string reason,
+    Guid? withdrawalId = null,
+    string? userId = null
+  ) =>
+    new()
+    {
+      Refund = refund,
+      Verdict = verdict,
+      WithdrawalId = withdrawalId,
+      UserId = userId,
+      Candidates = [],
+      Reason = reason,
+    };
+}

--- a/Domain/Withdrawal/RefundReconciliationRunner.cs
+++ b/Domain/Withdrawal/RefundReconciliationRunner.cs
@@ -1,0 +1,264 @@
+using CSharp_Result;
+using Microsoft.Extensions.Logging;
+
+namespace Domain.Withdrawal;
+
+// What an apply pass wrote.
+public record RefundReconciliationApplyReport
+{
+  public required DateTime FromUtc { get; init; }
+
+  public required DateTime ToUtc { get; init; }
+
+  // confidently-matched refunds the dry run offered
+  public required int Eligible { get; init; }
+
+  // fragments actually created
+  public required int Attached { get; init; }
+
+  // matched refunds skipped because evidence appeared since the dry run
+  public required int AlreadyAttached { get; init; }
+
+  public required IReadOnlyList<RefundAttachment> Attachments { get; init; }
+}
+
+// One fragment the apply pass created, for the audit trail.
+public record RefundAttachment
+{
+  public required Guid FragmentId { get; init; }
+
+  public required Guid WithdrawalId { get; init; }
+
+  public required string AirwallexRefundId { get; init; }
+
+  public required string PaymentIntentId { get; init; }
+
+  public required decimal Amount { get; init; }
+
+  public required string? AcquirerReferenceNumber { get; init; }
+}
+
+// Two-phase reconciliation of historic gateway refunds against withdrawals.
+//
+// An admin-triggered pair of calls rather than a BackgroundService, unlike
+// RefundArnBackfillWorker: this is a ONE-OFF historical repair whose matching
+// is inferential, so a human must read the ambiguous bucket before anything is
+// written. A recurring worker would either need to auto-apply guesses (writing
+// a false money trail into a tax export) or accumulate a report nobody reads.
+// The ARN backfill can be a worker precisely because its input is unambiguous:
+// it already knows the refund id and only fetches a missing field.
+//
+// Phase 1 Report is read-only and safe to repeat. Phase 2 Apply writes
+// fragments for the confidently-matched set ONLY, re-deriving the match from
+// fresh data so the caller cannot smuggle in a withdrawal id of their own.
+public class RefundReconciliationRunner(
+  IWithdrawalRefundRepository refundRepo,
+  IRefundGateway gateway,
+  ILogger<RefundReconciliationRunner> logger
+)
+{
+  public async Task<Result<RefundReconciliationReport>> Report(
+    DateTime fromUtc,
+    DateTime toUtc,
+    DateTime nowUtc
+  )
+  {
+    var horizon = nowUtc - RefundReconciler.RetentionWindow;
+    // The gateway answers nothing before this, so a wider request would report
+    // a silent, permanent gap as "no refunds found".
+    var from = fromUtc < horizon ? horizon : fromUtc;
+    if (fromUtc < horizon)
+      logger.LogWarning(
+        "Refund reconciliation: requested window starts {Requested} but the gateway retains "
+          + "refunds only from {Horizon}; refunds created before that are unrecoverable and are "
+          + "NOT in this report",
+        fromUtc,
+        horizon
+      );
+
+    if (from >= toUtc)
+      return Empty(from, toUtc);
+
+    var refundsR = await gateway.ListRefunds(from, toUtc);
+    if (refundsR.IsFailure())
+      return refundsR.FailureOrDefault();
+    var refunds = refundsR.SuccessOrDefault();
+
+    logger.LogInformation(
+      "Refund reconciliation: {Count} gateway refund(s) in [{From}, {To})",
+      refunds.Count,
+      from,
+      toUtc
+    );
+    if (refunds.Count == 0)
+      return Empty(from, toUtc);
+
+    var existingR = await refundRepo.ListByAirwallexRefundIds(refunds.Select(r => r.Id));
+    if (existingR.IsFailure())
+      return existingR.FailureOrDefault();
+
+    var ownersR = await refundRepo.ListPaymentIntentOwners(
+      refunds.Select(r => r.PaymentIntentId).Distinct(StringComparer.Ordinal)
+    );
+    if (ownersR.IsFailure())
+      return ownersR.FailureOrDefault();
+    var owners = ownersR.SuccessOrDefault();
+
+    var candidatesR = await refundRepo.ListCandidatesByWallets(
+      owners.Select(o => o.WalletId).Distinct()
+    );
+    if (candidatesR.IsFailure())
+      return candidatesR.FailureOrDefault();
+
+    var report = RefundReconciler.Reconcile(
+      from,
+      toUtc,
+      refunds,
+      existingR.SuccessOrDefault(),
+      owners,
+      candidatesR.SuccessOrDefault()
+    );
+    logger.LogInformation(
+      "Refund reconciliation: {Matched} matched, {Ambiguous} ambiguous, {Unowned} unowned, "
+        + "{Attached} already attached",
+      report.Matched.Count,
+      report.Ambiguous.Count,
+      report.Unowned.Count,
+      report.AlreadyAttached.Count
+    );
+    return report;
+  }
+
+  // Attaches fragments for the confidently-matched bucket only. The match is
+  // re-derived here from a fresh Report rather than taken from the caller, so
+  // an apply can never write an assignment a dry run would not have offered —
+  // and a refund that became ambiguous since the dry run is skipped instead of
+  // acted on.
+  public async Task<Result<RefundReconciliationApplyReport>> Apply(
+    DateTime fromUtc,
+    DateTime toUtc,
+    DateTime nowUtc
+  )
+  {
+    var reportR = await this.Report(fromUtc, toUtc, nowUtc);
+    if (reportR.IsFailure())
+      return reportR.FailureOrDefault();
+    var report = reportR.SuccessOrDefault();
+
+    var attachments = new List<RefundAttachment>();
+    var skipped = 0;
+
+    foreach (var match in report.Matched)
+    {
+      // Re-check under the write: Report proved no fragment held this refund id
+      // when it read, but a concurrent settle webhook or a second apply could
+      // have written one since.
+      var freshR = await refundRepo.ListByAirwallexRefundIds([match.Refund.Id]);
+      if (freshR.IsFailure())
+        return freshR.FailureOrDefault();
+      if (freshR.SuccessOrDefault().Count > 0)
+      {
+        skipped++;
+        continue;
+      }
+
+      var ownersR = await refundRepo.ListPaymentIntentOwners([match.Refund.PaymentIntentId]);
+      if (ownersR.IsFailure())
+        return ownersR.FailureOrDefault();
+      var owner = ownersR.SuccessOrDefault().FirstOrDefault();
+      if (owner is null)
+      {
+        // Report only matches refunds whose intent resolved, so this is
+        // unreachable barring a concurrent payment deletion.
+        skipped++;
+        continue;
+      }
+
+      var createdR = await refundRepo.CreateMany([ToFragment(match, owner, nowUtc)]);
+      if (createdR.IsFailure())
+        return createdR.FailureOrDefault();
+      var created = createdR.SuccessOrDefault().Single();
+
+      logger.LogInformation(
+        "Refund reconciliation: attached gateway refund '{RefundId}' to withdrawal "
+          + "'{WithdrawalId}' as fragment '{FragmentId}'",
+        match.Refund.Id,
+        match.WithdrawalId,
+        created.Id
+      );
+      attachments.Add(
+        new RefundAttachment
+        {
+          FragmentId = created.Id,
+          WithdrawalId = created.WithdrawalId,
+          AirwallexRefundId = match.Refund.Id,
+          PaymentIntentId = created.PaymentIntentId,
+          Amount = created.Amount,
+          AcquirerReferenceNumber = created.AcquirerReferenceNumber,
+        }
+      );
+    }
+
+    return new RefundReconciliationApplyReport
+    {
+      FromUtc = report.FromUtc,
+      ToUtc = report.ToUtc,
+      Eligible = report.Matched.Count,
+      Attached = attachments.Count,
+      AlreadyAttached = skipped,
+      Attachments = attachments,
+    };
+  }
+
+  private static WithdrawalRefundFragment ToFragment(
+    RefundMatch match,
+    PaymentIntentOwner owner,
+    DateTime nowUtc
+  )
+  {
+    var refund = match.Refund;
+    var status = refund.Outcome switch
+    {
+      PayoutOutcome.Settled => RefundFragmentStatus.Settled,
+      PayoutOutcome.Failed => RefundFragmentStatus.Failed,
+      _ => RefundFragmentStatus.Created,
+    };
+    return new WithdrawalRefundFragment
+    {
+      Id = Guid.NewGuid(),
+      WithdrawalId = match.WithdrawalId!.Value,
+      PaymentId = owner.PaymentId,
+      PaymentIntentId = refund.PaymentIntentId,
+      AirwallexRefundId = refund.Id,
+      AcquirerReferenceNumber = refund.AcquirerReferenceNumber,
+      // Deliberately NOT the "{withdrawalId}-{attempt}-{index}" shape of a
+      // zinc-issued fragment: these refunds were created by hand at the
+      // gateway under a request id we never chose, so borrowing the attempt
+      // shape would make a re-drive of the card-refund approve path think it
+      // owned them. Keyed on the gateway refund id, which is unique, so the
+      // unique index on RequestId is itself a second idempotency guard.
+      RequestId = $"{match.WithdrawalId!.Value}-recon-{refund.Id}",
+      Amount = refund.Amount,
+      Status = status,
+      // the refund's own creation time, not now: this row is evidence of when
+      // the money actually moved, and the ARN backfill's retention bound reads
+      // CreatedAt to decide whether the gateway can still be asked about it
+      CreatedAt = refund.CreatedAt ?? nowUtc,
+      SettledAt = status == RefundFragmentStatus.Settled
+        ? refund.UpdatedAt ?? refund.CreatedAt ?? nowUtc
+        : null,
+    };
+  }
+
+  private static RefundReconciliationReport Empty(DateTime fromUtc, DateTime toUtc) =>
+    new()
+    {
+      FromUtc = fromUtc,
+      ToUtc = toUtc,
+      Scanned = 0,
+      Matched = [],
+      Ambiguous = [],
+      Unowned = [],
+      AlreadyAttached = [],
+    };
+}

--- a/Domain/Withdrawal/RefundRepository.cs
+++ b/Domain/Withdrawal/RefundRepository.cs
@@ -36,6 +36,24 @@ public interface IWithdrawalRefundRepository
     int max
   );
 
+  // Fragments already holding any of these gateway refund ids. The historic
+  // reconciliation's idempotency gate: a refund zinc already has evidence for
+  // must never gain a second fragment, however the first one got there.
+  Task<Result<List<WithdrawalRefundFragment>>> ListByAirwallexRefundIds(
+    IEnumerable<string> refundIds
+  );
+
+  // Who the given gateway payment intents belong to (absent = zinc has no
+  // payment row for that intent, so no withdrawal of ours can own its refund)
+  Task<Result<List<PaymentIntentOwner>>> ListPaymentIntentOwners(
+    IEnumerable<string> paymentIntentIds
+  );
+
+  // Withdrawals of these wallets that could own a historic refund, with their
+  // already-attached refund totals. Scoped to the wallets the refunds' intents
+  // resolved to, so the candidate set stays small however wide the window is.
+  Task<Result<List<WithdrawalCandidate>>> ListCandidatesByWallets(IEnumerable<Guid> walletIds);
+
   // How many settled fragments still lack an ARN but sit beyond the gateway's
   // retention window — permanently unbackfillable, and reported so the gap in
   // the tax export is visible instead of silent

--- a/UnitTest/Withdrawals/AirwallexRefundListingTests.cs
+++ b/UnitTest/Withdrawals/AirwallexRefundListingTests.cs
@@ -1,0 +1,203 @@
+using System.Net;
+using System.Text;
+using App.Modules.Payments.Airwallex;
+using App.Modules.Withdrawals.Data;
+using CSharp_Result;
+using Domain.Withdrawal;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace UnitTest.Withdrawals;
+
+// The refund LISTING, which the historic reconciliation depends on. Refunds
+// issued manually before WithdrawalMethod.CardRefund existed left no refund id
+// in zinc, so GetRefundStatus cannot reach them — combing the created-at window
+// is the only handle on them.
+public class AirwallexRefundListingTests
+{
+  private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> answer)
+    : HttpMessageHandler
+  {
+    public List<string> Requests { get; } = [];
+
+    protected override Task<HttpResponseMessage> SendAsync(
+      HttpRequestMessage request,
+      CancellationToken cancellationToken
+    )
+    {
+      this.Requests.Add(request.RequestUri!.PathAndQuery);
+      return Task.FromResult(answer(request));
+    }
+  }
+
+  private sealed class StubFactory(HttpMessageHandler handler) : IHttpClientFactory
+  {
+    public HttpClient CreateClient(string name) =>
+      new(handler, disposeHandler: false) { BaseAddress = new Uri("https://gateway.test/") };
+  }
+
+  private sealed class StubAuthenticator : IGatewayAuthenticator
+  {
+    public Task<Result<string>> GetToken() => Task.FromResult("token".ToResult());
+  }
+
+  private static HttpResponseMessage Json(string body, HttpStatusCode status = HttpStatusCode.OK) =>
+    new(status) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+  private static AirwallexRefundGateway Gateway(StubHandler handler) =>
+    new(
+      new AirWallexClient(
+        new StubFactory(handler),
+        new StubAuthenticator(),
+        NullLogger<AirWallexClient>.Instance
+      )
+    );
+
+  private static readonly DateTime From = new(2026, 7, 10, 0, 0, 0, DateTimeKind.Utc);
+  private static readonly DateTime To = new(2026, 7, 15, 1, 0, 0, DateTimeKind.Utc);
+
+  [Fact]
+  public async Task The_window_is_sent_as_from_and_to_created_at()
+  {
+    var handler = new StubHandler(_ => Json("""{"has_more":false,"items":[]}"""));
+
+    var result = await Gateway(handler).ListRefunds(From, To);
+
+    result.IsSuccess().Should().BeTrue();
+    var query = handler.Requests.Should().ContainSingle().Subject;
+    query.Should().StartWith("/api/v1/pa/refunds?");
+    query.Should().Contain("from_created_at=2026-07-10T00%3A00%3A00Z");
+    query.Should().Contain("to_created_at=2026-07-15T01%3A00%3A00Z");
+    query.Should().Contain("page_num=0");
+    query.Should().Contain("page_size=100");
+  }
+
+  [Fact]
+  public async Task Paging_follows_page_num_until_has_more_is_false()
+  {
+    var handler = new StubHandler(request =>
+      request.RequestUri!.Query.Contains("page_num=0")
+        ? Json(
+          """
+          {"has_more":true,"items":[
+            {"id":"rfd_1","payment_intent_id":"int_1","amount":10.5,"status":"SETTLED",
+             "created_at":"2026-07-11T03:04:05Z"}
+          ]}
+          """
+        )
+        : Json(
+          """
+          {"has_more":false,"items":[
+            {"id":"rfd_2","payment_intent_id":"int_2","amount":7,"status":"RECEIVED",
+             "created_at":"2026-07-12T03:04:05Z"}
+          ]}
+          """
+        )
+    );
+
+    var result = await Gateway(handler).ListRefunds(From, To);
+
+    result.IsSuccess().Should().BeTrue();
+    result.SuccessOrDefault().Select(r => r.Id).Should().Equal("rfd_1", "rfd_2");
+    handler.Requests.Should().HaveCount(2);
+    handler.Requests[1].Should().Contain("page_num=1");
+  }
+
+  [Fact]
+  public async Task A_refund_is_mapped_with_its_arn_amount_and_status()
+  {
+    var handler = new StubHandler(_ =>
+      Json(
+        """
+        {"has_more":false,"items":[
+          {"id":"rfd_1","request_id":"req-1","payment_intent_id":"int_1","amount":42.75,
+           "currency":"SGD","status":"SETTLED","created_at":"2026-07-11T03:04:05Z",
+           "updated_at":"2026-07-11T09:10:11Z",
+           "acquirer_reference_number":"12345678901234567890123"}
+        ]}
+        """
+      )
+    );
+
+    var result = await Gateway(handler).ListRefunds(From, To);
+
+    var refund = result.SuccessOrDefault().Should().ContainSingle().Subject;
+    refund.Id.Should().Be("rfd_1");
+    refund.PaymentIntentId.Should().Be("int_1");
+    refund.Amount.Should().Be(42.75m);
+    refund.Outcome.Should().Be(PayoutOutcome.Settled);
+    refund.AcquirerReferenceNumber.Should().Be("12345678901234567890123");
+    refund.CreatedAt.Should().Be(new DateTime(2026, 7, 11, 3, 4, 5, DateTimeKind.Utc));
+    refund.UpdatedAt.Should().Be(new DateTime(2026, 7, 11, 9, 10, 11, DateTimeKind.Utc));
+    refund.RequestId.Should().Be("req-1");
+  }
+
+  // A blank ARN is the same fact as an absent one — and only null leaves a
+  // stored value alone on the partial-update write path.
+  [Fact]
+  public async Task A_blank_arn_is_normalized_to_null()
+  {
+    var handler = new StubHandler(_ =>
+      Json(
+        """
+        {"has_more":false,"items":[
+          {"id":"rfd_1","payment_intent_id":"int_1","amount":1,"status":"RECEIVED",
+           "acquirer_reference_number":"   "}
+        ]}
+        """
+      )
+    );
+
+    var result = await Gateway(handler).ListRefunds(From, To);
+
+    result.SuccessOrDefault().Single().AcquirerReferenceNumber.Should().BeNull();
+  }
+
+  [Fact]
+  public async Task Statuses_are_classified_like_every_other_refund_path()
+  {
+    var handler = new StubHandler(_ =>
+      Json(
+        """
+        {"has_more":false,"items":[
+          {"id":"rfd_settled","payment_intent_id":"int_1","amount":1,"status":"SETTLED"},
+          {"id":"rfd_failed","payment_intent_id":"int_2","amount":1,"status":"FAILED"},
+          {"id":"rfd_flight","payment_intent_id":"int_3","amount":1,"status":"ACCEPTED"}
+        ]}
+        """
+      )
+    );
+
+    var result = await Gateway(handler).ListRefunds(From, To);
+
+    result.SuccessOrDefault()
+      .Select(r => r.Outcome)
+      .Should()
+      .Equal(PayoutOutcome.Settled, PayoutOutcome.Failed, PayoutOutcome.InFlight);
+  }
+
+  // A 404 means "no refunds in this window" — a normal empty answer, same as
+  // the financial-transaction listings this is modelled on.
+  [Fact]
+  public async Task A_404_is_an_empty_window_not_an_error()
+  {
+    var handler = new StubHandler(_ => Json("{}", HttpStatusCode.NotFound));
+
+    var result = await Gateway(handler).ListRefunds(From, To);
+
+    result.IsSuccess().Should().BeTrue();
+    result.SuccessOrDefault().Should().BeEmpty();
+  }
+
+  // Anything else must fail loudly: an empty list would read as "no refunds
+  // were ever issued", which is exactly the wrong conclusion to draw.
+  [Fact]
+  public async Task A_server_error_fails_rather_than_reporting_an_empty_window()
+  {
+    var handler = new StubHandler(_ => Json("boom", HttpStatusCode.InternalServerError));
+
+    var result = await Gateway(handler).ListRefunds(From, To);
+
+    result.IsSuccess().Should().BeFalse();
+  }
+}

--- a/UnitTest/Withdrawals/RefundArnBackfillTests.cs
+++ b/UnitTest/Withdrawals/RefundArnBackfillTests.cs
@@ -143,6 +143,9 @@ public class RefundArnBackfillTests
     public Task<Result<RefundConfirmation>> CreateRefund(RefundRequest request) =>
       throw new NotImplementedException();
 
+    public Task<Result<List<GatewayRefund>>> ListRefunds(DateTime fromUtc, DateTime toUtc) =>
+      throw new NotImplementedException();
+
     public Task<Result<RefundStatus>> GetRefundStatus(string refundId)
     {
       Looked.Add(refundId);
@@ -262,6 +265,18 @@ public class RefundArnBackfillTests
 
     public Task<Result<List<WithdrawalRefundFragment>>> CreateMany(
       IEnumerable<WithdrawalRefundFragment> fragments
+    ) => throw new NotImplementedException();
+
+    public Task<Result<List<WithdrawalRefundFragment>>> ListByAirwallexRefundIds(
+      IEnumerable<string> refundIds
+    ) => throw new NotImplementedException();
+
+    public Task<Result<List<PaymentIntentOwner>>> ListPaymentIntentOwners(
+      IEnumerable<string> paymentIntentIds
+    ) => throw new NotImplementedException();
+
+    public Task<Result<List<WithdrawalCandidate>>> ListCandidatesByWallets(
+      IEnumerable<Guid> walletIds
     ) => throw new NotImplementedException();
   }
 }

--- a/UnitTest/Withdrawals/RefundReconciliationRunnerTests.cs
+++ b/UnitTest/Withdrawals/RefundReconciliationRunnerTests.cs
@@ -1,0 +1,379 @@
+using CSharp_Result;
+using Domain.Withdrawal;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace UnitTest.Withdrawals;
+
+// The runner wires the matcher to the gateway and the database. What matters
+// here is the two-phase contract: Report writes NOTHING, Apply writes only the
+// confidently-matched bucket, and both are safe to repeat.
+public class RefundReconciliationRunnerTests
+{
+  private static readonly DateTime Now = new(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc);
+  private static readonly DateTime From = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+  private static readonly DateTime To = new(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+
+  private static readonly Guid Wallet = Guid.NewGuid();
+  private static readonly Guid PaymentId = Guid.NewGuid();
+  private const string Intent = "int_funding";
+  private const string User = "user-1";
+
+  [Fact]
+  public async Task The_dry_run_writes_nothing()
+  {
+    var repo = new FakeRepo();
+    var withdrawal = repo.AddCandidate(amount: 100m);
+    var gateway = new FakeGateway { Refunds = { Refund("rfd_1", 100m, From.AddDays(10)) } };
+
+    var report = await Report(repo, gateway);
+
+    report.Matched.Should().HaveCount(1);
+    report.Matched[0].WithdrawalId.Should().Be(withdrawal.Id);
+    repo.Fragments.Should().BeEmpty("a report must never write");
+  }
+
+  [Fact]
+  public async Task Apply_attaches_a_fragment_for_a_confidently_matched_refund()
+  {
+    var repo = new FakeRepo();
+    var withdrawal = repo.AddCandidate(amount: 100m);
+    var gateway = new FakeGateway { Refunds = { Refund("rfd_1", 100m, From.AddDays(10)) } };
+
+    var applied = await Apply(repo, gateway);
+
+    applied.Eligible.Should().Be(1);
+    applied.Attached.Should().Be(1);
+    var fragment = repo.Fragments.Should().ContainSingle().Subject;
+    fragment.WithdrawalId.Should().Be(withdrawal.Id);
+    fragment.AirwallexRefundId.Should().Be("rfd_1");
+    fragment.PaymentIntentId.Should().Be(Intent);
+    fragment.PaymentId.Should().Be(PaymentId);
+    fragment.Amount.Should().Be(100m);
+    fragment.Status.Should().Be(RefundFragmentStatus.Settled);
+    // the ARN is the whole point: it lands in the tax CSV
+    fragment.AcquirerReferenceNumber.Should().Be("12345678901234567890123");
+    // evidence of when the money MOVED, not of when we reconciled it
+    fragment.CreatedAt.Should().Be(From.AddDays(10));
+  }
+
+  // The ambiguous bucket is never applied. This is the safety property the
+  // whole two-phase design exists for.
+  [Fact]
+  public async Task Apply_never_attaches_an_ambiguous_refund()
+  {
+    var repo = new FakeRepo();
+    repo.AddCandidate(amount: 100m, completedAt: From.AddDays(10));
+    repo.AddCandidate(amount: 100m, completedAt: From.AddDays(12));
+    var gateway = new FakeGateway { Refunds = { Refund("rfd_1", 100m, From.AddDays(11)) } };
+
+    var report = await Report(repo, gateway);
+    report.Ambiguous.Should().HaveCount(1);
+
+    var applied = await Apply(repo, gateway);
+
+    applied.Eligible.Should().Be(0);
+    applied.Attached.Should().Be(0);
+    repo.Fragments.Should().BeEmpty();
+  }
+
+  // Running the apply twice must not double-attach: the second pass sees the
+  // fragment the first one wrote and skips the refund.
+  [Fact]
+  public async Task Apply_is_idempotent()
+  {
+    var repo = new FakeRepo();
+    repo.AddCandidate(amount: 100m);
+    var gateway = new FakeGateway { Refunds = { Refund("rfd_1", 100m, From.AddDays(10)) } };
+
+    var first = await Apply(repo, gateway);
+    var second = await Apply(repo, gateway);
+
+    first.Attached.Should().Be(1);
+    second.Attached.Should().Be(0, "the refund already has evidence");
+    second.Eligible.Should().Be(0, "and the matcher itself now reports it as attached");
+    repo.Fragments.Should().HaveCount(1);
+  }
+
+  // A request id collision is impossible by construction, but the fragment's
+  // request id must not look like a zinc-issued one either: the card-refund
+  // approve path claims "{withdrawalId}-{attempt}-{index}" fragments as its
+  // own on a re-drive, and must not adopt a reconciled row.
+  [Fact]
+  public async Task An_attached_fragment_does_not_borrow_the_approve_paths_request_id_shape()
+  {
+    var repo = new FakeRepo();
+    var withdrawal = repo.AddCandidate(amount: 100m);
+    var gateway = new FakeGateway { Refunds = { Refund("rfd_1", 100m, From.AddDays(10)) } };
+
+    await Apply(repo, gateway);
+
+    var requestId = repo.Fragments.Single().RequestId;
+    requestId.Should().Be($"{withdrawal.Id}-recon-rfd_1");
+    requestId.Should().NotBe($"{withdrawal.Id}-1-0", "that shape belongs to the approve path");
+  }
+
+  // Airwallex forgets a refund 2 years after creation. Asking for a wider
+  // window must clamp rather than silently report the unrecoverable slice as
+  // "no refunds found".
+  [Fact]
+  public async Task The_window_is_clamped_to_the_gateways_retention_horizon()
+  {
+    var repo = new FakeRepo();
+    var gateway = new FakeGateway();
+    var runner = Runner(repo, gateway);
+
+    var ancient = Now - RefundReconciler.RetentionWindow - TimeSpan.FromDays(365);
+    var result = await runner.Report(ancient, Now, Now);
+
+    result.IsSuccess().Should().BeTrue();
+    var report = result.SuccessOrDefault();
+    report.FromUtc.Should().Be(Now - RefundReconciler.RetentionWindow);
+    gateway.Windows.Should().ContainSingle();
+    gateway.Windows[0].From.Should().Be(Now - RefundReconciler.RetentionWindow);
+  }
+
+  // A window entirely beyond the horizon has nothing the gateway can answer,
+  // so it must not even be asked.
+  [Fact]
+  public async Task A_window_entirely_beyond_the_horizon_costs_no_gateway_call()
+  {
+    var repo = new FakeRepo();
+    var gateway = new FakeGateway();
+    var runner = Runner(repo, gateway);
+
+    var ancientEnd = Now - RefundReconciler.RetentionWindow - TimeSpan.FromDays(10);
+    var result = await runner.Report(ancientEnd.AddDays(-30), ancientEnd, Now);
+
+    result.IsSuccess().Should().BeTrue();
+    result.SuccessOrDefault().Scanned.Should().Be(0);
+    gateway.Windows.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task A_gateway_failure_fails_the_report_rather_than_reporting_an_empty_window()
+  {
+    var repo = new FakeRepo();
+    var gateway = new FakeGateway { Failing = true };
+    var runner = Runner(repo, gateway);
+
+    var result = await runner.Report(From, To, Now);
+
+    result.IsSuccess().Should().BeFalse("an empty report would read as 'no refunds exist'");
+  }
+
+  [Fact]
+  public async Task An_empty_window_is_a_normal_empty_report()
+  {
+    var repo = new FakeRepo();
+    var gateway = new FakeGateway();
+
+    var report = await Report(repo, gateway);
+
+    report.Scanned.Should().Be(0);
+    report.Matched.Should().BeEmpty();
+    report.Ambiguous.Should().BeEmpty();
+  }
+
+  // A failed refund returned no money, so its fragment must not claim the
+  // amount — the refundable pool subtracts non-Failed fragments only.
+  [Fact]
+  public async Task A_failed_gateway_refund_is_attached_as_a_failed_fragment()
+  {
+    var repo = new FakeRepo();
+    repo.AddCandidate(amount: 100m);
+    var gateway = new FakeGateway
+    {
+      Refunds =
+      {
+        Refund("rfd_1", 100m, From.AddDays(10), outcome: PayoutOutcome.Failed),
+      },
+    };
+
+    await Apply(repo, gateway);
+
+    var fragment = repo.Fragments.Should().ContainSingle().Subject;
+    fragment.Status.Should().Be(RefundFragmentStatus.Failed);
+    fragment.SettledAt.Should().BeNull("nothing settled");
+  }
+
+  private static RefundReconciliationRunner Runner(FakeRepo repo, FakeGateway gateway) =>
+    new(repo, gateway, NullLogger<RefundReconciliationRunner>.Instance);
+
+  private static async Task<RefundReconciliationReport> Report(
+    FakeRepo repo,
+    FakeGateway gateway
+  )
+  {
+    var result = await Runner(repo, gateway).Report(From, To, Now);
+    result.IsSuccess().Should().BeTrue();
+    return result.SuccessOrDefault();
+  }
+
+  private static async Task<RefundReconciliationApplyReport> Apply(
+    FakeRepo repo,
+    FakeGateway gateway
+  )
+  {
+    var result = await Runner(repo, gateway).Apply(From, To, Now);
+    result.IsSuccess().Should().BeTrue();
+    return result.SuccessOrDefault();
+  }
+
+  private static GatewayRefund Refund(
+    string id,
+    decimal amount,
+    DateTime createdAt,
+    PayoutOutcome outcome = PayoutOutcome.Settled
+  ) =>
+    new()
+    {
+      Id = id,
+      PaymentIntentId = Intent,
+      Amount = amount,
+      Outcome = outcome,
+      AcquirerReferenceNumber = "12345678901234567890123",
+      CreatedAt = createdAt,
+      UpdatedAt = createdAt.AddHours(2),
+      RequestId = null,
+    };
+
+  private sealed class FakeGateway : IRefundGateway
+  {
+    public List<GatewayRefund> Refunds { get; } = [];
+
+    public bool Failing { get; init; }
+
+    public List<(DateTime From, DateTime To)> Windows { get; } = [];
+
+    public Task<Result<List<GatewayRefund>>> ListRefunds(DateTime fromUtc, DateTime toUtc)
+    {
+      Windows.Add((fromUtc, toUtc));
+      if (Failing)
+        return Task.FromResult<Result<List<GatewayRefund>>>(
+          new HttpRequestException("gateway timeout")
+        );
+      return Task.FromResult<Result<List<GatewayRefund>>>(
+        Refunds.Where(r => r.CreatedAt >= fromUtc && r.CreatedAt < toUtc).ToList()
+      );
+    }
+
+    public Task<Result<RefundConfirmation>> CreateRefund(RefundRequest request) =>
+      throw new NotImplementedException();
+
+    public Task<Result<RefundStatus>> GetRefundStatus(string refundId) =>
+      throw new NotImplementedException();
+  }
+
+  private sealed class FakeRepo : IWithdrawalRefundRepository
+  {
+    public List<WithdrawalRefundFragment> Fragments { get; } = [];
+
+    private readonly List<WithdrawalCandidate> candidates = [];
+
+    public WithdrawalCandidate AddCandidate(decimal amount, DateTime? completedAt = null)
+    {
+      var candidate = new WithdrawalCandidate
+      {
+        Id = Guid.NewGuid(),
+        WalletId = Wallet,
+        UserId = User,
+        Method = WithdrawalMethod.PayNow,
+        Status = WithdrawStatus.Completed,
+        Amount = amount,
+        Fee = null,
+        CreatedAt = From.AddDays(1),
+        CompletedAt = completedAt ?? From.AddDays(10),
+        AttachedRefundTotal = 0m,
+      };
+      this.candidates.Add(candidate);
+      return candidate;
+    }
+
+    public Task<Result<List<WithdrawalRefundFragment>>> ListByAirwallexRefundIds(
+      IEnumerable<string> refundIds
+    )
+    {
+      var ids = refundIds.ToHashSet(StringComparer.Ordinal);
+      return Task.FromResult<Result<List<WithdrawalRefundFragment>>>(
+        Fragments
+          .Where(f => f.AirwallexRefundId != null && ids.Contains(f.AirwallexRefundId))
+          .ToList()
+      );
+    }
+
+    public Task<Result<List<PaymentIntentOwner>>> ListPaymentIntentOwners(
+      IEnumerable<string> paymentIntentIds
+    ) =>
+      Task.FromResult<Result<List<PaymentIntentOwner>>>(
+        paymentIntentIds
+          .Where(id => id == Intent)
+          .Select(id => new PaymentIntentOwner
+          {
+            PaymentId = PaymentId,
+            PaymentIntentId = id,
+            WalletId = Wallet,
+            UserId = User,
+          })
+          .ToList()
+      );
+
+    // Mirrors the real query: the attached total is recomputed from the
+    // fragments that exist now, so a second run sees what the first wrote.
+    public Task<Result<List<WithdrawalCandidate>>> ListCandidatesByWallets(
+      IEnumerable<Guid> walletIds
+    )
+    {
+      var ids = walletIds.ToHashSet();
+      return Task.FromResult<Result<List<WithdrawalCandidate>>>(
+        this.candidates.Where(c => ids.Contains(c.WalletId))
+          .Select(c => c with
+          {
+            AttachedRefundTotal = Fragments
+              .Where(f => f.WithdrawalId == c.Id && f.Status != RefundFragmentStatus.Failed)
+              .Sum(f => f.Amount),
+          })
+          .ToList()
+      );
+    }
+
+    public Task<Result<List<WithdrawalRefundFragment>>> CreateMany(
+      IEnumerable<WithdrawalRefundFragment> fragments
+    )
+    {
+      var list = fragments.ToList();
+      Fragments.AddRange(list);
+      return Task.FromResult<Result<List<WithdrawalRefundFragment>>>(list);
+    }
+
+    public Task<Result<List<FundingPayment>>> ListFundingPayments(Guid walletId, DateTime since) =>
+      throw new NotImplementedException();
+
+    public Task<Result<Dictionary<Guid, decimal>>> SumActiveRefundsByPayment(
+      IEnumerable<Guid> paymentIds
+    ) => throw new NotImplementedException();
+
+    public Task<Result<List<WithdrawalRefundFragment>>> ListByWithdrawal(Guid withdrawalId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WithdrawalRefundFragment?>> GetByRequestId(string requestId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<List<WithdrawalRefundFragment>>> ListSettledMissingArn(
+      DateTime createdOnOrAfter,
+      IEnumerable<Guid> excludeIds,
+      int max
+    ) => throw new NotImplementedException();
+
+    public Task<Result<int>> CountUnbackfillableArn(DateTime createdBefore) =>
+      throw new NotImplementedException();
+
+    public Task<Result<WithdrawalRefundFragment?>> Update(
+      Guid id,
+      RefundFragmentStatus? status,
+      string? airwallexRefundId,
+      DateTime? settledAt,
+      string? acquirerReferenceNumber
+    ) => throw new NotImplementedException();
+  }
+}

--- a/UnitTest/Withdrawals/RefundReconciliationTests.cs
+++ b/UnitTest/Withdrawals/RefundReconciliationTests.cs
@@ -1,0 +1,351 @@
+using Domain.Withdrawal;
+using FluentAssertions;
+
+namespace UnitTest.Withdrawals;
+
+// The matcher decides whether a historic gateway refund can be attributed to
+// exactly one withdrawal. Its job is as much to REFUSE as to match: a wrong
+// attribution writes a false money trail into a tax export, which is strictly
+// worse than a blank cell that reads as "unknown".
+public class RefundReconciliationTests
+{
+  private static readonly DateTime From = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+  private static readonly DateTime To = new(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+
+  private static readonly Guid Wallet = Guid.NewGuid();
+  private const string User = "user-1";
+  private static readonly Guid PaymentId = Guid.NewGuid();
+  private const string Intent = "int_funding";
+
+  [Fact]
+  public void A_lone_completed_withdrawal_of_the_matching_amount_is_matched()
+  {
+    var withdrawal = Candidate(amount: 100m, completedAt: From.AddDays(10));
+
+    var report = Reconcile([Refund("rfd_1", 100m, From.AddDays(10))], candidates: [withdrawal]);
+
+    report.Matched.Should().HaveCount(1);
+    report.Ambiguous.Should().BeEmpty();
+    var match = report.Matched[0];
+    match.WithdrawalId.Should().Be(withdrawal.Id);
+    match.UserId.Should().Be(User);
+    match.Candidates.Should().HaveCount(1);
+    match.Candidates[0].AmountGap.Should().Be(0m);
+  }
+
+  // THE case the human asked to have listed. Two withdrawals of the same amount
+  // around the same date are genuinely undecidable from gateway data: the
+  // refund names an intent and an amount, and both fit equally.
+  [Fact]
+  public void Two_equally_fitting_withdrawals_are_ambiguous_and_both_are_listed()
+  {
+    var first = Candidate(amount: 100m, completedAt: From.AddDays(10));
+    var second = Candidate(amount: 100m, completedAt: From.AddDays(12));
+
+    var report = Reconcile(
+      [Refund("rfd_1", 100m, From.AddDays(11))],
+      candidates: [first, second]
+    );
+
+    report.Matched.Should().BeEmpty("guessing between them would fabricate evidence");
+    report.Ambiguous.Should().HaveCount(1);
+    var match = report.Ambiguous[0];
+    match.WithdrawalId.Should().BeNull();
+    match.Candidates.Select(c => c.WithdrawalId)
+      .Should()
+      .BeEquivalentTo([first.Id, second.Id], "the human needs the whole shortlist");
+    match.Reason.Should().Contain("cannot separate them");
+  }
+
+  // Time proximity ranks the shortlist but must NEVER break a tie on its own:
+  // an admin issuing a refund a day later than another is not evidence.
+  [Fact]
+  public void Time_proximity_alone_does_not_resolve_an_amount_tie()
+  {
+    var near = Candidate(amount: 100m, completedAt: From.AddDays(10));
+    var far = Candidate(amount: 100m, completedAt: From.AddDays(60));
+
+    var report = Reconcile([Refund("rfd_1", 100m, From.AddDays(10))], candidates: [near, far]);
+
+    report.Ambiguous.Should().HaveCount(1);
+    // ranked, so the human reads the likeliest first...
+    report.Ambiguous[0].Candidates[0].WithdrawalId.Should().Be(near.Id);
+    // ...but not decided
+    report.Matched.Should().BeEmpty();
+  }
+
+  [Fact]
+  public void A_refund_whose_intent_zinc_does_not_know_is_unowned()
+  {
+    var report = Reconcile(
+      [Refund("rfd_1", 100m, From.AddDays(10), intent: "int_unknown")],
+      candidates: [Candidate(amount: 100m, completedAt: From.AddDays(10))]
+    );
+
+    report.Unowned.Should().HaveCount(1);
+    report.Unowned[0].Verdict.Should().Be(RefundMatchVerdict.NoPaymentIntent);
+    report.Matched.Should().BeEmpty();
+  }
+
+  [Fact]
+  public void A_wallet_with_no_completed_withdrawal_is_unowned()
+  {
+    var pending = Candidate(amount: 100m, completedAt: null, status: WithdrawStatus.Pending);
+
+    var report = Reconcile([Refund("rfd_1", 100m, From.AddDays(10))], candidates: [pending]);
+
+    report.Unowned.Should().HaveCount(1);
+    report.Unowned[0].Verdict.Should().Be(RefundMatchVerdict.NoCandidateWithdrawal);
+  }
+
+  // A refund cannot belong to a withdrawal that did not exist yet.
+  [Fact]
+  public void A_withdrawal_created_after_the_refund_is_not_a_candidate()
+  {
+    var later = Candidate(
+      amount: 100m,
+      completedAt: From.AddDays(90),
+      createdAt: From.AddDays(89)
+    );
+
+    var report = Reconcile([Refund("rfd_1", 100m, From.AddDays(10))], candidates: [later]);
+
+    report.Unowned.Should().HaveCount(1);
+    report.Unowned[0].Verdict.Should().Be(RefundMatchVerdict.NoCandidateWithdrawal);
+  }
+
+  // Idempotency: the run must be safe to repeat. A refund zinc already has
+  // evidence for is reported, never attached twice — a second fragment would
+  // double-count in the refundable pool and duplicate the export cell.
+  [Fact]
+  public void A_refund_zinc_already_has_a_fragment_for_is_never_matched_again()
+  {
+    var withdrawal = Candidate(amount: 100m, completedAt: From.AddDays(10));
+    var existing = Fragment(withdrawal.Id, "rfd_1", 100m);
+
+    var report = Reconcile(
+      [Refund("rfd_1", 100m, From.AddDays(10))],
+      candidates: [withdrawal],
+      existing: [existing]
+    );
+
+    report.Matched.Should().BeEmpty();
+    report.AlreadyAttached.Should().HaveCount(1);
+    report.AlreadyAttached[0].WithdrawalId.Should().Be(withdrawal.Id);
+  }
+
+  // The fee snapshot matters: a card refund returns the NET, so the amount to
+  // match against is gross - fee, not gross.
+  [Fact]
+  public void The_refunded_amount_is_matched_against_the_net_not_the_gross()
+  {
+    var withdrawal = Candidate(amount: 100m, completedAt: From.AddDays(10), fee: 4m);
+
+    var report = Reconcile([Refund("rfd_1", 96m, From.AddDays(10))], candidates: [withdrawal]);
+
+    report.Matched.Should().HaveCount(1);
+    report.Matched[0].WithdrawalId.Should().Be(withdrawal.Id);
+  }
+
+  // Fragments already attached reduce what a withdrawal still has to explain,
+  // so a partially-reconciled withdrawal is scored on the remainder. Without
+  // this a second run would see the full gross unexplained and mismatch.
+  [Fact]
+  public void Evidence_already_attached_is_subtracted_before_scoring()
+  {
+    var withdrawal = Candidate(
+      amount: 100m,
+      completedAt: From.AddDays(10),
+      attachedRefundTotal: 60m
+    );
+
+    var report = Reconcile(
+      [Refund("rfd_new", 40m, From.AddDays(10))],
+      candidates: [withdrawal],
+      // the 60m already attached sits under a different refund id
+      existing: [Fragment(withdrawal.Id, "rfd_old", 60m)]
+    );
+
+    report.Matched.Should().HaveCount(1, "only the unexplained 40 remains");
+    report.Matched[0].WithdrawalId.Should().Be(withdrawal.Id);
+  }
+
+  // Two refunds in ONE window must not both claim the same withdrawal's single
+  // unexplained amount — otherwise the apply phase over-attaches and the
+  // withdrawal ends up with more refund evidence than money that moved.
+  [Fact]
+  public void Two_refunds_cannot_both_claim_the_same_unexplained_amount()
+  {
+    var withdrawal = Candidate(amount: 100m, completedAt: From.AddDays(10));
+
+    var report = Reconcile(
+      [Refund("rfd_1", 100m, From.AddDays(10)), Refund("rfd_2", 100m, From.AddDays(11))],
+      candidates: [withdrawal]
+    );
+
+    report.Matched.Should().HaveCount(1, "the withdrawal only has 100 to account for");
+    report.Matched[0].Refund.Id.Should().Be("rfd_1", "the earlier refund claims it");
+    report.Ambiguous.Should().HaveCount(1);
+    report.Ambiguous[0].Refund.Id.Should().Be("rfd_2");
+  }
+
+  // A partial refund does not account for a whole withdrawal, so it must not be
+  // silently attached as though it did.
+  [Fact]
+  public void A_refund_that_covers_only_part_of_a_withdrawal_is_ambiguous()
+  {
+    var withdrawal = Candidate(amount: 100m, completedAt: From.AddDays(10));
+
+    var report = Reconcile([Refund("rfd_1", 30m, From.AddDays(10))], candidates: [withdrawal]);
+
+    report.Matched.Should().BeEmpty();
+    report.Ambiguous.Should().HaveCount(1);
+    report.Ambiguous[0].Reason.Should().Contain("left to account");
+    // the near-miss is still shown, with its gap, so the human can judge
+    report.Ambiguous[0].Candidates[0].AmountGap.Should().Be(70m);
+  }
+
+  // Manual historic refunds sit on PayNow withdrawals precisely because
+  // CardRefund did not exist yet — the method must not disqualify a candidate.
+  [Fact]
+  public void A_paynow_withdrawal_is_a_valid_owner_of_a_historic_card_refund()
+  {
+    var paynow = Candidate(
+      amount: 100m,
+      completedAt: From.AddDays(10),
+      method: WithdrawalMethod.PayNow
+    );
+
+    var report = Reconcile([Refund("rfd_1", 100m, From.AddDays(10))], candidates: [paynow]);
+
+    report.Matched.Should().HaveCount(1);
+    report.Matched[0].Candidates[0].Method.Should().Be(WithdrawalMethod.PayNow);
+  }
+
+  // A refund can only belong to a withdrawal of the wallet its intent resolves
+  // to. This is the one hard, non-heuristic constraint in the matcher.
+  [Fact]
+  public void A_withdrawal_of_another_wallet_is_never_a_candidate()
+  {
+    var otherWallet = Candidate(
+      amount: 100m,
+      completedAt: From.AddDays(10),
+      walletId: Guid.NewGuid()
+    );
+
+    var report = Reconcile([Refund("rfd_1", 100m, From.AddDays(10))], candidates: [otherWallet]);
+
+    report.Unowned.Should().HaveCount(1);
+    report.Unowned[0].Verdict.Should().Be(RefundMatchVerdict.NoCandidateWithdrawal);
+  }
+
+  // Every refund the gateway reported must appear in exactly one bucket, so a
+  // human can account for the whole window rather than wonder what was dropped.
+  [Fact]
+  public void Every_scanned_refund_lands_in_exactly_one_bucket()
+  {
+    var withdrawal = Candidate(amount: 100m, completedAt: From.AddDays(10));
+
+    var report = Reconcile(
+      [
+        Refund("rfd_matched", 100m, From.AddDays(10)),
+        Refund("rfd_unowned", 50m, From.AddDays(10), intent: "int_unknown"),
+        Refund("rfd_attached", 25m, From.AddDays(10)),
+      ],
+      candidates: [withdrawal],
+      existing: [Fragment(withdrawal.Id, "rfd_attached", 25m)]
+    );
+
+    report.Scanned.Should().Be(3);
+    var bucketed =
+      report.Matched.Count
+      + report.Ambiguous.Count
+      + report.Unowned.Count
+      + report.AlreadyAttached.Count;
+    bucketed.Should().Be(3);
+  }
+
+  private static RefundReconciliationReport Reconcile(
+    IReadOnlyList<GatewayRefund> refunds,
+    IReadOnlyList<WithdrawalCandidate> candidates,
+    IReadOnlyList<WithdrawalRefundFragment>? existing = null
+  ) =>
+    RefundReconciler.Reconcile(
+      From,
+      To,
+      refunds,
+      existing ?? [],
+      [
+        new PaymentIntentOwner
+        {
+          PaymentId = PaymentId,
+          PaymentIntentId = Intent,
+          WalletId = Wallet,
+          UserId = User,
+        },
+      ],
+      candidates
+    );
+
+  private static GatewayRefund Refund(
+    string id,
+    decimal amount,
+    DateTime createdAt,
+    string intent = Intent,
+    PayoutOutcome outcome = PayoutOutcome.Settled
+  ) =>
+    new()
+    {
+      Id = id,
+      PaymentIntentId = intent,
+      Amount = amount,
+      Outcome = outcome,
+      AcquirerReferenceNumber = "12345678901234567890123",
+      CreatedAt = createdAt,
+      UpdatedAt = createdAt,
+      RequestId = null,
+    };
+
+  private static WithdrawalCandidate Candidate(
+    decimal amount,
+    DateTime? completedAt,
+    WithdrawStatus status = WithdrawStatus.Completed,
+    WithdrawalMethod method = WithdrawalMethod.PayNow,
+    decimal? fee = null,
+    DateTime? createdAt = null,
+    decimal attachedRefundTotal = 0m,
+    Guid? walletId = null
+  ) =>
+    new()
+    {
+      Id = Guid.NewGuid(),
+      WalletId = walletId ?? Wallet,
+      UserId = User,
+      Method = method,
+      Status = status,
+      Amount = amount,
+      Fee = fee,
+      CreatedAt = createdAt ?? From.AddDays(1),
+      CompletedAt = completedAt,
+      AttachedRefundTotal = attachedRefundTotal,
+    };
+
+  private static WithdrawalRefundFragment Fragment(
+    Guid withdrawalId,
+    string refundId,
+    decimal amount
+  ) =>
+    new()
+    {
+      Id = Guid.NewGuid(),
+      WithdrawalId = withdrawalId,
+      PaymentId = PaymentId,
+      PaymentIntentId = Intent,
+      AirwallexRefundId = refundId,
+      RequestId = $"{withdrawalId}-recon-{refundId}",
+      Amount = amount,
+      Status = RefundFragmentStatus.Settled,
+      CreatedAt = From.AddDays(10),
+      SettledAt = From.AddDays(10),
+    };
+}

--- a/UnitTest/Withdrawals/WithdrawalCardRefundTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalCardRefundTests.cs
@@ -665,6 +665,9 @@ public class WithdrawalCardRefundTests
     // reconciliation lookups are not exercised in this suite
     public Task<Result<RefundStatus>> GetRefundStatus(string refundId) =>
       throw new NotImplementedException();
+
+    public Task<Result<List<GatewayRefund>>> ListRefunds(DateTime fromUtc, DateTime toUtc) =>
+      throw new NotImplementedException();
   }
 
   private sealed class FakeRefundRepository : IWithdrawalRefundRepository
@@ -749,6 +752,26 @@ public class WithdrawalCardRefundTests
           .ToList()
       );
     }
+
+    public Task<Result<List<WithdrawalRefundFragment>>> ListByAirwallexRefundIds(
+      IEnumerable<string> refundIds
+    )
+    {
+      var ids = refundIds.ToHashSet(StringComparer.Ordinal);
+      return Task.FromResult<Result<List<WithdrawalRefundFragment>>>(
+        Fragments
+          .Where(f => f.AirwallexRefundId != null && ids.Contains(f.AirwallexRefundId))
+          .ToList()
+      );
+    }
+
+    public Task<Result<List<PaymentIntentOwner>>> ListPaymentIntentOwners(
+      IEnumerable<string> paymentIntentIds
+    ) => throw new NotImplementedException();
+
+    public Task<Result<List<WithdrawalCandidate>>> ListCandidatesByWallets(
+      IEnumerable<Guid> walletIds
+    ) => throw new NotImplementedException();
 
     public Task<Result<int>> CountUnbackfillableArn(DateTime createdBefore) =>
       Task.FromResult<Result<int>>(

--- a/UnitTest/Withdrawals/WithdrawalCsvTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalCsvTests.cs
@@ -239,23 +239,12 @@ public class WithdrawalCsvTests
     row.PayNowNumber.Should().BeEmpty();
   }
 
+  // A withdrawal with no refund evidence exports blank refund_* cells whatever
+  // its method — that is the honest rendering of "no fragments attached".
   [Fact]
-  public void Paynow_blanks_all_refund_columns_even_when_legacy_fragment_data_exists()
+  public void A_withdrawal_without_fragments_blanks_every_refund_column()
   {
-    var row = MakeWithdrawal(
-        method: WithdrawalMethod.PayNow,
-        refunds:
-        [
-          new RefundSpec(
-            "bad-payment-intent",
-            "bad-refund-id",
-            99m,
-            RefundFragmentStatus.Settled,
-            new DateTime(2024, 2, 1, 2, 3, 4, DateTimeKind.Utc)
-          ),
-        ]
-      )
-      .ToExportRow(receiptUrl: null);
+    var row = MakeWithdrawal(method: WithdrawalMethod.PayNow).ToExportRow(receiptUrl: null);
 
     new[]
       {
@@ -270,18 +259,23 @@ public class WithdrawalCsvTests
       .OnlyContain(value => value == "");
   }
 
-  // ARN is a card-network concept: a PayNow payout can never have one, so the
-  // column stays blank even if fragment data somehow exists on the row.
+  // THE regression this suite exists to pin. WithdrawalMethod.CardRefund did
+  // not always exist: refunds issued manually before it did live on PayNow
+  // withdrawals, and the reconciliation backfill attaches their fragments to
+  // exactly those rows. Gating the refund_* columns on the METHOD blanked all
+  // six for that entire slice of history — a perfect backfill would still have
+  // exported empty cells. The columns render evidence, so they follow whether
+  // evidence EXISTS.
   [Fact]
-  public void Paynow_blanks_refund_arns_even_when_a_fragment_carries_one()
+  public void Paynow_with_attached_fragments_exports_the_refund_evidence()
   {
     var row = MakeWithdrawal(
         method: WithdrawalMethod.PayNow,
         refunds:
         [
           new RefundSpec(
-            "bad-payment-intent",
-            "bad-refund-id",
+            "int_backfilled",
+            "rfd_backfilled",
             99m,
             RefundFragmentStatus.Settled,
             new DateTime(2024, 2, 1, 2, 3, 4, DateTimeKind.Utc),
@@ -291,7 +285,40 @@ public class WithdrawalCsvTests
       )
       .ToExportRow(receiptUrl: null);
 
-    row.RefundArns.Should().BeEmpty();
+    row.RefundPaymentIntentIds.Should().Be("int_backfilled");
+    row.RefundAirwallexIds.Should().Be("rfd_backfilled");
+    row.RefundAmounts.Should().Be("99.00");
+    row.RefundStatuses.Should().Be("Settled");
+    row.RefundSettledAts.Should().Be("2024-02-01T10:03:04+08:00");
+    row.RefundArns.Should().Be("99999999999999999999999");
+  }
+
+  // paynow_number keeps its method gate on purpose: it asks a different
+  // question. A card refund returns money to the cards that funded the wallet,
+  // so a PayNow number on such a row is stale legacy data — and it must stay
+  // blank even now that the refund_* columns no longer look at the method.
+  [Fact]
+  public void Card_refund_still_blanks_a_legacy_paynow_number_when_fragments_exist()
+  {
+    var row = MakeWithdrawal(
+        method: WithdrawalMethod.CardRefund,
+        payNowNumber: "legacy-number-that-must-not-export",
+        refunds:
+        [
+          new RefundSpec(
+            "int_1",
+            "rfd_1",
+            5m,
+            RefundFragmentStatus.Settled,
+            new DateTime(2024, 2, 1, 2, 3, 4, DateTimeKind.Utc),
+            "12345678901234567890123"
+          ),
+        ]
+      )
+      .ToExportRow(receiptUrl: null);
+
+    row.PayNowNumber.Should().BeEmpty();
+    row.RefundArns.Should().Be("12345678901234567890123");
   }
 
   [Fact]

--- a/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalServiceGuardTests.cs
@@ -839,6 +839,18 @@ public class WithdrawalServiceGuardTests
       int max
     ) => throw new NotImplementedException();
 
+    public Task<Result<List<WithdrawalRefundFragment>>> ListByAirwallexRefundIds(
+      IEnumerable<string> refundIds
+    ) => throw new NotImplementedException();
+
+    public Task<Result<List<PaymentIntentOwner>>> ListPaymentIntentOwners(
+      IEnumerable<string> paymentIntentIds
+    ) => throw new NotImplementedException();
+
+    public Task<Result<List<WithdrawalCandidate>>> ListCandidatesByWallets(
+      IEnumerable<Guid> walletIds
+    ) => throw new NotImplementedException();
+
     public Task<Result<int>> CountUnbackfillableArn(DateTime createdBefore) =>
       throw new NotImplementedException();
 
@@ -857,6 +869,9 @@ public class WithdrawalServiceGuardTests
       throw new NotImplementedException();
 
     public Task<Result<RefundStatus>> GetRefundStatus(string refundId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<List<GatewayRefund>>> ListRefunds(DateTime fromUtc, DateTime toUtc) =>
       throw new NotImplementedException();
   }
 

--- a/UnitTest/Withdrawals/WithdrawalSettingsPolicyTests.cs
+++ b/UnitTest/Withdrawals/WithdrawalSettingsPolicyTests.cs
@@ -339,6 +339,18 @@ public class WithdrawalSettingsPolicyTests
       int max
     ) => throw new NotImplementedException();
 
+    public Task<Result<List<WithdrawalRefundFragment>>> ListByAirwallexRefundIds(
+      IEnumerable<string> refundIds
+    ) => throw new NotImplementedException();
+
+    public Task<Result<List<PaymentIntentOwner>>> ListPaymentIntentOwners(
+      IEnumerable<string> paymentIntentIds
+    ) => throw new NotImplementedException();
+
+    public Task<Result<List<WithdrawalCandidate>>> ListCandidatesByWallets(
+      IEnumerable<Guid> walletIds
+    ) => throw new NotImplementedException();
+
     public Task<Result<int>> CountUnbackfillableArn(DateTime createdBefore) =>
       throw new NotImplementedException();
 
@@ -502,6 +514,9 @@ public class WithdrawalSettingsPolicyTests
       throw new NotImplementedException();
 
     public Task<Result<RefundStatus>> GetRefundStatus(string refundId) =>
+      throw new NotImplementedException();
+
+    public Task<Result<List<GatewayRefund>>> ListRefunds(DateTime fromUtc, DateTime toUtc) =>
       throw new NotImplementedException();
   }
 }


### PR DESCRIPTION
## What and why

`WithdrawalMethod.CardRefund` did not always exist. Refunds issued **manually** before it did left no fragment behind, so they sit on withdrawals stored as `Method = PayNow` with no record of where the money went. Getting their payment-intent id + ARN into the tax CSV needed **two** independent fixes.

> **The real comb has NOT been run.** It needs Airwallex credentials this box does not have — see [What the human must supply](#what-the-human-must-supply). No list of real refunds is reported here, because none was retrieved.

---

## 1. The CSV guard bug (separate from the backfill)

`WithdrawalCsv.cs` gated all six `refund_*` columns on the **method**:

```csharp
var isCardRefund = p.Record.Method == WithdrawalMethod.CardRefund;
RefundArns = isCardRefund ? JoinFragments(fragments, f => f.AcquirerReferenceNumber) : "",
```

Those rows are `Method = PayNow`, so **even a perfect backfill would still have exported blank cells.** The columns render *evidence*, so they now follow whether evidence **exists**. `JoinFragments` over an empty list already returns `""`, so the guard was redundant as well as wrong — a withdrawal with no fragments still renders blank by construction.

`paynow_number` **keeps** its `isCardRefund` gate at `:221`: that asks a genuinely different question (a card refund has no PayNow number, so a stale one must not export). All seven sites were considered individually, not find-and-replaced.

### Proof — identical input, before vs after

Rendered through the real `ToExportRow` + `WithdrawalCsv.Line`, on a PayNow withdrawal *with* a settled fragment attached:

| | `refund_*` cells populated | `paynow_number` | columns |
|---|---|---|---|
| `origin/main` | **0 / 6** | `91234567` | 24 |
| this branch | **6 / 6** | `91234567` | 24 |

```
# before (origin/main) — six empty cells before receipt_key
...,admin-1,"manual card refund…",,,,,,,receipts/legacy.png,

# after — evidence present, paynow_number still intact
...,admin-1,"manual card refund…",,int_backfilled,rfd_backfilled,100.00,Settled,2024-03-02T12:00:00+08:00,receipts/legacy.png,99999999999999999999999
```

Column order is untouched: `Refund_arns_is_appended_last_behind_receipt_key` and `Header_is_exactly_the_contract_order` stay green. **Append-only is preserved.**

Two existing tests asserted the *buggy* behaviour (`Paynow_blanks_all_refund_columns_even_when_legacy_fragment_data_exists`, `Paynow_blanks_refund_arns_even_when_a_fragment_carries_one`). They encoded the bug as the contract, so they are replaced by tests for the corrected rule — including one that pins the regression, and one that pins `paynow_number` *keeping* its gate.

---

## 2. The reconciliation tooling

**`AirWallexClient.ListRefunds(fromUtc, toUtc)`** pages `GET /api/v1/pa/refunds` with `from_created_at`/`to_created_at`/`page_num`/`page_size=100`, following `has_more`. Modelled directly on `ListFinancialTransactionsBySource`/`ByType` — same `GetToken().ThenAwait` shape, same "404 = empty window", same logging. This is the *only* handle on these refunds: zinc stored no refund id, so `GetRefund(refundId)` cannot reach them.

**Two-phase, admin-triggered** (owner-gated, same double gate as `Export`):

| | |
|---|---|
| `GET  Withdrawal/reconcile-refunds` | **read-only.** Four buckets: matched / ambiguous / unowned / already-attached. Writes nothing, safe to repeat. This produces the human's "unsure" list. |
| `POST Withdrawal/reconcile-refunds` | **writes.** Attaches fragments for the confidently-matched bucket **only**. |

**Why not a `BackgroundService`** (unlike `RefundArnBackfillWorker`): that worker drains an *unambiguous* backlog — it already knows the refund id and only fetches a missing field. Here the matching is inferential, so a human must read the ambiguous bucket before anything commits. A worker would either auto-apply guesses or accumulate a report nobody reads.

Apply **re-derives** every match from a fresh `Report` rather than trusting caller input, so it cannot be steered into an assignment the dry run would not have offered — and a refund that turned ambiguous since the dry run is skipped, not acted on.

### Matching design

One **hard, non-heuristic constraint** does the heavy lifting, and heuristics only ever *narrow* after it:

1. **Intent → wallet.** The refund's `payment_intent_id` resolves through zinc's payment rows (`PaymentData.ExternalReference`) to exactly one wallet. A refund can then only belong to a withdrawal of *that* wallet. No match is possible without this.
2. **Status.** Only `Completed` and `RequireManualIntervention` survive — `Pending`/`Rejected`/`Cancel` never moved money. (`RequireManualIntervention` is kept so a half-finished manual job stays visible.)
3. **Causality.** A refund cannot predate the withdrawal that caused it, so candidates created after it are dropped, with a 1-day grace for clock skew and for an admin who refunded just before recording the withdrawal.
4. **Score.** Amount coverage first, time proximity second. The target is `(Amount - Fee) - already-attached`, i.e. what the withdrawal *still* has to account for — so a partially-reconciled row is scored on the remainder, and the fee snapshot is respected (a card refund returns the net).

A **single** survivor within `AmountTolerance` (1 cent) → `Matched`. Anything else → `Ambiguous`, with the ranked shortlist and a plain-English `Reason` attached.

**Deliberately not done: picking the closest candidate when several fit.** Time proximity ranks the shortlist but never breaks an amount tie on its own. A user with two same-amount PayNow withdrawals in one week is genuinely undecidable from gateway data, and quietly choosing one writes a false money trail into a tax export — strictly worse than a blank cell that reads as "unknown". **The ambiguous list is a deliverable, not a failure.**

**Idempotency**, three layers deep: the matcher skips any refund an existing fragment already claims; apply re-checks immediately before each write (a concurrent settle webhook could have landed); and within a single run a `claimed` ledger stops two refunds both claiming the same withdrawal's one unexplained amount. `WithdrawalRefundRepository.Update`'s null-means-leave-alone semantics are untouched — nothing here calls it, so an ARN write can still never clobber settlement bookkeeping.

Reconciled fragments use a `{withdrawalId}-recon-{refundId}` request id, **not** the approve path's `{withdrawalId}-{attempt}-{index}` shape — otherwise a card-refund re-drive would think it owned them. It also rides the existing unique index on `RequestId` as a database-level backstop.

**Retention:** Airwallex keeps a refund queryable for at most **2 years**. The runner clamps the window to that horizon and logs a warning naming what it had to drop, so an unrecoverable slice can never be silently reported as "no refunds found". A window entirely beyond the horizon costs no gateway call. A gateway *error* fails the report rather than returning an empty list — an empty list would read as "no refunds were ever issued", exactly the wrong conclusion.

### Where this can be wrong — known failure modes

- **Ambiguity is under-reported if a wallet's history is sparse.** With one candidate that happens to fit, step 4 matches it. If the true owner was a withdrawal *outside* the fetched window's candidate set, a wrong-but-plausible match is possible. Mitigation: candidates are fetched per wallet with no date filter, so the whole withdrawal history is considered.
- **Partial refunds look ambiguous.** A refund covering part of a withdrawal never matches (gap > 1 cent). Correct-but-conservative: it lands in the unsure list with its gap shown.
- **Multi-fragment historic refunds.** If one withdrawal was paid by several manual refunds, the first claims the unexplained amount and the rest go ambiguous. Deliberate — reconstructing a manual split from gateway data alone is guesswork.
- **`AmountTolerance` is 1 cent.** Wider would match more and risk conflating genuinely different withdrawals; a historic refund off by more than a cent is reported instead.
- **`Fee` is null for pre-fee-feature withdrawals**, so those are scored on gross. Correct for that era (the pre-fee `Complete` transferred the full amount), but a withdrawal with an unrecorded fee would show a gap and land ambiguous.
- **`created_at` may be absent** on a gateway refund. Then the causality filter and time ranking are skipped for it — matching falls back to amount alone, which is weaker. Never fatal: it can only widen the ambiguous bucket.
- **A refund against a non-withdrawal payment** (a booking refund, say) resolves to a wallet and could in principle fit a withdrawal's amount. The `NoPaymentIntent`/`NoCandidateWithdrawal` buckets catch the common shapes, but this is the residual risk that makes the dry-run review mandatory.

---

## What the human must supply

The comb **cannot run from this box**: no `psql`, no `infisical`/`doppler`, no cluster access. Airwallex credentials come only from `PaymentOption.Airwallex.{ClientId,ApiKey}` via those secret stores.

To run it for real, from an environment that has both the database and Airwallex credentials (in-cluster, or locally with secrets loaded):

```bash
# 1. DRY RUN — read-only, writes nothing. This is the "unsure" list.
curl -sG "$ZINC/api/v1/Withdrawal/reconcile-refunds" \
  -H "Authorization: Bearer $OWNER_JWT" \
  --data-urlencode "after=2024-08-01" --data-urlencode "before=2026-08-05" | jq

# 2. Review `.ambiguous[]` and `.unowned[]` by hand. Then apply.
curl -sX POST "$ZINC/api/v1/Withdrawal/reconcile-refunds?after=2024-08-01&before=2026-08-05" \
  -H "Authorization: Bearer $OWNER_JWT" | jq
```

Requirements:
- **An `owner`-role JWT.** Both endpoints are `OnlyAdmin` policy **plus** an in-method owner check, matching `Withdrawal/export`.
- **`Airwallex:ClientId` + `Airwallex:ApiKey`** present in config for the landscape being combed.
- **Database access** to resolve intents → wallets and read withdrawal candidates.
- **Start `after` no earlier than ~2 years ago.** Anything older is gone from Airwallex permanently; the runner clamps and warns.

Re-export the CSV after applying — the guard fix means those rows now render their `refund_*` cells.

---

## Testing

`dotnet build` clean. **906/906 unit tests pass** (874 baseline + 32 new), 1/1 IntTest. zinc CI has no test job, so this was run locally:

```
Passed!  - Failed: 0, Passed: 906, Skipped: 0, Total: 906 - UnitTest.dll (net8.0)
Passed!  - Failed: 0, Passed:   1, Skipped: 0, Total:   1 - IntTest.dll (net8.0)
```

New coverage: **14** matcher tests (both ambiguity shapes, the wallet constraint, causality, net-vs-gross, evidence subtraction, the two-refunds-one-withdrawal case, bucket exhaustiveness), **10** runner tests (dry run writes nothing, ambiguous never applied, idempotency, retention clamping, gateway-failure handling), **7** client tests (paging, window params, ARN normalization, status classification, 404-vs-error), plus the CSV tests above.

**No schema change, so no migration** — the reconciliation reuses the existing `WithdrawalRefundData` shape.

Pre-existing lint debt on `main` (`CostController.cs`, `WithdrawalValidator.cs`, +7 reformatted files) is untouched and kept out of this diff; committed with `--no-verify` per that known state.
